### PR TITLE
Fix prism run failing with external input assets

### DIFF
--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -795,12 +795,15 @@ def run(
 
     import dagster as dg
 
-    # Select assets to materialize
+    # Select assets to materialize (exclude external/input-only assets)
     all_assets = list(defs.get_all_asset_specs())
     if outputs:
         selection = list(outputs)
     else:
-        selection = [spec.key.path[-1] for spec in all_assets]
+        selection = [
+            spec.key.path[-1] for spec in all_assets
+            if not (spec.metadata or {}).get('external', False)
+        ]
 
     # Use a persistent DagsterInstance so run history is recorded for the
     # Dagster webserver (prism dev) to display.


### PR DESCRIPTION
## Summary

- `prism run` (without explicit output args) was including external input assets in the Dagster materialization selection
- External assets have no compute function, so Dagster fails with `Failed to resolve asset job __ephemeral_asset_job__`
- Filter out assets with the `external` metadata flag so only executable outputs are selected

## Reproduction

Any `astra.yaml` with `inputs:` entries will trigger this when running `prism run` or `prism run --universe <name>`.

## Test plan

- [ ] `prism run --universe <name>` succeeds on a project with external inputs
- [ ] `prism run <specific_output>` still works (explicit selection path unchanged)
- [ ] `prism run` without args on a project with no inputs still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)