### PR TITLE
Forward container_flags and stage external inputs via data/ convention

### DIFF
--- a/src/prism/dagster/assets.py
+++ b/src/prism/dagster/assets.py
@@ -178,7 +178,8 @@ def build_definitions(
         runner_config = {"connection": target_config.get("connection", {})}
         scheduler = {}
         for key in ("account", "qos", "constraint", "node_type",
-                     "container_runtime", "nodes", "time_limit"):
+                     "container_runtime", "container_flags",
+                     "nodes", "time_limit"):
             if target_config.get(key) is not None:
                 scheduler[key] = target_config[key]
         if scheduler:

--- a/src/prism/dagster/assets.py
+++ b/src/prism/dagster/assets.py
@@ -6,12 +6,22 @@ from pathlib import Path
 from typing import Any
 
 import dagster as dg
-from asp.helpers import get_outputs, load_yaml
+from asp.helpers import get_inputs, get_outputs, load_yaml
 
 from prism.container import resolve_container_for_slurm, resolve_container_spec
 from prism.dagster.runner import ASPContainerRunner
 
 logger = logging.getLogger(__name__)
+
+
+def get_external_inputs(spec: dict[str, Any]) -> dict[str, str]:
+    """Return {input_id: source_path} for inputs with a filesystem source."""
+    result = {}
+    for inp in get_inputs(spec):
+        source = inp.get("source")
+        if source and isinstance(source, str) and source.startswith("/"):
+            result[inp["id"]] = source
+    return result
 
 
 def _resolve_container(
@@ -42,7 +52,7 @@ def build_asset_definitions(
     project_name: str | None = None,
     no_build: bool = False,
     container_runtime: str | None = None,
-) -> list[dg.AssetsDefinition]:
+) -> list[dg.AssetsDefinition | dg.AssetSpec]:
     """Generate one @asset per output with a recipe."""
     outputs = get_outputs(spec)
 
@@ -57,7 +67,14 @@ def build_asset_definitions(
     else:
         default_container = raw_default if isinstance(raw_default, str) else None
 
-    assets: list[dg.AssetsDefinition] = []
+    # Collect external inputs (inputs with filesystem source paths)
+    external = get_external_inputs(spec)
+    asset_specs = [
+        dg.AssetSpec(inp_id, metadata={"source": source, "external": True})
+        for inp_id, source in external.items()
+    ]
+
+    assets: list[dg.AssetsDefinition | dg.AssetSpec] = list(asset_specs)
     for output_def in outputs:
         output_id = output_def.get("id")
         recipe = output_def.get("recipe")
@@ -68,6 +85,7 @@ def build_asset_definitions(
                 output_id, recipe, runner, universe_id, project_path,
                 project_name=project_name, default_container=default_container,
                 no_build=no_build, container_runtime=container_runtime,
+                external_inputs=external,
             )
         )
 
@@ -97,10 +115,15 @@ def _build_single_asset(
     default_container: str | None = None,
     no_build: bool = False,
     container_runtime: str | None = None,
+    external_inputs: dict[str, str] | None = None,
 ) -> dg.AssetsDefinition:
     """Build a single Dagster asset from an output recipe."""
     input_ids = recipe.get("inputs") or []
     command = recipe["command"]
+    # Filter external inputs to those referenced by this recipe
+    recipe_external = {
+        k: v for k, v in (external_inputs or {}).items() if k in input_ids
+    } or None
     raw_container = recipe.get("container")
     # Resolve per-recipe container spec; fall back to analysis-level default.
     if raw_container is not None and not no_build:
@@ -131,6 +154,7 @@ def _build_single_asset(
             universe_id=universe_id,
             resources=resources,
             params=params,
+            external_inputs=recipe_external,
         )
         if result.metadata.get("stdout"):
             context.log.info(result.metadata["stdout"])

--- a/src/prism/dagster/runner.py
+++ b/src/prism/dagster/runner.py
@@ -71,6 +71,7 @@ class ASPContainerRunner:
         inputs: list[str] | None = None,
         resources: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
