### PR TITLE
Fix remaining review issues: rm permission, universe validation, completion ordering

### DIFF
--- a/claude/prism/skills/prism-build/SKILL.md
+++ b/claude/prism/skills/prism-build/SKILL.md
@@ -3,7 +3,7 @@ name: prism-build
 description: >
   Build an ASTRA analysis from spec to materialized results. Plans interactively,
   then loops autonomously via ralph-wiggum until all outputs are verified.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash(astra:*), Bash(prism:*), Bash(python:*), Bash(git:*), Bash(pip:*), Bash(mkdir:*), Bash(setup-prism-build:*), Agent, AskUserQuestion
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(astra:*), Bash(prism:*), Bash(python:*), Bash(git:*), Bash(pip:*), Bash(mkdir:*), Bash(rm:*), Bash(setup-prism-build:*), Agent, AskUserQuestion
 argument-hint: "[--universe NAME] [--max-iterations N]"
 ---
 

--- a/claude/prism/skills/prism-build/assets/loop-prompt.md
+++ b/claude/prism/skills/prism-build/assets/loop-prompt.md
@@ -41,7 +41,7 @@ All outputs are materialized. Time to verify.
    Report all findings with file paths and line numbers. If all checks pass, end your report with exactly: VERIFIED"
    ```
 4. **If sub-agent reports issues:** fix them, commit. Exit (loop continues).
-5. **If sub-agent says VERIFIED:** Clean up the build plan (`rm plans/build-plan-{{UNIVERSE}}.md`), then output exactly: `<promise>BUILD_COMPLETE</promise>`
+5. **If sub-agent says VERIFIED:** Output exactly: `<promise>BUILD_COMPLETE</promise>`, then clean up the build plan (`rm plans/build-plan-{{UNIVERSE}}.md`).
 
 ## Reference: How Work Gets Done
 

--- a/claude/prism/skills/prism-build/scripts/setup-prism-build.sh
+++ b/claude/prism/skills/prism-build/scripts/setup-prism-build.sh
@@ -35,6 +35,13 @@ if [[ -z "$MODE" ]]; then
     exit 1
 fi
 
+# Validate universe name — must be safe for sed substitution and file paths
+if [[ ! "$UNIVERSE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    echo "Error: Universe name must contain only letters, numbers, underscores, and hyphens." >&2
+    echo "Got: '${UNIVERSE}'" >&2
+    exit 1
+fi
+
 # ─── Validate mode ───────────────────────────────────────────────────
 
 if [[ "$MODE" == "validate" ]]; then


### PR DESCRIPTION
- Add Bash(rm:*) to allowed-tools so loop can autonomously clean up state and plan files without user approval
- Validate universe name against [a-zA-Z0-9_-]+ to prevent sed injection in template substitution
- Reverse BUILD_COMPLETE/plan-deletion ordering so a crash mid-cleanup doesn't lose both the plan and the completion signal