### PR TITLE
Rename Canvas to Prism-UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Prism/
 ├── extern/ASTRA            # Symlink to ASTRA repo
 ├── src/prism/
 │   ├── __init__.py
-│   ├── cli.py              # Prism CLI (init, remote, canvas, navigator)
+│   ├── cli.py              # Prism CLI (init, remote, prism-ui, navigator)
 │   └── remote.py           # HPC/remote target config
 ├── claude/prism/            # Claude Code plugin
 │   ├── skills/             # Skills for Claude Code
@@ -47,7 +47,7 @@ mypy src/
 ## Key Conventions
 
 - Prism depends on ASTRA for all spec operations (validation, schemas, helpers)
-- The `prism` CLI handles agent/execution operations (init with scaffolding, remote, canvas)
+- The `prism` CLI handles agent/execution operations (init with scaffolding, remote, prism-ui)
 - The `astra` CLI handles spec operations (validate, info, universe, viz, schema, paper)
 - Skills are branded as `/prism-new`, `/prism-build`, `/prism-verify`
 - Target configs are stored in `~/.prism/targets/`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prism is the agentic layer for ASTRA (Agentic Schema for Transparent Research An
 - **Project scaffolding** with Claude Code integration (`prism init`)
 - **Claude Code skills** for analysis creation, insight extraction, and verification
 - **HPC/remote target management** for running on compute clusters
-- **Visual editors** (Canvas, Navigator)
+- **Visual editors** (Prism-UI, Navigator)
 
 ## Quick Start
 
@@ -44,7 +44,7 @@ prism remote setup --list
 prism remote show perlmutter
 
 # Visual editors
-prism canvas
+prism prism-ui
 prism navigator
 
 # Spec operations (via ASTRA CLI):

--- a/claude/prism/skills/prism-feedback/SKILL.md
+++ b/claude/prism/skills/prism-feedback/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: prism-feedback
+description: >
+  File a bug report from the current session. Use when something breaks:
+  /prism-feedback <description of what went wrong>
+allowed-tools: Bash(gh:*), Bash(python:*), Bash(uname:*), AskUserQuestion
+argument-hint: "<what went wrong>"
+---
+
+# /prism-feedback
+
+File a bug report against the right Lightcone repo based on the current session.
+
+Be fast. The user is in the middle of work and wants to get back to it.
+
+## Prerequisites
+
+Run `gh auth status` silently. If it fails:
+
+> GitHub CLI is not authenticated. Run `gh auth login`, then try again.
+
+Stop.
+
+---
+
+## Step 1: Description
+
+The user should have provided a description inline (e.g., `/prism-feedback pipeline dies on second output`). If they didn't, ask briefly:
+
+**What went wrong?**
+
+---
+
+## Step 2: Draft and Confirm
+
+Triage the repo from context:
+- **ASTRA** — `astra` CLI, schema validation, YAML parsing
+- **Prism** — `prism` CLI, pipeline execution, recipes, dagster, scaffolding, skills
+- **Prism-UI** — visualization, Prism-UI, VS Code extension
+
+Default to **Prism** if ambiguous.
+
+Collect versions silently:
+
+```bash
+python3 -c "import astra; print(astra.__version__)" 2>/dev/null || echo "n/a"
+python3 -c "import prism; print(prism.__version__)" 2>/dev/null || echo "n/a"
+python3 --version 2>&1
+uname -s -r
+```
+
+Show the user a single confirmation message with the target repo, title, and body. Use `AskUserQuestion` with options "File it" / "Let me edit". The issue body format:
+
+```
+## What happened
+
+[1-3 sentences combining user description + session context]
+
+## Error
+
+[Trimmed error/traceback from session, if any]
+
+## Reproduction
+
+[Brief steps from session context]
+
+## Environment
+
+- ASTRA: [version]
+- Prism: [version]
+- Python: [version]
+- OS: [os]
+```
+
+Omit sections that don't apply (e.g., no Error section if there was no traceback).
+
+---
+
+## Step 3: File
+
+```bash
+gh issue create --repo LightconeResearch/<REPO> --title "<TITLE>" --label "beta-feedback" --body "<BODY>"
+```
+
+If it fails due to the label not existing, retry without `--label`. Print the issue URL.
+
+---
+
+## Rules
+
+- **Be fast** — minimize back-and-forth, one confirmation then file
+- **Read-only** — never modify project files
+- **Trim aggressively** — only the relevant portion of errors, not full files
+- **No sensitive data** — strip absolute paths, credentials, tokens
+- **Don't editorialize** — report what happened, don't speculate on fixes

--- a/claude/prism/skills/prism-new/SKILL.md
+++ b/claude/prism/skills/prism-new/SKILL.md
@@ -79,7 +79,7 @@ Use the conversation and literature to identify decisions. Apply [decision-guide
 - Where did papers disagree or compare alternatives?
 - Where did the user express uncertainty?
 
-Write candidate decisions to astra.yaml as a batch for user review in Canvas. Keep chat output concise (summary + decision IDs), and avoid dumping full decision details in chat.
+Write candidate decisions to astra.yaml as a batch for user review in Prism-UI. Keep chat output concise (summary + decision IDs), and avoid dumping full decision details in chat.
 
 **Probe for blind spots** -- analysts over-focus on methods and neglect data handling. Probe 1-3 areas: data exclusion, variable operationalization, inference criteria.
 
@@ -175,5 +175,5 @@ You MUST spawn subagents (via Task) for paper processing. One paper per subagent
 - **Too many papers** -- ~2 papers per topic area, max 10 per section; do not try to be exhaustive
 - **Background interruptions** -- Never spawn search or extraction subagents during conversation. Collect candidates in Mode 1, process them in Mode 2
 - **Reading PDFs in main context** -- Always delegate to subagents; PDFs consume too much context
-- **Chat dump of decisions** -- Do not dump full candidate decision content in chat; write decisions to astra.yaml and use Canvas for detailed review
+- **Chat dump of decisions** -- Do not dump full candidate decision content in chat; write decisions to astra.yaml and use Prism-UI for detailed review
 - **Skipping verification** -- If quotes were extracted, always run `astra validate --verify-evidence`


### PR DESCRIPTION
## Summary
- Rename all references to "Canvas" (the product) to "Prism-UI" across documentation and skill files
- Updates README.md, CLAUDE.md, prism-new/SKILL.md, and prism-feedback/SKILL.md
- Includes CLI command reference (`prism canvas` -> `prism prism-ui`)

## Test plan
- [ ] Verify no remaining "Canvas" or "canvas" references in the repo (confirmed via grep)
- [ ] Confirm CLI command `prism prism-ui` works if the CLI entrypoint has been updated separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)