+        external_inputs: dict[str, str] | None = None,
     ) -> ExecutionResult:
         """Execute a recipe, dispatching to the configured backend.
 
@@ -93,6 +94,7 @@ class ASPContainerRunner:
                 output_id=output_id,
                 universe_id=universe_id,
                 resources=resources or {},
+                external_inputs=external_inputs,
             )
 
         # Docker backend — try Docker first, fall back to local
@@ -216,6 +218,7 @@ class ASPContainerRunner:
         output_id: str,
         universe_id: str,
         resources: dict[str, Any],
+        external_inputs: dict[str, str] | None = None,
     ) -> ExecutionResult:
         """Execute a recipe via SLURM on a login node.
 
@@ -242,6 +245,7 @@ class ASPContainerRunner:
             resources=resources,
             scheduler_config=scheduler,
             resource_limits=resource_limits,
+            external_inputs=external_inputs,
         )
 
         # Write script to a temp file inside the project so it's on the
@@ -417,6 +421,7 @@ def generate_sbatch_script(
     resources: dict[str, Any],
     scheduler_config: dict[str, Any] | None = None,
     resource_limits: dict[str, Any] | None = None,
+    external_inputs: dict[str, str] | None = None,
 ) -> str:
     """Generate an sbatch script for a recipe execution.
 
@@ -456,9 +461,16 @@ def generate_sbatch_script(
     if container and container_runtime == "podman-hpc":
         lines.append(_podman_hpc_run_command(
             command, container, project_root, resources, scheduler_config,
+            external_inputs=external_inputs,
         ))
     else:
-        # No container — run directly
+        # No container — symlink external inputs into data/ directory
+        if external_inputs:
+            lines.append("mkdir -p data")
+            for input_id, source in sorted(external_inputs.items()):
+                lines.append(f"ln -sfn {source} data/{input_id}")
+            lines.append("")
+        # Run directly
         lines.append(command)
 
     lines.append("")
@@ -471,6 +483,7 @@ def _podman_hpc_run_command(
     project_root: Path,
     resources: dict[str, Any],
     scheduler_config: dict[str, Any],
+    external_inputs: dict[str, str] | None = None,
 ) -> str:
     """Build a podman-hpc run invocation for use inside an sbatch script.
 
