### PR TITLE
Add Dagster execution layer design document

### DIFF
--- a/claude/prism/skills/prism-run/SKILL.md
+++ b/claude/prism/skills/prism-run/SKILL.md
@@ -176,59 +176,26 @@ Configure targets with `prism remote setup <name>`.
 
 ## Running on NERSC (Perlmutter)
 
-Perlmutter uses SLURM with either **podman-hpc** (recommended) or **shifter** as the container runtime. Prism generates and submits sbatch scripts automatically, then polls for completion.
+Perlmutter uses SLURM with **podman-hpc** (recommended) or **shifter** as the container runtime. Prism handles everything automatically: building/migrating container images, generating sbatch scripts, submitting jobs, and polling for completion.
 
 ### One-Time Setup
 
-1. **Log in to Perlmutter** and clone/install the project on the shared filesystem (e.g. `$SCRATCH` or `$CFS`):
-
-```bash
-ssh <user>@perlmutter.nersc.gov
-cd $SCRATCH
-git clone <repo>
-pip install prism
-```
-
-2. **Configure the Perlmutter target** on the machine where you'll run `prism` (can be the login node):
+Configure the Perlmutter target (the wizard auto-detects Perlmutter and pre-fills most defaults — you only need the user's account/allocation):
 
 ```bash
 prism remote setup perlmutter
 ```
 
-Interactive prompts to fill in:
-
-| Prompt | Perlmutter value |
-|--------|-----------------|
-| Backend | `slurm` |
-| Container runtime | `podman-hpc` (recommended) or `shifter` |
-| Account | Your NERSC allocation, e.g. `m1234` |
-| Partition | `regular` (CPU), `gpu` (GPU), `debug` |
-| QOS | `regular`, `premium`, or `debug` |
-| Constraint | `cpu`, `gpu`, `gpu&hbm80g` (A100 80 GB) |
-| Container flags | `--gpu` for GPU jobs; add `--mpi` for MPI, `--nccl` for NCCL collective ops |
-
-3. **Migrate container images** (podman-hpc only) — images must be migrated before compute nodes can use them:
-
-```bash
-# On the Perlmutter login node
-podman-hpc migrate <image>
-# e.g.:
-podman-hpc migrate ghcr.io/myorg/myanalysis:latest
-```
-
-Shifter pulls images directly — no migration step needed.
-
 ### Running
 
 ```bash
-# On the Perlmutter login node, inside the project directory:
 prism run --target perlmutter
 prism run trained_model --target perlmutter --universe baseline
 ```
 
-Prism writes sbatch scripts to `results/.slurm/` and polls via `sacct`/`squeue`. Job logs go to `results/.slurm/<output_id>_<universe_id>.out/.err`.
+Container images are automatically built (`podman-hpc build`) and migrated for compute nodes, or pulled via `shifterimg` for Shifter targets. Use `prism build --runtime podman-hpc` to pre-build without running.
 
-### Example asp.yaml recipe for GPU jobs on Perlmutter
+### Example recipe for GPU jobs
 
 ```yaml
 outputs:
@@ -245,19 +212,14 @@ outputs:
         time_limit: 2h
 ```
 
-The `gpus:` field in `resources` automatically adds `--gpu` to the `podman-hpc` invocation and `#SBATCH --gpus=<n>` to the script.
+The `gpus:` field automatically adds `--gpu` to the `podman-hpc` invocation and `#SBATCH --gpus=<n>` to the script.
 
 ### Monitoring SLURM jobs
 
 ```bash
-# Check Prism's view (polls sacct/squeue)
 prism status
-
-# Direct SLURM commands
 squeue -u $USER
 sacct -j <job_id> --format=JobID,State,ExitCode,Elapsed
-
-# Read job logs
 cat results/.slurm/<output_id>_<universe_id>.out
 cat results/.slurm/<output_id>_<universe_id>.err
 ```
@@ -266,10 +228,8 @@ cat results/.slurm/<output_id>_<universe_id>.err
 
 | Problem | Solution |
 |---------|----------|
-| `podman-hpc: image not found` | Run `podman-hpc migrate <image>` on the login node |
-| `sbatch: command not found` | Run `prism run --target perlmutter` from the login node, not a local machine |
-| CANCELLED job treated as pending | Update Prism — earlier versions had a bug where CANCELLED reported exit_code 0 |
-| MPI performance poor | Add `--mpi` to container flags in `prism remote setup` |
+| `sbatch: command not found` | You must run `prism run --target` from a Perlmutter login node |
+| MPI performance poor | Add `--mpi` to container flags: `prism remote edit perlmutter` |
 | NCCL errors on multi-GPU | Add `--nccl` (and optionally `--cuda-mpi`) to container flags |
 | Job not found in `prism status` | Give sacct a moment — it may lag by ~30s after completion |
 

--- a/claude/prism/skills/prism-run/SKILL.md
+++ b/claude/prism/skills/prism-run/SKILL.md
@@ -174,6 +174,107 @@ Configure targets with `prism remote setup <name>`.
 
 ---
 
+## Running on NERSC (Perlmutter)
+
+Perlmutter uses SLURM with either **podman-hpc** (recommended) or **shifter** as the container runtime. Prism generates and submits sbatch scripts automatically, then polls for completion.
+
+### One-Time Setup
+
+1. **Log in to Perlmutter** and clone/install the project on the shared filesystem (e.g. `$SCRATCH` or `$CFS`):
+
+```bash
+ssh <user>@perlmutter.nersc.gov
+cd $SCRATCH
+git clone <repo>
+pip install prism
+```
+
+2. **Configure the Perlmutter target** on the machine where you'll run `prism` (can be the login node):
+
+```bash
+prism remote setup perlmutter
+```
+
+Interactive prompts to fill in:
+
+| Prompt | Perlmutter value |
+|--------|-----------------|
+| Backend | `slurm` |
+| Container runtime | `podman-hpc` (recommended) or `shifter` |
+| Account | Your NERSC allocation, e.g. `m1234` |
+| Partition | `regular` (CPU), `gpu` (GPU), `debug` |
+| QOS | `regular`, `premium`, or `debug` |
+| Constraint | `cpu`, `gpu`, `gpu&hbm80g` (A100 80 GB) |
+| Container flags | `--gpu` for GPU jobs; add `--mpi` for MPI, `--nccl` for NCCL collective ops |
+
+3. **Migrate container images** (podman-hpc only) — images must be migrated before compute nodes can use them:
+
+```bash
+# On the Perlmutter login node
+podman-hpc migrate <image>
+# e.g.:
+podman-hpc migrate ghcr.io/myorg/myanalysis:latest
+```
+
+Shifter pulls images directly — no migration step needed.
+
+### Running
+
+```bash
+# On the Perlmutter login node, inside the project directory:
+prism run --target perlmutter
+prism run trained_model --target perlmutter --universe baseline
+```
+
+Prism writes sbatch scripts to `results/.slurm/` and polls via `sacct`/`squeue`. Job logs go to `results/.slurm/<output_id>_<universe_id>.out/.err`.
+
+### Example asp.yaml recipe for GPU jobs on Perlmutter
+
+```yaml
+outputs:
+  - id: trained_model
+    type: data
+    recipe:
+      command: python scripts/train.py
+      container: ghcr.io/myorg/myanalysis:latest
+      resources:
+        nodes: 1
+        cpus: 64
+        gpus: 4
+        memory: 256GB
+        time_limit: 2h
+```
+
+The `gpus:` field in `resources` automatically adds `--gpu` to the `podman-hpc` invocation and `#SBATCH --gpus=<n>` to the script.
+
+### Monitoring SLURM jobs
+
+```bash
+# Check Prism's view (polls sacct/squeue)
+prism status
+
+# Direct SLURM commands
+squeue -u $USER
+sacct -j <job_id> --format=JobID,State,ExitCode,Elapsed
+
+# Read job logs
+cat results/.slurm/<output_id>_<universe_id>.out
+cat results/.slurm/<output_id>_<universe_id>.err
+```
+
+### Common NERSC Issues
+
+| Problem | Solution |
+|---------|----------|
+| `podman-hpc: image not found` | Run `podman-hpc migrate <image>` on the login node |
+| `sbatch: command not found` | Run `prism run --target perlmutter` from the login node, not a local machine |
+| CANCELLED job treated as pending | Update Prism — earlier versions had a bug where CANCELLED reported exit_code 0 |
+| MPI performance poor | Add `--mpi` to container flags in `prism remote setup` |
+| NCCL errors on multi-GPU | Add `--nccl` (and optionally `--cuda-mpi`) to container flags |
+| Job not found in `prism status` | Give sacct a moment — it may lag by ~30s after completion |
+
+---
+
 ## Rules
 
 - **Always validate first** — `asp validate asp.yaml` before running

--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -529,7 +529,13 @@ def run(
 
 @main.command()
 @click.option("--force", is_flag=True, help="Rebuild images even if they already exist")
-def build(force: bool) -> None:
+@click.option(
+    "--runtime", "-r",
+    type=click.Choice(["docker", "podman-hpc", "shifter"]),
+    default="docker",
+    help="Container runtime to build with (default: docker)",
+)
+def build(force: bool, runtime: str) -> None:
     """Build container images from Containerfile specs in asp.yaml.
 
     Scans the analysis specification for container build specs (both
@@ -537,13 +543,22 @@ def build(force: bool) -> None:
     Images are content-addressed — rebuilds only happen when the
     Containerfile or dependency files change.
 
+    For NERSC targets, use --runtime to build with podman-hpc (which
+    also migrates images for compute nodes) or pull pre-built images
+    with shifter.
+
     Examples:
-        prism build             # build missing images
-        prism build --force     # rebuild all images
+        prism build                      # build with docker
+        prism build --runtime podman-hpc # build + migrate for NERSC
+        prism build --force              # rebuild all images
     """
     from asp.helpers import get_outputs, load_yaml
 
-    from prism.container import ContainerBuildError, resolve_container_spec
+    from prism.container import (
+        ContainerBuildError,
+        resolve_container_for_slurm,
+        resolve_container_spec,
+    )
 
     project_path = Path.cwd()
     if not (project_path / "asp.yaml").exists():
@@ -554,32 +569,48 @@ def build(force: bool) -> None:
     project_name = spec.get("name") or project_path.name
 
     # Collect all unique container build specs.
-    build_specs: list[tuple[str, dict]] = []  # (label, spec_dict)
+    build_specs: list[tuple[str, str | dict]] = []  # (label, spec)
     raw_default = spec.get("container")
-    if isinstance(raw_default, dict) and "build" in raw_default:
-        build_specs.append(("analysis-level", raw_default))
+    if raw_default is not None:
+        if isinstance(raw_default, dict) and "build" in raw_default:
+            build_specs.append(("analysis-level", raw_default))
+        elif isinstance(raw_default, str) and runtime != "docker":
+            # Pre-built images need pull/migrate for HPC runtimes
+            build_specs.append(("analysis-level", raw_default))
 
     for output_def in get_outputs(spec):
         recipe = output_def.get("recipe")
         if not recipe:
             continue
         raw = recipe.get("container")
-        if isinstance(raw, dict) and "build" in raw:
-            label = f"recipe:{output_def.get('id', '?')}"
-            build_specs.append((label, raw))
+        if raw is not None:
+            if isinstance(raw, dict) and "build" in raw:
+                label = f"recipe:{output_def.get('id', '?')}"
+                build_specs.append((label, raw))
+            elif isinstance(raw, str) and runtime != "docker":
+                label = f"recipe:{output_def.get('id', '?')}"
+                build_specs.append((label, raw))
 
     if not build_specs:
         console.print("[dim]No container build specs found in asp.yaml.[/dim]")
         return
 
-    console.print(f"[bold]Found {len(build_specs)} container build spec(s)[/bold]\n")
+    console.print(
+        f"[bold]Found {len(build_specs)} container spec(s) "
+        f"(runtime: {runtime})[/bold]\n"
+    )
 
     for label, bspec in build_specs:
         try:
-            tag = resolve_container_spec(
-                bspec, project_path, project_name, force=force,
-            )
-            console.print(f"  [green]built[/green]  {label} -> {tag}")
+            if runtime in ("podman-hpc", "shifter"):
+                tag = resolve_container_for_slurm(
+                    bspec, project_path, project_name, runtime, force=force,
+                )
+            else:
+                tag = resolve_container_spec(
+                    bspec, project_path, project_name, force=force,
+                )
+            console.print(f"  [green]ready[/green]  {label} -> {tag}")
         except ContainerBuildError as e:
             console.print(f"  [red]fail[/red]   {label}: {e}")
 
@@ -731,21 +762,33 @@ def remote_setup(name: str | None, list_targets_flag: bool) -> None:
     Sets up connection details, scheduler config, and resource limits
     for remote execution backends (SLURM, etc.).
 
+    Known HPC sites (NERSC Perlmutter, OLCF Frontier, ALCF Polaris, ...)
+    are auto-detected from the target name and pre-filled with sensible
+    defaults.  You can override any value during the wizard.
+
     Examples:
         prism remote setup perlmutter
         prism remote setup --list
     """
+    from prism.dagster.sites import detect_site, get_site_defaults, list_known_sites
     from prism.dagster.targets import list_targets, save_target
 
     if list_targets_flag:
         saved = list_targets()
         if not saved:
             console.print("[dim]No saved targets.[/dim]")
-            console.print("Run [cyan]prism remote setup <name>[/cyan] to configure one.")
         else:
             console.print("[bold]Saved targets:[/bold]")
             for t in saved:
                 console.print(f"  - {t}")
+
+        known = list_known_sites()
+        console.print(f"\n[bold]Known sites[/bold] (auto-detected defaults):")
+        for key, display in known:
+            console.print(f"  - [cyan]{key}[/cyan]  ({display})")
+        console.print(
+            "\nRun [cyan]prism remote setup <name>[/cyan] to configure a target."
+        )
         return
 
     if name is None:
@@ -754,35 +797,107 @@ def remote_setup(name: str | None, list_targets_flag: bool) -> None:
 
     console.print(f"\n[bold]Setting up target: [cyan]{name}[/cyan][/bold]\n")
 
+    # Try to detect a known site from the target name.
+    site_key = detect_site(name)
+    site: dict[str, Any] = {}
+    if site_key:
+        site = get_site_defaults(site_key) or {}
+        display = site.get("display_name", site_key)
+        console.print(
+            f"  Detected known site: [cyan]{display}[/cyan] "
+            f"(using site defaults)\n"
+        )
+
+    # --- Connection ---
+    site_conn = site.get("connection", {})
+    site_sched = site.get("scheduler", {})
+    site_limits = site.get("resource_limits", {})
+    site_partitions = site.get("partitions", {})
+
     backend = click.prompt(
-        "  Backend", type=click.Choice(["slurm", "pbs"]), default="slurm"
+        "  Backend",
+        type=click.Choice(["slurm", "pbs"]),
+        default=site.get("backend", "slurm"),
     )
-    hostname = click.prompt("  Hostname")
-    username = click.prompt("  Username", default=os.environ.get("USER", ""))
+    hostname = click.prompt(
+        "  Hostname",
+        default=site_conn.get("hostname", ""),
+    )
+    username = click.prompt(
+        "  Username",
+        default=os.environ.get("USER", ""),
+    )
     account = click.prompt("  Account/allocation")
-    partition = click.prompt("  Partition", default="regular")
+
+    # If the site has named partition presets, let the user pick one.
+    partition_default = "regular"
+    constraint_default = ""
+    container_flags_default: list[str] = []
+    if site_partitions:
+        partition_keys = list(site_partitions.keys())
+        console.print(f"\n  [bold]Available partition presets:[/bold]")
+        for pk in partition_keys:
+            pinfo = site_partitions[pk]
+            desc_parts = []
+            if pinfo.get("constraint"):
+                desc_parts.append(f"constraint={pinfo['constraint']}")
+            if pinfo.get("container_flags"):
+                desc_parts.append(f"flags={' '.join(pinfo['container_flags'])}")
+            desc = ", ".join(desc_parts) if desc_parts else "(no constraints)"
+            console.print(f"    - [cyan]{pk}[/cyan]: {desc}")
+
+        partition = click.prompt(
+            "\n  Partition",
+            type=click.Choice(partition_keys + ["custom"]),
+            default=partition_keys[0],
+        )
+        if partition != "custom" and partition in site_partitions:
+            pinfo = site_partitions[partition]
+            constraint_default = pinfo.get("constraint", "")
+            container_flags_default = pinfo.get("container_flags", [])
+        else:
+            partition = click.prompt("  Custom partition name")
+    else:
+        partition = click.prompt("  Partition", default="regular")
+
     container_runtime = click.prompt(
         "  Container runtime",
         type=click.Choice(["podman-hpc", "shifter", "singularity"]),
-        default="podman-hpc",
+        default=site_sched.get("container_runtime", "podman-hpc"),
     )
 
-    qos = click.prompt("  QOS", default="regular")
+    qos = click.prompt(
+        "  QOS",
+        default=site_sched.get("qos", "regular"),
+    )
     constraint = click.prompt(
-        "  Constraint (e.g., cpu, gpu, gpu&hbm80g)", default="",
+        "  Constraint (e.g., cpu, gpu, gpu&hbm80g)",
+        default=constraint_default,
     )
 
-    # Container runtime flags (NERSC-specific: --gpu, --mpi, --nccl, etc.)
     container_flags_str = click.prompt(
-        "  Container flags (e.g., --gpu --mpi --nccl)", default="",
+        "  Container flags (e.g., --gpu --mpi --nccl)",
+        default=" ".join(container_flags_default),
     )
     container_flags = container_flags_str.split() if container_flags_str.strip() else []
 
     console.print("\n  [bold]Resource limits[/bold]")
-    max_nodes = click.prompt("    Max nodes per job", type=int, default=4)
-    max_walltime = click.prompt("    Max walltime (minutes)", type=int, default=240)
-    max_concurrent = click.prompt("    Max concurrent jobs", type=int, default=8)
-    max_node_hours = click.prompt("    Max node-hours per session", type=int, default=32)
+    max_nodes = click.prompt(
+        "    Max nodes per job", type=int,
+        default=site_limits.get("max_nodes", 4),
+    )
+    max_walltime = click.prompt(
+        "    Max walltime (minutes)", type=int,
+        default=site_limits.get("max_walltime_minutes", 240),
+    )
+    max_concurrent = click.prompt(
+        "    Max concurrent jobs", type=int,
+        default=site_limits.get("max_concurrent_jobs", 8),
+    )
+    max_node_hours = click.prompt(
+        "    Max node-hours per session", type=int,
+        default=site_limits.get("max_node_hours_per_session", 32),
+    )
 
     scheduler_config: dict[str, Any] = {
         "account": account,
@@ -796,7 +911,7 @@ def remote_setup(name: str | None, list_targets_flag: bool) -> None:
     if container_flags:
         scheduler_config["container_flags"] = container_flags
 
-    config = {
+    config: dict[str, Any] = {
         "name": name,
         "backend": backend,
         "connection": {"hostname": hostname, "username": username},
@@ -808,6 +923,8 @@ def remote_setup(name: str | None, list_targets_flag: bool) -> None:
             "max_node_hours_per_session": max_node_hours,
         },
     }
+    if site_key:
+        config["site"] = site_key
 
     path = save_target(name, config)
     console.print(f"\n[green]✓[/green] Saved to [cyan]{path}[/cyan]")

--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -763,9 +763,20 @@ def remote_setup(name: str | None, list_targets_flag: bool) -> None:
     partition = click.prompt("  Partition", default="regular")
     container_runtime = click.prompt(
         "  Container runtime",
-        type=click.Choice(["shifter", "podman-hpc", "singularity"]),
-        default="shifter",
+        type=click.Choice(["podman-hpc", "shifter", "singularity"]),
+        default="podman-hpc",
     )
+
+    qos = click.prompt("  QOS", default="regular")
+    constraint = click.prompt(
+        "  Constraint (e.g., cpu, gpu, gpu&hbm80g)", default="",
+    )
+
+    # Container runtime flags (NERSC-specific: --gpu, --mpi, --nccl, etc.)
+    container_flags_str = click.prompt(
+        "  Container flags (e.g., --gpu --mpi --nccl)", default="",
+    )
+    container_flags = container_flags_str.split() if container_flags_str.strip() else []
 
     console.print("\n  [bold]Resource limits[/bold]")
     max_nodes = click.prompt("    Max nodes per job", type=int, default=4)
@@ -773,15 +784,23 @@ def remote_setup(name: str | None, list_targets_flag: bool) -> None:
     max_concurrent = click.prompt("    Max concurrent jobs", type=int, default=8)
     max_node_hours = click.prompt("    Max node-hours per session", type=int, default=32)
 
+    scheduler_config: dict[str, Any] = {
+        "account": account,
+        "partition": partition,
+        "container_runtime": container_runtime,
+    }
+    if qos:
+        scheduler_config["qos"] = qos
+    if constraint:
+        scheduler_config["constraint"] = constraint
+    if container_flags:
+        scheduler_config["container_flags"] = container_flags
+
     config = {
         "name": name,
         "backend": backend,
         "connection": {"hostname": hostname, "username": username},
-        "scheduler": {
-            "account": account,
-            "partition": partition,
-            "container_runtime": container_runtime,
-        },
+        "scheduler": scheduler_config,
         "resource_limits": {
             "max_nodes": max_nodes,
             "max_walltime_minutes": max_walltime,

--- a/src/prism/container.py
+++ b/src/prism/container.py
@@ -194,6 +194,203 @@ class ContainerStatus:
     extra: dict[str, Any] = field(default_factory=dict)
 
 
+# ---------------------------------------------------------------------------
+# HPC container runtimes (podman-hpc, shifter)
+# ---------------------------------------------------------------------------
+
+
+def build_image_podman_hpc(
+    tag: str,
+    containerfile: Path,
+    context: Path,
+    build_args: dict[str, str] | None = None,
+) -> ContainerBuildResult:
+    """Build a container image with ``podman-hpc build``.
+
+    Runs on NERSC login nodes.  After building, the image is automatically
+    migrated so it is available on compute nodes.
+
+    Raises :class:`ContainerBuildError` on failure.
+    """
+    cmd: list[str] = [
+        "podman-hpc", "build",
+        "-t", tag,
+        "-f", str(containerfile),
+    ]
+    for key, value in (build_args or {}).items():
+        cmd += ["--build-arg", f"{key}={value}"]
+    cmd.append(str(context))
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError:
+        raise ContainerBuildError(
+            "podman-hpc is not installed or not on PATH. "
+            "Are you running on a NERSC login node?"
+        )
+
+    if proc.returncode != 0:
+        raise ContainerBuildError(
+            f"podman-hpc build failed (exit code {proc.returncode}):\n{proc.stderr}"
+        )
+
+    # Migrate the image so compute nodes can access it.
+    _podman_hpc_migrate(tag)
+
+    return ContainerBuildResult(
+        tag=tag,
+        already_existed=False,
+        exit_code=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+    )
+
+
+def _podman_hpc_migrate(tag: str) -> None:
+    """Run ``podman-hpc migrate <tag>`` to make image available on compute nodes."""
+    try:
+        proc = subprocess.run(
+            ["podman-hpc", "migrate", tag],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        raise ContainerBuildError("podman-hpc not found — cannot migrate image.")
+    if proc.returncode != 0:
+        raise ContainerBuildError(
+            f"podman-hpc migrate failed (exit code {proc.returncode}):\n{proc.stderr}"
+        )
+    logger.info("podman-hpc migrate %s succeeded.", tag)
+
+
+def image_exists_podman_hpc(tag: str) -> bool:
+    """Check whether *tag* exists in the local podman-hpc image store."""
+    try:
+        result = subprocess.run(
+            ["podman-hpc", "image", "exists", tag],
+            capture_output=True,
+            check=False,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def pull_shifterimg(image: str) -> None:
+    """Pull an image into Shifter via ``shifterimg pull``.
+
+    This converts the image from a registry into Shifter format. It is a
+    no-op if the image already exists in Shifter's cache (shifterimg handles
+    this internally).
+
+    Raises :class:`ContainerBuildError` on failure.
+    """
+    try:
+        proc = subprocess.run(
+            ["shifterimg", "pull", image],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        raise ContainerBuildError(
+            "shifterimg is not installed or not on PATH. "
+            "Are you running on a NERSC login node?"
+        )
+    if proc.returncode != 0:
+        raise ContainerBuildError(
+            f"shifterimg pull failed (exit code {proc.returncode}):\n{proc.stderr}"
+        )
+    logger.info("shifterimg pull %s succeeded.", image)
+
+
+def shifterimg_lookup(image: str) -> bool:
+    """Check whether *image* is available in Shifter via ``shifterimg lookup``."""
+    try:
+        result = subprocess.run(
+            ["shifterimg", "lookup", image],
+            capture_output=True,
+            check=False,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def resolve_container_for_slurm(
+    spec: str | dict[str, Any] | None,
+    project_path: Path,
+    project_name: str,
+    container_runtime: str,
+    *,
+    force: bool = False,
+) -> str | None:
+    """Resolve a container spec for SLURM execution, building if needed.
+
+    For ``podman-hpc``:
+    - Build specs (dict with ``build`` key) are built with ``podman-hpc build``
+      and migrated automatically.
+    - Pre-built image strings are migrated if not already available.
+
+    For ``shifter``:
+    - Pre-built image strings are pulled via ``shifterimg pull``.
+    - Build specs are NOT supported (Shifter cannot build on the cluster).
+      Raises :class:`ContainerBuildError` in this case.
+
+    Returns the image tag string to use, or ``None`` if no container.
+    """
+    if spec is None:
+        return None
+
+    if isinstance(spec, str):
+        # Pre-built image reference
+        if container_runtime == "podman-hpc":
+            if not force and image_exists_podman_hpc(spec):
+                logger.info("Image %s already available in podman-hpc, skipping migrate.", spec)
+            else:
+                logger.info("Migrating %s for podman-hpc compute nodes...", spec)
+                _podman_hpc_migrate(spec)
+        elif container_runtime == "shifter":
+            if not force and shifterimg_lookup(spec):
+                logger.info("Image %s already available in Shifter.", spec)
+            else:
+                logger.info("Pulling %s into Shifter...", spec)
+                pull_shifterimg(spec)
+        return spec
+
+    # Must be a build spec dict.
+    build_path = spec.get("build")
+    if not build_path:
+        raise ContainerBuildError(
+            "Container build spec must have a 'build' key pointing to a Containerfile."
+        )
+
+    if container_runtime == "shifter":
+        raise ContainerBuildError(
+            "Shifter does not support building images on the cluster. "
+            "Use a pre-built image string, or switch to podman-hpc."
+        )
+
+    containerfile = project_path / build_path
+    if not containerfile.is_file():
+        raise ContainerBuildError(f"Containerfile not found: {containerfile}")
+
+    tag = compute_image_tag(project_name, containerfile, project_path)
+
+    if not force and image_exists_podman_hpc(tag):
+        logger.info("Image %s already exists in podman-hpc, skipping build.", tag)
+        return tag
+
+    context_dir = project_path
+    if spec.get("context"):
+        context_dir = project_path / spec["context"]
+
+    logger.info("Building image %s with podman-hpc from %s ...", tag, containerfile)
+    build_image_podman_hpc(tag, containerfile, context_dir, build_args=spec.get("args"))
+    return tag
+
+
 def get_container_status(
     spec: str | dict[str, Any] | None,
     project_path: Path,

--- a/src/prism/dagster/__init__.py
+++ b/src/prism/dagster/__init__.py
@@ -7,7 +7,11 @@ Provides:
 - get_output_status(): Query materialization status
 """
 from prism.dagster.io_manager import ASPIOManager
-from prism.dagster.runner import ASPContainerRunner
+from prism.dagster.runner import (
+    ASPContainerRunner,
+    generate_sbatch_script,
+    translate_resources_to_slurm_directives,
+)
 from prism.dagster.status import get_all_universe_status, get_output_status
 from prism.dagster.targets import list_targets, load_target, save_target
 
@@ -16,11 +20,13 @@ __all__ = [
     "ASPIOManager",
     "build_asset_definitions",
     "build_definitions",
+    "generate_sbatch_script",
     "get_output_status",
     "get_all_universe_status",
     "list_targets",
     "load_target",
     "save_target",
+    "translate_resources_to_slurm_directives",
 ]
 
 

--- a/src/prism/dagster/assets.py
+++ b/src/prism/dagster/assets.py
@@ -1,14 +1,37 @@
 """Asset factory — generates Dagster assets from asp.yaml output recipes."""
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 import dagster as dg
 from asp.helpers import get_outputs, load_yaml
 
-from prism.container import resolve_container_spec
+from prism.container import resolve_container_for_slurm, resolve_container_spec
 from prism.dagster.runner import ASPContainerRunner
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_container(
+    spec: str | dict[str, Any] | None,
+    project_path: Path,
+    project_name: str,
+    container_runtime: str | None = None,
+) -> str | None:
+    """Resolve a container spec, dispatching to the right builder.
+
+    When *container_runtime* is set (i.e. we are targeting SLURM), uses
+    ``resolve_container_for_slurm`` which handles podman-hpc build/migrate
+    and shifterimg pull automatically.  Otherwise falls back to the
+    default Docker-based ``resolve_container_spec``.
+    """
+    if container_runtime:
+        return resolve_container_for_slurm(
+            spec, project_path, project_name, container_runtime,
+        )
+    return resolve_container_spec(spec, project_path, project_name)
 
 
 def build_asset_definitions(
@@ -18,6 +41,7 @@ def build_asset_definitions(
     project_path: Path | None = None,
     project_name: str | None = None,
     no_build: bool = False,
+    container_runtime: str | None = None,
 ) -> list[dg.AssetsDefinition]:
     """Generate one @asset per output with a recipe."""
     outputs = get_outputs(spec)
@@ -27,7 +51,9 @@ def build_asset_definitions(
     if raw_default is not None and not no_build:
         _name = project_name or spec.get("name") or "project"
         _path = project_path or Path.cwd()
-        default_container = resolve_container_spec(raw_default, _path, _name)
+        default_container = _resolve_container(
+            raw_default, _path, _name, container_runtime,
+        )
     else:
         default_container = raw_default if isinstance(raw_default, str) else None
 
@@ -41,7 +67,7 @@ def build_asset_definitions(
             _build_single_asset(
                 output_id, recipe, runner, universe_id, project_path,
                 project_name=project_name, default_container=default_container,
-                no_build=no_build,
+                no_build=no_build, container_runtime=container_runtime,
             )
         )
 
@@ -70,6 +96,7 @@ def _build_single_asset(
     project_name: str | None = None,
     default_container: str | None = None,
     no_build: bool = False,
+    container_runtime: str | None = None,
 ) -> dg.AssetsDefinition:
     """Build a single Dagster asset from an output recipe."""
     input_ids = recipe.get("inputs") or []
@@ -79,7 +106,7 @@ def _build_single_asset(
     if raw_container is not None and not no_build:
         _name = project_name or "project"
         _path = project_path or Path.cwd()
-        container = resolve_container_spec(raw_container, _path, _name)
+        container = _resolve_container(raw_container, _path, _name, container_runtime)
     elif raw_container is not None and isinstance(raw_container, str):
         container = raw_container
     else:
@@ -132,27 +159,40 @@ def build_definitions(
 ) -> dg.Definitions:
     """Build complete Dagster Definitions from an ASP project.
 
-    This is the main entry point for the Dagster integration.
+    This is the main entry point for the Dagster integration.  When a SLURM
+    target is specified, container images are automatically built (podman-hpc)
+    or pulled (shifter) before asset definitions are constructed.
     """
     from prism.dagster.targets import load_target
 
     spec = load_yaml(project_path / "asp.yaml")
     project_name = spec.get("name") or project_path.name
 
+    # Determine the container runtime from the target config (if SLURM).
+    target_config = None
+    container_runtime: str | None = None
+    if target:
+        target_config = load_target(target)
+        if target_config is None:
+            raise ValueError(f"Unknown target: {target}")
+        if target_config.get("backend") == "slurm":
+            container_runtime = (
+                target_config.get("scheduler", {}).get("container_runtime", "podman-hpc")
+            )
+
     # Resolve analysis-level container spec to a string for the runner.
+    # For SLURM targets this triggers podman-hpc build/migrate or
+    # shifterimg pull automatically.
     raw_container = spec.get("container")
     if not no_build:
-        default_container = resolve_container_spec(
-            raw_container, project_path, project_name
+        default_container = _resolve_container(
+            raw_container, project_path, project_name, container_runtime,
         )
     else:
         default_container = raw_container if isinstance(raw_container, str) else None
 
     # Build runner from target config
-    if target:
-        target_config = load_target(target)
-        if target_config is None:
-            raise ValueError(f"Unknown target: {target}")
+    if target_config:
         runner = ASPContainerRunner(
             project_root=str(project_path),
             backend=target_config.get("backend", "docker"),
@@ -169,6 +209,7 @@ def build_definitions(
     assets = build_asset_definitions(
         spec, runner=runner, universe_id=universe_id, project_path=project_path,
         project_name=project_name, no_build=no_build,
+        container_runtime=container_runtime,
     )
 
     return dg.Definitions(assets=assets)

--- a/src/prism/dagster/runner.py
+++ b/src/prism/dagster/runner.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
 import sys
+import tempfile
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -217,5 +220,400 @@ class ASPContainerRunner:
         universe_id: str,
         resources: dict[str, Any],
     ) -> ExecutionResult:
-        """Execute a recipe via SLURM. Placeholder for Phase 2."""
-        raise NotImplementedError("SLURM backend not yet implemented")
+        """Execute a recipe via SLURM on a login node.
+
+        Generates an sbatch script with the appropriate container runtime
+        (podman-hpc or shifter), submits it, and polls for completion.
+        Assumes we are running on a login node with access to sbatch/squeue/sacct
+        and the project directory is on a shared filesystem.
+        """
+        scheduler = self.target_config.get("scheduler", {})
+        container_runtime = scheduler.get("container_runtime", "podman-hpc")
+
+        output_path = self.project_root / "results" / universe_id
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        # Generate the sbatch script
+        script = generate_sbatch_script(
+            command=command,
+            container=container,
+            container_runtime=container_runtime,
+            project_root=self.project_root,
+            output_id=output_id,
+            universe_id=universe_id,
+            resources=resources,
+            scheduler_config=scheduler,
+        )
+
+        # Write script to a temp file inside the project so it's on the
+        # shared filesystem visible to compute nodes.
+        scripts_dir = self.project_root / "results" / ".slurm"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        job_name = f"{output_id}_{universe_id}"
+        script_path = scripts_dir / f"{job_name}.sh"
+        script_path.write_text(script)
+        script_path.chmod(0o755)
+
+        logger.info("Submitting SLURM job for %s/%s", output_id, universe_id)
+        logger.debug("sbatch script:\n%s", script)
+
+        # Submit via sbatch
+        try:
+            submit_result = subprocess.run(
+                ["sbatch", str(script_path)],
+                capture_output=True,
+                text=True,
+                cwd=str(self.project_root),
+            )
+        except FileNotFoundError:
+            return ExecutionResult(
+                exit_code=127,
+                output_path=output_path,
+                metadata={"stderr": "sbatch: command not found"},
+            )
+
+        if submit_result.returncode != 0:
+            return ExecutionResult(
+                exit_code=submit_result.returncode,
+                output_path=output_path,
+                metadata={
+                    "stderr": submit_result.stderr,
+                    "backend": "slurm",
+                },
+            )
+
+        # Parse job ID from "Submitted batch job 12345"
+        job_id = _parse_sbatch_job_id(submit_result.stdout)
+        if job_id is None:
+            return ExecutionResult(
+                exit_code=1,
+                output_path=output_path,
+                metadata={
+                    "stderr": f"Could not parse job ID from: {submit_result.stdout}",
+                    "backend": "slurm",
+                },
+            )
+
+        logger.info("SLURM job submitted: %s", job_id)
+
+        # Poll for completion
+        poll_config = self.target_config.get("poll", {})
+        poll_interval = poll_config.get("interval_seconds", 15)
+        poll_timeout = poll_config.get("timeout_seconds", 14400)  # 4h default
+        exit_code, job_metadata = _poll_slurm_job(
+            job_id, poll_interval=poll_interval, poll_timeout=poll_timeout,
+        )
+
+        # Collect stdout/stderr from SLURM output files
+        slurm_stdout = ""
+        slurm_stderr = ""
+        stdout_file = scripts_dir / f"{job_name}.out"
+        stderr_file = scripts_dir / f"{job_name}.err"
+        if stdout_file.exists():
+            slurm_stdout = stdout_file.read_text()[-2000:]
+        if stderr_file.exists():
+            slurm_stderr = stderr_file.read_text()[-2000:]
+
+        return ExecutionResult(
+            exit_code=exit_code,
+            output_path=output_path,
+            metadata={
+                "backend": "slurm",
+                "slurm_job_id": job_id,
+                "container_runtime": container_runtime,
+                "stdout": slurm_stdout,
+                "stderr": slurm_stderr,
+                "sbatch_script": str(script_path),
+                **job_metadata,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# SLURM helpers
+# ---------------------------------------------------------------------------
+
+
+def translate_resources_to_slurm_directives(
+    resources: dict[str, Any],
+    scheduler_config: dict[str, Any] | None = None,
+) -> list[str]:
+    """Translate ASP resource requirements to SLURM #SBATCH directives.
+
+    Returns a list of directive strings (without the ``#SBATCH`` prefix).
+    """
+    scheduler_config = scheduler_config or {}
+    directives: list[str] = []
+
+    if account := scheduler_config.get("account"):
+        directives.append(f"--account={account}")
+    if partition := scheduler_config.get("partition"):
+        directives.append(f"--partition={partition}")
+    if qos := scheduler_config.get("qos"):
+        directives.append(f"--qos={qos}")
+    if constraint := scheduler_config.get("constraint"):
+        directives.append(f"--constraint={constraint}")
+
+    if nodes := resources.get("nodes"):
+        directives.append(f"--nodes={nodes}")
+    if cpus := resources.get("cpus"):
+        directives.append(f"--cpus-per-task={cpus}")
+    if memory := resources.get("memory"):
+        directives.append(f"--mem={memory}")
+    if gpus := resources.get("gpus"):
+        directives.append(f"--gpus={gpus}")
+    if time_limit := resources.get("time_limit"):
+        directives.append(f"--time={_normalise_time_limit(time_limit)}")
+
+    return directives
+
+
+def _normalise_time_limit(value: str | int) -> str:
+    """Convert time_limit values like '2h', '30m', 120 to HH:MM:SS."""
+    if isinstance(value, int):
+        # Assume minutes
+        hours, minutes = divmod(value, 60)
+        return f"{hours:02d}:{minutes:02d}:00"
+    value = str(value).strip()
+    match = re.match(r"^(\d+)([hm]?)$", value, re.IGNORECASE)
+    if match:
+        num, unit = int(match.group(1)), match.group(2).lower()
+        if unit == "h":
+            return f"{num:02d}:00:00"
+        elif unit == "m":
+            hours, minutes = divmod(num, 60)
+            return f"{hours:02d}:{minutes:02d}:00"
+        else:
+            # bare number = minutes
+            hours, minutes = divmod(num, 60)
+            return f"{hours:02d}:{minutes:02d}:00"
+    # Already in HH:MM:SS or similar — pass through
+    return value
+
+
+def generate_sbatch_script(
+    command: str,
+    container: str | None,
+    container_runtime: str,
+    project_root: Path,
+    output_id: str,
+    universe_id: str,
+    resources: dict[str, Any],
+    scheduler_config: dict[str, Any] | None = None,
+) -> str:
+    """Generate an sbatch script for a recipe execution.
+
+    Supports two container runtimes at NERSC:
+    - ``podman-hpc``: The recommended runtime on Perlmutter. Containers are
+      run via ``podman-hpc run`` with optional ``--gpu`` / ``--mpi`` flags.
+      Images must be pre-migrated (``podman-hpc migrate``).
+    - ``shifter``: Legacy runtime. Uses ``#SBATCH --image=`` and
+      ``srun shifter`` to execute inside the container.
+
+    If no container image is specified, the command runs directly (no
+    container wrapping).
+    """
+    scheduler_config = scheduler_config or {}
+    job_name = f"prism_{output_id}_{universe_id}"
+
+    lines = ["#!/bin/bash"]
+
+    # Standard SBATCH header
+    lines.append(f"#SBATCH --job-name={job_name}")
+
+    # Output / error files go next to the script
+    lines.append(f"#SBATCH --output=results/.slurm/{output_id}_{universe_id}.out")
+    lines.append(f"#SBATCH --error=results/.slurm/{output_id}_{universe_id}.err")
+
+    # Resource directives
+    directives = translate_resources_to_slurm_directives(resources, scheduler_config)
+
+    # For Shifter, the image is specified as an SBATCH directive
+    if container_runtime == "shifter" and container:
+        directives.append(f"--image={container}")
+
+    for d in directives:
+        lines.append(f"#SBATCH {d}")
+
+    lines.append("")
+    lines.append("# --- Prism / ASP recipe execution ---")
+    lines.append(f"cd {project_root}")
+    lines.append("")
+
+    # Build the execution command based on container runtime
+    if container and container_runtime == "podman-hpc":
+        lines.append(_podman_hpc_run_command(
+            command, container, project_root, resources, scheduler_config,
+        ))
+    elif container and container_runtime == "shifter":
+        lines.append(_shifter_run_command(command, resources))
+    else:
+        # No container — run directly
+        lines.append(command)
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _podman_hpc_run_command(
+    command: str,
+    container: str,
+    project_root: Path,
+    resources: dict[str, Any],
+    scheduler_config: dict[str, Any],
+) -> str:
+    """Build a podman-hpc run invocation for use inside an sbatch script.
+
+    Key podman-hpc flags used:
+    - ``--rm``: Clean up container after exit.
+    - ``--gpu``: Bind NVIDIA GPU devices and drivers into the container.
+    - ``--mpi``: Inject Cray MPICH for optimized MPI on Slingshot.
+    - ``-v``: Volume mount the project root at /workspace.
+    - ``-w``: Set the working directory inside the container.
+    """
+    parts = ["podman-hpc", "run", "--rm"]
+
+    # GPU support
+    if resources.get("gpus"):
+        parts.append("--gpu")
+
+    # MPI support — if the scheduler config opts in
+    container_flags = scheduler_config.get("container_flags", [])
+    if "--mpi" in container_flags:
+        parts.append("--mpi")
+    if "--nccl" in container_flags:
+        parts.append("--nccl")
+    if "--cuda-mpi" in container_flags:
+        parts.append("--cuda-mpi")
+
+    # Any extra user-specified flags
+    for flag in container_flags:
+        if flag not in ("--mpi", "--nccl", "--cuda-mpi", "--gpu"):
+            parts.append(flag)
+
+    # Volume mount project root
+    parts.extend(["-v", f"{project_root}:/workspace", "-w", "/workspace"])
+
+    parts.append(container)
+    parts.extend(["sh", "-c", _shell_quote(command)])
+
+    return " ".join(parts)
+
+
+def _shifter_run_command(command: str, resources: dict[str, Any]) -> str:
+    """Build a shifter invocation for use inside an sbatch script.
+
+    With Shifter the image is specified via ``#SBATCH --image=`` so
+    we only need ``srun shifter <command>`` here.
+    """
+    return f"srun shifter sh -c {_shell_quote(command)}"
+
+
+def _shell_quote(s: str) -> str:
+    """Wrap a string in single quotes for shell, escaping internal quotes."""
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _parse_sbatch_job_id(stdout: str) -> str | None:
+    """Extract job ID from sbatch output like 'Submitted batch job 12345'."""
+    match = re.search(r"Submitted batch job (\d+)", stdout)
+    return match.group(1) if match else None
+
+
+def _poll_slurm_job(
+    job_id: str,
+    poll_interval: int = 15,
+    poll_timeout: int = 14400,
+) -> tuple[int, dict[str, Any]]:
+    """Poll a SLURM job until completion, returning (exit_code, metadata).
+
+    Uses ``sacct`` to query the final status.  Falls back to ``squeue`` if
+    sacct is not available.
+    """
+    start = time.monotonic()
+    metadata: dict[str, Any] = {}
+
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed > poll_timeout:
+            logger.warning(
+                "SLURM job %s timed out after %ds", job_id, poll_timeout,
+            )
+            metadata["timeout"] = True
+            return 1, metadata
+
+        # Check sacct for completed job
+        exit_code, meta = _check_sacct(job_id)
+        if exit_code is not None:
+            metadata.update(meta)
+            return exit_code, metadata
+
+        logger.debug(
+            "Job %s still running (%.0fs elapsed), polling in %ds",
+            job_id, elapsed, poll_interval,
+        )
+        time.sleep(poll_interval)
+
+
+def _check_sacct(job_id: str) -> tuple[int | None, dict[str, Any]]:
+    """Query sacct for a completed job. Returns (exit_code, metadata) or (None, {})."""
+    try:
+        result = subprocess.run(
+            [
+                "sacct", "-j", job_id,
+                "--format=JobID,State,ExitCode,Elapsed,NodeList",
+                "--noheader", "--parsable2",
+            ],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        # sacct not available, try squeue fallback
+        return _check_squeue_fallback(job_id)
+
+    if result.returncode != 0:
+        return None, {}
+
+    for line in result.stdout.strip().splitlines():
+        parts = line.split("|")
+        if len(parts) < 5:
+            continue
+        sacct_job_id, state, exit_code_str, elapsed, nodelist = parts[:5]
+        # Only look at the main job step (not .batch, .extern, etc.)
+        if "." in sacct_job_id:
+            continue
+
+        state = state.strip()
+        if state in ("COMPLETED", "FAILED", "CANCELLED", "TIMEOUT", "NODE_FAIL",
+                      "OUT_OF_MEMORY", "PREEMPTED"):
+            # Parse exit code — format is "exit:signal" e.g. "0:0"
+            try:
+                exit_code = int(exit_code_str.split(":")[0])
+            except (ValueError, IndexError):
+                exit_code = 1 if state != "COMPLETED" else 0
+            return exit_code, {
+                "slurm_state": state,
+                "elapsed": elapsed,
+                "nodelist": nodelist,
+            }
+
+    return None, {}
+
+
+def _check_squeue_fallback(job_id: str) -> tuple[int | None, dict[str, Any]]:
+    """Fallback: use squeue to check if a job is still running."""
+    try:
+        result = subprocess.run(
+            ["squeue", "-j", job_id, "--noheader", "--format=%T"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        logger.error("Neither sacct nor squeue found — cannot poll SLURM job")
+        return 1, {"error": "sacct and squeue not found"}
+
+    state = result.stdout.strip()
+    if not state:
+        # Job no longer in queue — assume completed (sacct would be better)
+        return 0, {"slurm_state": "COMPLETED (assumed)"}
+    return None, {}

--- a/src/prism/dagster/runner.py
+++ b/src/prism/dagster/runner.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import logging
 import re
+import shlex
 import subprocess
 import sys
-import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -78,12 +78,13 @@ class ASPContainerRunner:
         is unavailable or the container run fails.
         """
         cli_args = _build_cli_args(params or {}, universe_id)
+        full_command = (command + " " + " ".join(cli_args)).strip()
         results_dir = self.project_root / "results" / universe_id
         results_dir.mkdir(parents=True, exist_ok=True)
 
         if self.backend == "slurm":
             return self._run_slurm(
-                command=command,
+                command=full_command,
                 container=container or self.default_container,
                 input_ids=inputs or [],
                 output_id=output_id,
@@ -95,11 +96,10 @@ class ASPContainerRunner:
         effective_container = container or self.default_container
         if effective_container:
             result = self._run_docker(
-                command=command,
+                command=full_command,
                 container=effective_container,
                 universe_id=universe_id,
                 resources=resources or {},
-                cli_args=cli_args,
             )
             if result.exit_code == 0:
                 return result
@@ -112,10 +112,9 @@ class ASPContainerRunner:
             )
 
         return self._run_local(
-            command=command,
+            command=full_command,
             output_id=output_id,
             universe_id=universe_id,
-            cli_args=cli_args,
             warn=effective_container is not None,
         )
 
@@ -125,22 +124,19 @@ class ASPContainerRunner:
         container: str,
         universe_id: str,
         resources: dict[str, Any],
-        cli_args: list[str],
     ) -> ExecutionResult:
         """Execute a recipe in a Docker container.
 
         Mounts the project root at /workspace so scripts can read data and
         write results using their normal relative paths.
         """
-        full_command = command + " " + " ".join(cli_args)
-
         cmd = ["docker", "run", "--rm"]
         cmd.extend(translate_resources_to_docker_flags(resources))
         cmd.extend([
             "-v", f"{self.project_root}:/workspace",
             "-w", "/workspace",
             container,
-            "sh", "-c", full_command,
+            "sh", "-c", command,
         ])
 
         try:
@@ -169,7 +165,6 @@ class ASPContainerRunner:
         command: str,
         output_id: str,
         universe_id: str,
-        cli_args: list[str],
         warn: bool = False,
     ) -> ExecutionResult:
         """Execute a recipe as a local subprocess.
@@ -184,10 +179,9 @@ class ASPContainerRunner:
                 output_id,
             )
 
-        full_command = command + " " + " ".join(cli_args)
-
         # Use the same Python that is running prism, unless the command
         # explicitly names an interpreter.
+        full_command = command
         env_python = sys.executable
         if full_command.startswith("python "):
             full_command = env_python + full_command[len("python"):]
@@ -511,7 +505,7 @@ def _shifter_run_command(command: str, resources: dict[str, Any]) -> str:
 
 def _shell_quote(s: str) -> str:
     """Wrap a string in single quotes for shell, escaping internal quotes."""
-    return "'" + s.replace("'", "'\\''") + "'"
+    return shlex.quote(s)
 
 
 def _parse_sbatch_job_id(stdout: str) -> str | None:
@@ -586,11 +580,15 @@ def _check_sacct(job_id: str) -> tuple[int | None, dict[str, Any]]:
         state = state.strip()
         if state in ("COMPLETED", "FAILED", "CANCELLED", "TIMEOUT", "NODE_FAIL",
                       "OUT_OF_MEMORY", "PREEMPTED"):
-            # Parse exit code — format is "exit:signal" e.g. "0:0"
-            try:
-                exit_code = int(exit_code_str.split(":")[0])
-            except (ValueError, IndexError):
-                exit_code = 1 if state != "COMPLETED" else 0
+            # For non-COMPLETED states always treat as failure — sacct often
+            # reports 0:0 for CANCELLED jobs which would be a false success.
+            if state != "COMPLETED":
+                exit_code = 1
+            else:
+                try:
+                    exit_code = int(exit_code_str.split(":")[0])
+                except (ValueError, IndexError):
+                    exit_code = 0
             return exit_code, {
                 "slurm_state": state,
                 "elapsed": elapsed,

--- a/src/prism/dagster/sites.py
+++ b/src/prism/dagster/sites.py
@@ -1,0 +1,152 @@
+"""Known HPC site defaults for target configuration.
+
+When ``prism remote setup`` detects a known hostname, it auto-populates
+scheduler settings with site-specific defaults (container runtime,
+partitions, constraints, etc.).  Users can override any value during the
+interactive wizard.
+
+To add a new site, append an entry to ``SITE_DEFAULTS``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Each entry maps a site key to its defaults.  The ``hostname_patterns``
+# list is used to auto-detect the site from user-provided hostnames.
+SITE_DEFAULTS: dict[str, dict[str, Any]] = {
+    "perlmutter": {
+        "hostname_patterns": ["perlmutter", "saul"],
+        "display_name": "NERSC Perlmutter",
+        "backend": "slurm",
+        "connection": {
+            "hostname": "perlmutter.nersc.gov",
+        },
+        "scheduler": {
+            "container_runtime": "podman-hpc",
+            "qos": "regular",
+        },
+        "partitions": {
+            "gpu": {
+                "constraint": "gpu",
+                "container_flags": ["--gpu"],
+            },
+            "gpu_hbm80": {
+                "constraint": "gpu&hbm80g",
+                "container_flags": ["--gpu"],
+            },
+            "cpu": {
+                "constraint": "cpu",
+                "container_flags": [],
+            },
+        },
+        "resource_limits": {
+            "max_nodes": 4,
+            "max_walltime_minutes": 360,
+            "max_concurrent_jobs": 8,
+            "max_node_hours_per_session": 64,
+        },
+    },
+    "cori": {
+        "hostname_patterns": ["cori"],
+        "display_name": "NERSC Cori (retired)",
+        "backend": "slurm",
+        "connection": {
+            "hostname": "cori.nersc.gov",
+        },
+        "scheduler": {
+            "container_runtime": "shifter",
+            "qos": "regular",
+        },
+        "partitions": {
+            "haswell": {
+                "constraint": "haswell",
+                "container_flags": [],
+            },
+            "knl": {
+                "constraint": "knl",
+                "container_flags": [],
+            },
+        },
+        "resource_limits": {
+            "max_nodes": 4,
+            "max_walltime_minutes": 240,
+            "max_concurrent_jobs": 8,
+            "max_node_hours_per_session": 32,
+        },
+    },
+    "frontier": {
+        "hostname_patterns": ["frontier"],
+        "display_name": "OLCF Frontier",
+        "backend": "slurm",
+        "connection": {
+            "hostname": "frontier.olcf.ornl.gov",
+        },
+        "scheduler": {
+            "container_runtime": "singularity",
+            "qos": "batch",
+        },
+        "partitions": {
+            "batch": {
+                "constraint": "",
+                "container_flags": [],
+            },
+        },
+        "resource_limits": {
+            "max_nodes": 4,
+            "max_walltime_minutes": 120,
+            "max_concurrent_jobs": 8,
+            "max_node_hours_per_session": 32,
+        },
+    },
+    "polaris": {
+        "hostname_patterns": ["polaris"],
+        "display_name": "ALCF Polaris",
+        "backend": "pbs",
+        "connection": {
+            "hostname": "polaris.alcf.anl.gov",
+        },
+        "scheduler": {
+            "container_runtime": "singularity",
+        },
+        "partitions": {
+            "default": {
+                "constraint": "",
+                "container_flags": [],
+            },
+        },
+        "resource_limits": {
+            "max_nodes": 4,
+            "max_walltime_minutes": 180,
+            "max_concurrent_jobs": 8,
+            "max_node_hours_per_session": 32,
+        },
+    },
+}
+
+
+def detect_site(hostname_or_name: str) -> str | None:
+    """Detect a known HPC site from a hostname or target name.
+
+    Returns the site key (e.g. ``"perlmutter"``) or ``None`` if no match.
+    """
+    normalized = hostname_or_name.lower()
+    for site_key, site in SITE_DEFAULTS.items():
+        if site_key in normalized:
+            return site_key
+        for pattern in site.get("hostname_patterns", []):
+            if pattern in normalized:
+                return site_key
+    return None
+
+
+def get_site_defaults(site_key: str) -> dict[str, Any] | None:
+    """Return defaults for a known site, or ``None``."""
+    return SITE_DEFAULTS.get(site_key)
+
+
+def list_known_sites() -> list[tuple[str, str]]:
+    """Return list of (site_key, display_name) for all known sites."""
+    return [
+        (key, site.get("display_name", key))
+        for key, site in SITE_DEFAULTS.items()
+    ]

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -9,11 +9,16 @@ import pytest
 from prism.container import (
     ContainerBuildError,
     build_image,
+    build_image_podman_hpc,
     compute_image_tag,
     find_dependency_files,
     get_container_status,
     image_exists_locally,
+    image_exists_podman_hpc,
+    pull_shifterimg,
+    resolve_container_for_slurm,
     resolve_container_spec,
+    shifterimg_lookup,
 )
 
 
@@ -229,3 +234,153 @@ class TestGetContainerStatus:
         assert s.type == "build"
         assert s.exists is True
         assert s.image is not None
+
+
+# ---------------------------------------------------------------------------
+# HPC container runtimes
+# ---------------------------------------------------------------------------
+
+
+class TestImageExistsPodmanHpc:
+    @patch("prism.container.subprocess.run")
+    def test_exists(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        assert image_exists_podman_hpc("my-image:v1") is True
+
+    @patch("prism.container.subprocess.run")
+    def test_not_exists(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+        assert image_exists_podman_hpc("my-image:v1") is False
+
+    @patch("prism.container.subprocess.run", side_effect=FileNotFoundError)
+    def test_not_installed(self, mock_run):
+        assert image_exists_podman_hpc("my-image:v1") is False
+
+
+class TestBuildImagePodmanHpc:
+    @patch("prism.container._podman_hpc_migrate")
+    @patch("prism.container.subprocess.run")
+    def test_success(self, mock_run, mock_migrate, project):
+        mock_run.return_value = MagicMock(returncode=0, stdout="built", stderr="")
+        result = build_image_podman_hpc(
+            "prism-test-abc123", project / "Containerfile", project,
+        )
+        assert result.tag == "prism-test-abc123"
+        assert result.already_existed is False
+        # Should also have migrated
+        mock_migrate.assert_called_once_with("prism-test-abc123")
+
+    @patch("prism.container.subprocess.run")
+    def test_failure(self, mock_run, project):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="build error")
+        with pytest.raises(ContainerBuildError, match="podman-hpc build failed"):
+            build_image_podman_hpc(
+                "prism-test-abc123", project / "Containerfile", project,
+            )
+
+    @patch("prism.container.subprocess.run", side_effect=FileNotFoundError)
+    def test_not_installed(self, mock_run, project):
+        with pytest.raises(ContainerBuildError, match="podman-hpc is not installed"):
+            build_image_podman_hpc(
+                "prism-test-abc123", project / "Containerfile", project,
+            )
+
+
+class TestShifterimgLookup:
+    @patch("prism.container.subprocess.run")
+    def test_exists(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        assert shifterimg_lookup("registry.nersc.gov/proj/img:v1") is True
+
+    @patch("prism.container.subprocess.run")
+    def test_not_exists(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+        assert shifterimg_lookup("registry.nersc.gov/proj/img:v1") is False
+
+    @patch("prism.container.subprocess.run", side_effect=FileNotFoundError)
+    def test_not_installed(self, mock_run):
+        assert shifterimg_lookup("registry.nersc.gov/proj/img:v1") is False
+
+
+class TestPullShifterimg:
+    @patch("prism.container.subprocess.run")
+    def test_success(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        pull_shifterimg("registry.nersc.gov/proj/img:v1")
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["shifterimg", "pull", "registry.nersc.gov/proj/img:v1"]
+
+    @patch("prism.container.subprocess.run")
+    def test_failure(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="pull error")
+        with pytest.raises(ContainerBuildError, match="shifterimg pull failed"):
+            pull_shifterimg("registry.nersc.gov/proj/img:v1")
+
+    @patch("prism.container.subprocess.run", side_effect=FileNotFoundError)
+    def test_not_installed(self, mock_run):
+        with pytest.raises(ContainerBuildError, match="shifterimg is not installed"):
+            pull_shifterimg("registry.nersc.gov/proj/img:v1")
+
+
+class TestResolveContainerForSlurm:
+    def test_none_returns_none(self, project):
+        assert resolve_container_for_slurm(None, project, "test", "podman-hpc") is None
+
+    @patch("prism.container.image_exists_podman_hpc", return_value=True)
+    def test_prebuilt_podman_already_exists(self, mock_exists, project):
+        result = resolve_container_for_slurm(
+            "my-image:v1", project, "test", "podman-hpc",
+        )
+        assert result == "my-image:v1"
+
+    @patch("prism.container._podman_hpc_migrate")
+    @patch("prism.container.image_exists_podman_hpc", return_value=False)
+    def test_prebuilt_podman_migrates(self, mock_exists, mock_migrate, project):
+        result = resolve_container_for_slurm(
+            "my-image:v1", project, "test", "podman-hpc",
+        )
+        assert result == "my-image:v1"
+        mock_migrate.assert_called_once_with("my-image:v1")
+
+    @patch("prism.container.shifterimg_lookup", return_value=True)
+    def test_prebuilt_shifter_already_exists(self, mock_lookup, project):
+        result = resolve_container_for_slurm(
+            "my-image:v1", project, "test", "shifter",
+        )
+        assert result == "my-image:v1"
+
+    @patch("prism.container.pull_shifterimg")
+    @patch("prism.container.shifterimg_lookup", return_value=False)
+    def test_prebuilt_shifter_pulls(self, mock_lookup, mock_pull, project):
+        result = resolve_container_for_slurm(
+            "my-image:v1", project, "test", "shifter",
+        )
+        assert result == "my-image:v1"
+        mock_pull.assert_called_once_with("my-image:v1")
+
+    @patch("prism.container.build_image_podman_hpc")
+    @patch("prism.container.image_exists_podman_hpc", return_value=False)
+    def test_build_spec_podman(self, mock_exists, mock_build, project):
+        mock_build.return_value = MagicMock(tag="prism-test-abc123")
+        spec = {"build": "Containerfile"}
+        tag = resolve_container_for_slurm(spec, project, "test", "podman-hpc")
+        assert tag is not None
+        assert tag.startswith("prism-test-")
+        mock_build.assert_called_once()
+
+    @patch("prism.container.image_exists_podman_hpc", return_value=True)
+    def test_build_spec_podman_cached(self, mock_exists, project):
+        spec = {"build": "Containerfile"}
+        tag = resolve_container_for_slurm(spec, project, "test", "podman-hpc")
+        assert tag is not None
+        assert tag.startswith("prism-test-")
+
+    def test_build_spec_shifter_raises(self, project):
+        spec = {"build": "Containerfile"}
+        with pytest.raises(ContainerBuildError, match="Shifter does not support building"):
+            resolve_container_for_slurm(spec, project, "test", "shifter")
+
+    def test_missing_containerfile(self, tmp_path):
+        spec = {"build": "NoSuchFile"}
+        with pytest.raises(ContainerBuildError, match="Containerfile not found"):
+            resolve_container_for_slurm(spec, tmp_path, "test", "podman-hpc")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,11 +1,19 @@
 """Tests for ASP Container Runner."""
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from prism.dagster.runner import (
     ASPContainerRunner,
+    _normalise_time_limit,
+    _parse_sbatch_job_id,
+    _shell_quote,
+    generate_sbatch_script,
     translate_resources_to_docker_flags,
+    translate_resources_to_slurm_directives,
 )
 
 
@@ -56,14 +64,389 @@ class TestDockerRunner:
         )
         assert runner.default_container == "myimage:latest"
 
-    def test_slurm_backend_not_implemented(self, tmp_path):
+
+# ---------------------------------------------------------------------------
+# SLURM resource translation
+# ---------------------------------------------------------------------------
+
+
+class TestSlurmResourceTranslation:
+    def test_translate_cpus(self):
+        dirs = translate_resources_to_slurm_directives({"cpus": 4})
+        assert "--cpus-per-task=4" in dirs
+
+    def test_translate_memory(self):
+        dirs = translate_resources_to_slurm_directives({"memory": "16GB"})
+        assert "--mem=16GB" in dirs
+
+    def test_translate_gpus(self):
+        dirs = translate_resources_to_slurm_directives({"gpus": 1})
+        assert "--gpus=1" in dirs
+
+    def test_translate_nodes(self):
+        dirs = translate_resources_to_slurm_directives({"nodes": 2})
+        assert "--nodes=2" in dirs
+
+    def test_translate_time_limit_hours(self):
+        dirs = translate_resources_to_slurm_directives({"time_limit": "2h"})
+        assert "--time=02:00:00" in dirs
+
+    def test_translate_time_limit_minutes(self):
+        dirs = translate_resources_to_slurm_directives({"time_limit": "30m"})
+        assert "--time=00:30:00" in dirs
+
+    def test_translate_time_limit_int(self):
+        dirs = translate_resources_to_slurm_directives({"time_limit": 90})
+        assert "--time=01:30:00" in dirs
+
+    def test_translate_time_limit_passthrough(self):
+        dirs = translate_resources_to_slurm_directives({"time_limit": "01:30:00"})
+        assert "--time=01:30:00" in dirs
+
+    def test_translate_empty(self):
+        dirs = translate_resources_to_slurm_directives({})
+        assert dirs == []
+
+    def test_scheduler_config_account(self):
+        dirs = translate_resources_to_slurm_directives(
+            {}, scheduler_config={"account": "m1234"},
+        )
+        assert "--account=m1234" in dirs
+
+    def test_scheduler_config_full(self):
+        dirs = translate_resources_to_slurm_directives(
+            {"cpus": 4},
+            scheduler_config={
+                "account": "m1234",
+                "partition": "gpu",
+                "qos": "regular",
+                "constraint": "gpu&hbm80g",
+            },
+        )
+        assert "--account=m1234" in dirs
+        assert "--partition=gpu" in dirs
+        assert "--qos=regular" in dirs
+        assert "--constraint=gpu&hbm80g" in dirs
+        assert "--cpus-per-task=4" in dirs
+
+
+# ---------------------------------------------------------------------------
+# Time limit normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseTimeLimit:
+    def test_hours(self):
+        assert _normalise_time_limit("2h") == "02:00:00"
+        assert _normalise_time_limit("12H") == "12:00:00"
+
+    def test_minutes(self):
+        assert _normalise_time_limit("30m") == "00:30:00"
+        assert _normalise_time_limit("90M") == "01:30:00"
+
+    def test_bare_int(self):
+        assert _normalise_time_limit(120) == "02:00:00"
+        assert _normalise_time_limit(45) == "00:45:00"
+
+    def test_bare_string_number(self):
+        assert _normalise_time_limit("60") == "01:00:00"
+
+    def test_passthrough(self):
+        assert _normalise_time_limit("01:30:00") == "01:30:00"
+
+
+# ---------------------------------------------------------------------------
+# sbatch script generation
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSbatchScript:
+    def test_podman_hpc_basic(self, tmp_path):
+        script = generate_sbatch_script(
+            command="python scripts/train.py",
+            container="ghcr.io/proj/ml:latest",
+            container_runtime="podman-hpc",
+            project_root=tmp_path,
+            output_id="trained_model",
+            universe_id="baseline",
+            resources={"cpus": 4, "memory": "16GB"},
+            scheduler_config={"account": "m1234", "partition": "gpu"},
+        )
+        assert "#!/bin/bash" in script
+        assert "#SBATCH --job-name=prism_trained_model_baseline" in script
+        assert "#SBATCH --account=m1234" in script
+        assert "#SBATCH --partition=gpu" in script
+        assert "#SBATCH --cpus-per-task=4" in script
+        assert "#SBATCH --mem=16GB" in script
+        assert "podman-hpc run --rm" in script
+        assert f"-v {tmp_path}:/workspace" in script
+        assert "-w /workspace" in script
+        assert "ghcr.io/proj/ml:latest" in script
+        assert "python scripts/train.py" in script
+        # No --image directive for podman-hpc
+        assert "#SBATCH --image=" not in script
+
+    def test_podman_hpc_with_gpu(self, tmp_path):
+        script = generate_sbatch_script(
+            command="python scripts/train.py",
+            container="ghcr.io/proj/ml:latest",
+            container_runtime="podman-hpc",
+            project_root=tmp_path,
+            output_id="train",
+            universe_id="baseline",
+            resources={"cpus": 4, "gpus": 1},
+            scheduler_config={"account": "m1234"},
+        )
+        assert "--gpu" in script
+        assert "#SBATCH --gpus=1" in script
+
+    def test_podman_hpc_with_mpi_flags(self, tmp_path):
+        script = generate_sbatch_script(
+            command="python scripts/train.py",
+            container="ghcr.io/proj/ml:latest",
+            container_runtime="podman-hpc",
+            project_root=tmp_path,
+            output_id="train",
+            universe_id="baseline",
+            resources={},
+            scheduler_config={
+                "account": "m1234",
+                "container_flags": ["--mpi", "--nccl"],
+            },
+        )
+        assert "--mpi" in script
+        assert "--nccl" in script
+
+    def test_shifter_basic(self, tmp_path):
+        script = generate_sbatch_script(
+            command="python scripts/train.py",
+            container="ghcr.io/proj/ml:latest",
+            container_runtime="shifter",
+            project_root=tmp_path,
+            output_id="trained_model",
+            universe_id="baseline",
+            resources={"cpus": 4, "memory": "16GB"},
+            scheduler_config={"account": "m1234", "partition": "gpu"},
+        )
+        assert "#!/bin/bash" in script
+        assert "#SBATCH --job-name=prism_trained_model_baseline" in script
+        assert "#SBATCH --account=m1234" in script
+        assert "#SBATCH --image=ghcr.io/proj/ml:latest" in script
+        assert "srun shifter" in script
+        assert "python scripts/train.py" in script
+        # No podman-hpc for shifter
+        assert "podman-hpc" not in script
+
+    def test_no_container(self, tmp_path):
+        script = generate_sbatch_script(
+            command="python scripts/train.py",
+            container=None,
+            container_runtime="podman-hpc",
+            project_root=tmp_path,
+            output_id="train",
+            universe_id="baseline",
+            resources={"cpus": 4},
+            scheduler_config={"account": "m1234"},
+        )
+        assert "podman-hpc" not in script
+        assert "shifter" not in script
+        assert "python scripts/train.py" in script
+
+    def test_output_and_error_files(self, tmp_path):
+        script = generate_sbatch_script(
+            command="echo hello",
+            container=None,
+            container_runtime="podman-hpc",
+            project_root=tmp_path,
+            output_id="test",
+            universe_id="baseline",
+            resources={},
+        )
+        assert "#SBATCH --output=results/.slurm/test_baseline.out" in script
+        assert "#SBATCH --error=results/.slurm/test_baseline.err" in script
+
+    def test_qos_and_constraint(self, tmp_path):
+        script = generate_sbatch_script(
+            command="echo hello",
+            container="img:1.0",
+            container_runtime="podman-hpc",
+            project_root=tmp_path,
+            output_id="test",
+            universe_id="baseline",
+            resources={},
+            scheduler_config={
+                "account": "m1234",
+                "qos": "debug",
+                "constraint": "gpu&hbm80g",
+            },
+        )
+        assert "#SBATCH --qos=debug" in script
+        assert "#SBATCH --constraint=gpu&hbm80g" in script
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_parse_sbatch_job_id(self):
+        assert _parse_sbatch_job_id("Submitted batch job 12345\n") == "12345"
+        assert _parse_sbatch_job_id("Submitted batch job 99999999") == "99999999"
+        assert _parse_sbatch_job_id("some random output") is None
+        assert _parse_sbatch_job_id("") is None
+
+    def test_shell_quote(self):
+        assert _shell_quote("hello") == "'hello'"
+        assert _shell_quote("it's") == "'it'\\''s'"
+        assert _shell_quote("echo 'hi'") == "'echo '\\''hi'\\'''"
+
+
+# ---------------------------------------------------------------------------
+# SLURM runner integration (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestSlurmRunner:
+    def test_slurm_submit_sbatch_not_found(self, tmp_path):
+        """When sbatch is not found, return exit code 127."""
         runner = ASPContainerRunner(
             project_root=str(tmp_path),
             backend="slurm",
+            target_config={
+                "scheduler": {"container_runtime": "podman-hpc", "account": "m1234"},
+            },
         )
-        with pytest.raises(NotImplementedError, match="SLURM backend"):
-            runner.execute(
-                command="test",
-                output_id="result",
-                universe_id="baseline",
-            )
+        result = runner.execute(
+            command="python train.py",
+            output_id="model",
+            universe_id="baseline",
+        )
+        assert result.exit_code == 127
+        assert "sbatch" in result.metadata.get("stderr", "")
+
+    @patch("prism.dagster.runner.subprocess.run")
+    @patch("prism.dagster.runner._poll_slurm_job")
+    def test_slurm_submit_and_poll(self, mock_poll, mock_run, tmp_path):
+        """Test the full submit + poll flow with mocked subprocess."""
+        # Mock sbatch submission
+        mock_submit = MagicMock()
+        mock_submit.returncode = 0
+        mock_submit.stdout = "Submitted batch job 12345\n"
+        mock_submit.stderr = ""
+        mock_run.return_value = mock_submit
+
+        # Mock successful poll
+        mock_poll.return_value = (0, {"slurm_state": "COMPLETED", "elapsed": "00:05:00"})
+
+        runner = ASPContainerRunner(
+            project_root=str(tmp_path),
+            backend="slurm",
+            target_config={
+                "scheduler": {
+                    "container_runtime": "podman-hpc",
+                    "account": "m1234",
+                },
+            },
+        )
+        result = runner.execute(
+            command="python train.py",
+            output_id="model",
+            universe_id="baseline",
+            container="ghcr.io/proj/ml:latest",
+        )
+
+        assert result.exit_code == 0
+        assert result.metadata["backend"] == "slurm"
+        assert result.metadata["slurm_job_id"] == "12345"
+        assert result.metadata["container_runtime"] == "podman-hpc"
+        assert result.metadata["slurm_state"] == "COMPLETED"
+
+    @patch("prism.dagster.runner.subprocess.run")
+    def test_slurm_submit_failure(self, mock_run, tmp_path):
+        """sbatch returns non-zero exit code."""
+        mock_submit = MagicMock()
+        mock_submit.returncode = 1
+        mock_submit.stdout = ""
+        mock_submit.stderr = "sbatch: error: invalid account"
+        mock_run.return_value = mock_submit
+
+        runner = ASPContainerRunner(
+            project_root=str(tmp_path),
+            backend="slurm",
+            target_config={
+                "scheduler": {"container_runtime": "shifter", "account": "m1234"},
+            },
+        )
+        result = runner.execute(
+            command="python train.py",
+            output_id="model",
+            universe_id="baseline",
+        )
+        assert result.exit_code == 1
+        assert "invalid account" in result.metadata["stderr"]
+
+    @patch("prism.dagster.runner.subprocess.run")
+    def test_slurm_creates_script_file(self, mock_run, tmp_path):
+        """Verify that sbatch script is written to results/.slurm/."""
+        mock_submit = MagicMock()
+        mock_submit.returncode = 1
+        mock_submit.stdout = ""
+        mock_submit.stderr = "error"
+        mock_run.return_value = mock_submit
+
+        runner = ASPContainerRunner(
+            project_root=str(tmp_path),
+            backend="slurm",
+            target_config={
+                "scheduler": {
+                    "container_runtime": "podman-hpc",
+                    "account": "m1234",
+                },
+            },
+        )
+        runner.execute(
+            command="python train.py",
+            output_id="model",
+            universe_id="baseline",
+            container="img:1.0",
+        )
+
+        script_path = tmp_path / "results" / ".slurm" / "model_baseline.sh"
+        assert script_path.exists()
+        content = script_path.read_text()
+        assert "#!/bin/bash" in content
+        assert "podman-hpc run" in content
+
+    @patch("prism.dagster.runner.subprocess.run")
+    def test_slurm_shifter_creates_correct_script(self, mock_run, tmp_path):
+        """Verify that shifter scripts use #SBATCH --image and srun shifter."""
+        mock_submit = MagicMock()
+        mock_submit.returncode = 1
+        mock_submit.stdout = ""
+        mock_submit.stderr = "error"
+        mock_run.return_value = mock_submit
+
+        runner = ASPContainerRunner(
+            project_root=str(tmp_path),
+            backend="slurm",
+            target_config={
+                "scheduler": {
+                    "container_runtime": "shifter",
+                    "account": "m1234",
+                },
+            },
+        )
+        runner.execute(
+            command="python scripts/eval.py",
+            output_id="accuracy",
+            universe_id="experiment1",
+            container="registry.nersc.gov/proj/analysis:v2",
+        )
+
+        script_path = tmp_path / "results" / ".slurm" / "accuracy_experiment1.sh"
+        assert script_path.exists()
+        content = script_path.read_text()
+        assert "#SBATCH --image=registry.nersc.gov/proj/analysis:v2" in content
+        assert "srun shifter" in content
+        assert "podman-hpc" not in content

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -8,6 +8,7 @@ import pytest
 
 from prism.dagster.runner import (
     ASPContainerRunner,
+    _check_sacct,
     _normalise_time_limit,
     _parse_sbatch_job_id,
     _shell_quote,
@@ -450,3 +451,79 @@ class TestSlurmRunner:
         assert "#SBATCH --image=registry.nersc.gov/proj/analysis:v2" in content
         assert "srun shifter" in content
         assert "podman-hpc" not in content
+
+    @patch("prism.dagster.runner.subprocess.run")
+    def test_slurm_forwards_universe_and_params(self, mock_run, tmp_path):
+        """Universe ID and decision params must appear in the sbatch script command."""
+        mock_submit = MagicMock()
+        mock_submit.returncode = 1  # fail fast; we only care about the script
+        mock_submit.stdout = ""
+        mock_submit.stderr = "error"
+        mock_run.return_value = mock_submit
+
+        runner = ASPContainerRunner(
+            project_root=str(tmp_path),
+            backend="slurm",
+            target_config={
+                "scheduler": {"container_runtime": "podman-hpc", "account": "m1234"},
+            },
+        )
+        runner.execute(
+            command="python scripts/train.py",
+            output_id="model",
+            universe_id="experiment1",
+            container="img:1.0",
+            params={"method": "npe", "lr": "0.001"},
+        )
+
+        script_path = tmp_path / "results" / ".slurm" / "model_experiment1.sh"
+        content = script_path.read_text()
+        assert "--universe experiment1" in content
+        assert "--method npe" in content
+        assert "--lr 0.001" in content
+
+
+# ---------------------------------------------------------------------------
+# sacct exit-code correctness
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSacct:
+    def test_completed_returns_zero(self):
+        stdout = "12345|COMPLETED|0:0|00:05:00|nid001\n"
+        with patch("prism.dagster.runner.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=stdout, stderr="")
+            exit_code, meta = _check_sacct("12345")
+        assert exit_code == 0
+        assert meta["slurm_state"] == "COMPLETED"
+
+    def test_cancelled_returns_nonzero(self):
+        """CANCELLED jobs report 0:0 in sacct but should be treated as failure."""
+        stdout = "12345|CANCELLED|0:0|00:01:00|nid001\n"
+        with patch("prism.dagster.runner.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=stdout, stderr="")
+            exit_code, meta = _check_sacct("12345")
+        assert exit_code != 0
+        assert meta["slurm_state"] == "CANCELLED"
+
+    def test_timeout_returns_nonzero(self):
+        stdout = "12345|TIMEOUT|0:0|04:00:00|nid001\n"
+        with patch("prism.dagster.runner.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=stdout, stderr="")
+            exit_code, meta = _check_sacct("12345")
+        assert exit_code != 0
+
+    def test_failed_returns_nonzero(self):
+        stdout = "12345|FAILED|1:0|00:02:00|nid001\n"
+        with patch("prism.dagster.runner.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=stdout, stderr="")
+            exit_code, meta = _check_sacct("12345")
+        assert exit_code != 0
+
+    def test_running_returns_none(self):
+        stdout = "12345|RUNNING|0:0|00:01:00|nid001\n"
+        with patch("prism.dagster.runner.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=stdout, stderr="")
+            exit_code, meta = _check_sacct("12345")
+        assert exit_code is None
+        assert meta == {}

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -298,9 +298,11 @@ class TestHelpers:
         assert _parse_sbatch_job_id("") is None
 
     def test_shell_quote(self):
-        assert _shell_quote("hello") == "'hello'"
-        assert _shell_quote("it's") == "'it'\\''s'"
-        assert _shell_quote("echo 'hi'") == "'echo '\\''hi'\\'''"
+        # Uses shlex.quote — simple strings need no quoting
+        assert _shell_quote("hello") == "hello"
+        # Strings with special chars get single-quoted
+        assert "'" in _shell_quote("it's") or "\\" in _shell_quote("it's")
+        assert _shell_quote("echo hi there") == "'echo hi there'"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,0 +1,122 @@
+"""Tests for HPC site defaults."""
+from __future__ import annotations
+
+from prism.dagster.sites import (
+    SITE_DEFAULTS,
+    detect_site,
+    get_site_defaults,
+    list_known_sites,
+)
+
+
+class TestDetectSite:
+    def test_exact_match(self):
+        assert detect_site("perlmutter") == "perlmutter"
+
+    def test_hostname_match(self):
+        assert detect_site("perlmutter.nersc.gov") == "perlmutter"
+
+    def test_partial_match(self):
+        assert detect_site("my-perlmutter-target") == "perlmutter"
+
+    def test_case_insensitive(self):
+        assert detect_site("Perlmutter") == "perlmutter"
+        assert detect_site("PERLMUTTER") == "perlmutter"
+
+    def test_cori(self):
+        assert detect_site("cori") == "cori"
+
+    def test_frontier(self):
+        assert detect_site("frontier") == "frontier"
+
+    def test_polaris(self):
+        assert detect_site("polaris") == "polaris"
+
+    def test_saul_matches_perlmutter(self):
+        """saul is an alias hostname for perlmutter."""
+        assert detect_site("saul.nersc.gov") == "perlmutter"
+
+    def test_unknown(self):
+        assert detect_site("my-cluster") is None
+
+    def test_empty(self):
+        assert detect_site("") is None
+
+
+class TestGetSiteDefaults:
+    def test_perlmutter(self):
+        site = get_site_defaults("perlmutter")
+        assert site is not None
+        assert site["backend"] == "slurm"
+        assert site["scheduler"]["container_runtime"] == "podman-hpc"
+        assert "gpu" in site["partitions"]
+        assert site["connection"]["hostname"] == "perlmutter.nersc.gov"
+
+    def test_perlmutter_gpu_partition(self):
+        site = get_site_defaults("perlmutter")
+        assert site is not None
+        gpu = site["partitions"]["gpu"]
+        assert gpu["constraint"] == "gpu"
+        assert "--gpu" in gpu["container_flags"]
+
+    def test_perlmutter_cpu_partition(self):
+        site = get_site_defaults("perlmutter")
+        assert site is not None
+        cpu = site["partitions"]["cpu"]
+        assert cpu["constraint"] == "cpu"
+        assert cpu["container_flags"] == []
+
+    def test_cori_uses_shifter(self):
+        site = get_site_defaults("cori")
+        assert site is not None
+        assert site["scheduler"]["container_runtime"] == "shifter"
+
+    def test_frontier_uses_singularity(self):
+        site = get_site_defaults("frontier")
+        assert site is not None
+        assert site["scheduler"]["container_runtime"] == "singularity"
+
+    def test_unknown(self):
+        assert get_site_defaults("nonexistent") is None
+
+
+class TestListKnownSites:
+    def test_returns_all_sites(self):
+        sites = list_known_sites()
+        keys = [s[0] for s in sites]
+        assert "perlmutter" in keys
+        assert "frontier" in keys
+        assert "polaris" in keys
+
+    def test_has_display_names(self):
+        sites = list_known_sites()
+        for key, display in sites:
+            assert len(display) > 0
+
+    def test_matches_site_defaults(self):
+        sites = list_known_sites()
+        assert len(sites) == len(SITE_DEFAULTS)
+
+
+class TestSiteDefaultsSchema:
+    """Ensure all site entries have the required fields."""
+
+    def test_all_sites_have_required_fields(self):
+        required = {"hostname_patterns", "backend", "connection", "scheduler",
+                     "partitions", "resource_limits"}
+        for key, site in SITE_DEFAULTS.items():
+            missing = required - set(site.keys())
+            assert not missing, f"Site '{key}' missing fields: {missing}"
+
+    def test_all_sites_have_container_runtime(self):
+        for key, site in SITE_DEFAULTS.items():
+            assert "container_runtime" in site["scheduler"], \
+                f"Site '{key}' missing scheduler.container_runtime"
+
+    def test_all_partitions_have_constraint(self):
+        for key, site in SITE_DEFAULTS.items():
+            for pname, pinfo in site["partitions"].items():
+                assert "constraint" in pinfo, \
+                    f"Site '{key}' partition '{pname}' missing constraint"
+                assert "container_flags" in pinfo, \
+                    f"Site '{key}' partition '{pname}' missing container_flags"


### PR DESCRIPTION
Approved design for integrating Dagster into Prism as the execution
framework. Key decisions: outputs as assets, universes as partitions,
inline recipes on outputs, Docker + SLURM backends.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>