### PR TITLE
Fix CI badge and secret reference

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Configure git credentials for private ASTRA repo
-        run: git config --global url."https://x-access-token:${{ secrets.ASTRA_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ secrets.ASP_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install dependencies
         run: pip install -e ".[dev]"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prism
 
-[![CI](https://github.com/LightconeResearch/Prism/actions/workflows/ci.yml/badge.svg)](https://github.com/LightconeResearch/Prism/actions/workflows/ci.yml)
+[![Tests](https://github.com/LightconeResearch/Prism/actions/workflows/tests.yml/badge.svg)](https://github.com/LightconeResearch/Prism/actions/workflows/tests.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
## Summary
- Fix badge URL: `ci.yml` → `tests.yml` (actual workflow filename)
- Fix secret reference: `ASTRA_TOKEN` → `ASP_TOKEN` (actual secret name in repo)

## Test plan
- [ ] CI passes after merge
- [ ] Badge renders on README

🤖 Generated with [Claude Code](https://claude.com/claude-code)