@@ -503,6 +516,10 @@ def _podman_hpc_run_command(
 
     # Volume mount project root
     parts.extend(["-v", f"{project_root}:/workspace", "-w", "/workspace"])
+
+    # Read-only volume mounts for external inputs
+    for input_id, source in sorted((external_inputs or {}).items()):
+        parts.extend(["-v", f"{source}:/workspace/data/{input_id}:ro"])
 
     parts.append(container)
     parts.extend(["sh", "-c", _shell_quote(command)])

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -79,6 +79,24 @@ class TestBuildAssetDefinitions:
         defs = build_definitions(sample_asp_yaml)
         assert isinstance(defs, dg.Definitions)
 
+    def test_container_flags_forwarded_to_runner(self, sample_asp_yaml):
+        """container_flags from target config should reach the runner's scheduler config."""
+        target_config = {
+            "backend": "slurm",
+            "account": "m1234",
+            "container_runtime": "podman-hpc",
+            "container_flags": ["--scratch", "--cfs"],
+        }
+        with unittest.mock.patch(
+            "prism.dagster.assets.ASPContainerRunner",
+        ) as MockRunner:
+            build_definitions(
+                sample_asp_yaml, target_config=target_config, no_build=True,
+            )
+            call_kwargs = MockRunner.call_args[1]
+            scheduler = call_kwargs["target_config"]["scheduler"]
+            assert scheduler["container_flags"] == ["--scratch", "--cfs"]
+
     def test_build_spec_resolved_to_string(self, tmp_path, mock_runner):
         """Container build specs should be resolved to tag strings."""
         containerfile = tmp_path / "Containerfile"

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -8,7 +8,11 @@ import dagster as dg
 import pytest
 from asp.helpers import load_yaml
 
-from prism.dagster.assets import build_asset_definitions, build_definitions
+from prism.dagster.assets import (
+    build_asset_definitions,
+    build_definitions,
+    get_external_inputs,
+)
 
 
 @pytest.fixture
@@ -131,3 +135,127 @@ class TestBuildAssetDefinitions:
             container_val = meta.get("container", "")
             assert isinstance(container_val, str)
             assert "build" not in container_val  # not the raw dict
+
+
+class TestGetExternalInputs:
+    def test_extracts_filesystem_sources(self):
+        spec = {
+            "inputs": [
+                {"id": "sim_data", "type": "data", "source": "/pscratch/sd/f/francois/sim_42"},
+                {"id": "obs_data", "type": "data", "source": "/global/cfs/cdirs/m1234/obs"},
+            ],
+            "outputs": [],
+        }
+        result = get_external_inputs(spec)
+        assert result == {
+            "sim_data": "/pscratch/sd/f/francois/sim_42",
+            "obs_data": "/global/cfs/cdirs/m1234/obs",
+        }
+
+    def test_ignores_non_filesystem_sources(self):
+        spec = {
+            "inputs": [
+                {"id": "raw", "type": "data"},
+                {"id": "web", "type": "data", "source": "https://example.com/data.tar"},
+                {"id": "local", "type": "data", "source": "relative/path"},
+            ],
+            "outputs": [],
+        }
+        result = get_external_inputs(spec)
+        assert result == {}
+
+    def test_empty_inputs(self):
+        assert get_external_inputs({"inputs": [], "outputs": []}) == {}
+        assert get_external_inputs({"outputs": []}) == {}
+
+
+class TestExternalInputsAssetSpecs:
+    def test_external_inputs_become_asset_specs(self, mock_runner):
+        spec = {
+            "inputs": [
+                {"id": "sim_data", "type": "data", "source": "/pscratch/sim"},
+            ],
+            "outputs": [
+                {
+                    "id": "result",
+                    "type": "metric",
+                    "recipe": {"command": "python run.py", "inputs": ["sim_data"]},
+                },
+            ],
+        }
+        assets = build_asset_definitions(spec, runner=mock_runner)
+        # Should have 1 AssetSpec (sim_data) + 1 AssetsDefinition (result)
+        specs = [a for a in assets if isinstance(a, dg.AssetSpec)]
+        defs = [a for a in assets if isinstance(a, dg.AssetsDefinition)]
+        assert len(specs) == 1
+        assert specs[0].key.path[-1] == "sim_data"
+        assert specs[0].metadata["external"] is True
+        assert specs[0].metadata["source"] == "/pscratch/sim"
+        assert len(defs) == 1
+
+    def test_external_inputs_in_definitions(self, tmp_path):
+        asp_yaml = tmp_path / "asp.yaml"
+        asp_yaml.write_text("""
+version: "1.0"
+name: "Test"
+inputs:
+  - id: sim_data
+    type: data
+    source: /pscratch/sim
+outputs:
+  - id: result
+    type: metric
+    recipe:
+      command: python run.py
+      inputs: [sim_data]
+""")
+        defs = build_definitions(tmp_path, no_build=True)
+        assert isinstance(defs, dg.Definitions)
+
+    def test_external_inputs_passed_to_runner(self, mock_runner):
+        spec = {
+            "inputs": [
+                {"id": "sim_data", "type": "data", "source": "/pscratch/sim"},
+                {"id": "other", "type": "data"},
+            ],
+            "outputs": [
+                {
+                    "id": "result",
+                    "type": "metric",
+                    "recipe": {"command": "python run.py", "inputs": ["sim_data"]},
+                },
+            ],
+        }
+        mock_runner.execute.return_value = MagicMock(
+            exit_code=0, output_path=None, metadata={"backend": "docker"},
+        )
+        assets = build_asset_definitions(spec, runner=mock_runner)
+        # Materialize the recipe asset to trigger runner.execute
+        recipe_asset = [a for a in assets if isinstance(a, dg.AssetsDefinition)][0]
+        # Execute the inner function directly
+        context = MagicMock()
+        recipe_asset.op.compute_fn.decorated_fn(context)
+        # Check that runner.execute was called with the right external_inputs
+        call_kwargs = mock_runner.execute.call_args[1]
+        assert call_kwargs["external_inputs"] == {"sim_data": "/pscratch/sim"}
+
+    def test_no_external_inputs_passes_none(self, mock_runner):
+        spec = {
+            "inputs": [{"id": "raw", "type": "data"}],
+            "outputs": [
+                {
+                    "id": "result",
+                    "type": "metric",
+                    "recipe": {"command": "python run.py", "inputs": ["raw"]},
+                },
+            ],
+        }
+        mock_runner.execute.return_value = MagicMock(
+            exit_code=0, output_path=None, metadata={"backend": "docker"},
+        )
+        assets = build_asset_definitions(spec, runner=mock_runner)
+        recipe_asset = [a for a in assets if isinstance(a, dg.AssetsDefinition)][0]
+        context = MagicMock()
+        recipe_asset.op.compute_fn.decorated_fn(context)
+        call_kwargs = mock_runner.execute.call_args[1]
+        assert call_kwargs["external_inputs"] is None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -8,6 +8,7 @@ from prism.dagster.runner import (
     _check_sacct,
     _normalise_time_limit,
     _parse_sbatch_job_id,
+    _podman_hpc_run_command,
     _shell_quote,
     generate_sbatch_script,
     translate_resources_to_docker_flags,
@@ -553,3 +554,92 @@ class TestCheckSacct:
             exit_code, meta = _check_sacct("12345")
         assert exit_code is None
         assert meta == {}
+
+
+# ---------------------------------------------------------------------------
+# External inputs
+# ---------------------------------------------------------------------------
+
+
+class TestExternalInputs:
+    def test_podman_hpc_with_external_inputs(self, tmp_path):
+        """External inputs produce read-only volume mounts in podman-hpc command."""
+        cmd = _podman_hpc_run_command(
+            command="python scripts/analyze.py",
+            container="ghcr.io/proj/ml:latest",
+            project_root=tmp_path,
+            resources={},
+            scheduler_config={"account": "m1234"},
+            external_inputs={
+                "sim_data": "/pscratch/sd/f/francois/sim_42",
+                "obs_data": "/global/cfs/cdirs/m1234/obs",
+            },
+        )
+        assert "-v /global/cfs/cdirs/m1234/obs:/workspace/data/obs_data:ro" in cmd
+        assert "-v /pscratch/sd/f/francois/sim_42:/workspace/data/sim_data:ro" in cmd
+        # Volume mounts should come before the container image
+        img_pos = cmd.index("ghcr.io/proj/ml:latest")
+        assert cmd.index("/workspace/data/obs_data:ro") < img_pos
+        assert cmd.index("/workspace/data/sim_data:ro") < img_pos
+
+    def test_podman_hpc_no_external_inputs(self, tmp_path):
+        """No external inputs means no extra volume mounts."""
+        cmd = _podman_hpc_run_command(
+            command="python scripts/analyze.py",
+            container="ghcr.io/proj/ml:latest",
+            project_root=tmp_path,
+            resources={},
+            scheduler_config={},
+        )
+        assert "/workspace/data/" not in cmd
+
+    def test_sbatch_external_inputs_with_container(self, tmp_path):
+        """generate_sbatch_script forwards external_inputs to podman-hpc."""
+        script = generate_sbatch_script(
+            command="python scripts/analyze.py",
+            container="ghcr.io/proj/ml:latest",
+            container_runtime="podman-hpc",
+            project_root=tmp_path,
+            output_id="result",
+            universe_id="baseline",
+            resources={},
+            scheduler_config={"account": "m1234"},
+            external_inputs={"sim_data": "/pscratch/sim"},
+        )
+        assert "-v /pscratch/sim:/workspace/data/sim_data:ro" in script
+
+    def test_sbatch_external_inputs_no_container(self, tmp_path):
+        """Without container, external inputs create symlinks."""
+        script = generate_sbatch_script(
+            command="python scripts/analyze.py",
+            container=None,
+            container_runtime="podman-hpc",
+            project_root=tmp_path,
+            output_id="result",
+            universe_id="baseline",
+            resources={},
+            scheduler_config={"account": "m1234"},
+            external_inputs={
+                "sim_data": "/pscratch/sim",
+                "obs_data": "/global/cfs/obs",
+            },
+        )
+        assert "mkdir -p data" in script
+        assert "ln -sfn /global/cfs/obs data/obs_data" in script
+        assert "ln -sfn /pscratch/sim data/sim_data" in script
+        # No podman-hpc in the script
+        assert "podman-hpc" not in script
+
+    def test_sbatch_no_external_inputs_no_symlinks(self, tmp_path):
+        """Without external inputs, no symlink section appears."""
+        script = generate_sbatch_script(
+            command="python scripts/analyze.py",
+            container=None,
+            container_runtime="podman-hpc",
+            project_root=tmp_path,
+            output_id="result",
+            universe_id="baseline",
+            resources={},
+        )
+        assert "mkdir -p data" not in script
+        assert "ln -sfn" not in script

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -247,6 +247,24 @@ class TestGenerateSbatchScript:
         assert "--mpi" in script
         assert "--nccl" in script
 
+    def test_podman_hpc_with_custom_flags(self, tmp_path):
+        """Custom container_flags like --scratch pass through to podman-hpc."""
+        script = generate_sbatch_script(
+            command="python scripts/train.py",
+            container="ghcr.io/proj/ml:latest",
+            container_runtime="podman-hpc",
+            project_root=tmp_path,
+            output_id="train",
+            universe_id="baseline",
+            resources={},
+            scheduler_config={
+                "account": "m1234",
+                "container_flags": ["--scratch", "--cfs"],
+            },
+        )
+        assert "--scratch" in script
+        assert "--cfs" in script
+
     def test_no_container(self, tmp_path):
         script = generate_sbatch_script(
             command="python scripts/train.py",


### PR DESCRIPTION
## Summary

Two related improvements to the container execution pipeline:

- **Container flags forwarding** (first commit): `container_flags` from target config (e.g. `--scratch`, `--cfs`) are now correctly forwarded through to the podman-hpc runner
- **External input staging** (second commit): Inputs with a filesystem `source` in `asp.yaml` are automatically made available inside containers at `data/<input_id>/`

## External input staging

External data on shared filesystems (e.g. `/pscratch`, `/global/cfs`) can now be declared in `asp.yaml`:

```yaml
inputs:
  - id: simulation_data
    type: data
    source: /pscratch/sd/f/francois/sim_run_42

outputs:
  - id: analysis_result
    recipe:
      command: python scripts/analyze.py
      inputs: [simulation_data]
```

This generates a podman-hpc command with a read-only volume mount:

```bash
podman-hpc run --rm --gpu \
  -v /path/to/project:/workspace \
  -v /pscratch/sd/f/francois/sim_run_42:/workspace/data/simulation_data:ro \
  -w /workspace \
  ghcr.io/proj/ml:latest sh -c 'python scripts/analyze.py --universe baseline'
```

For bare (no-container) execution, symlinks are created instead:

```bash
mkdir -p data
ln -sfn /pscratch/sd/f/francois/sim_run_42 data/simulation_data
```

External inputs are also registered as Dagster `AssetSpec` entries, so they appear in the lineage graph with full provenance.

### What's NOT handled

Remote sources (`s3://`, `https://`) are intentionally not staged by Prism — recipes that need remote data handle their own downloads for now.

## Changes

- `src/prism/dagster/assets.py` — `get_external_inputs()` helper, `AssetSpec` generation, wiring through `build_asset_definitions` → `_build_single_asset` → `runner.execute()`
- `src/prism/dagster/runner.py` — `external_inputs` param threaded through `execute` → `_run_slurm` → `generate_sbatch_script` → `_podman_hpc_run_command`; volume mounts for container case, symlinks for bare case
- 12 new tests across `test_assets.py` and `test_runner.py`

All new params default to `None` — zero impact on existing callers.

## Test plan

- [x] `pytest tests/ -v` — 205 tests pass
- [x] `ruff check src/ tests/` — clean
- [ ] Manual verification on Perlmutter with a real external input path

🤖 Generated with [Claude Code](https://claude.com/claude-code)