### PR TITLE
Add prism update command and startup update check

### DIFF
--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -82,7 +82,7 @@ def _get_plugin_source_dir() -> Path | None:
 def main(ctx: click.Context) -> None:
     """Prism - ASTRA-compliant Agentic Layer CLI."""
     ctx.ensure_object(dict)
-    if ctx.invoked_subcommand in ("setup", "target"):
+    if ctx.invoked_subcommand in ("setup", "target", "update"):
         return
     from prism.dagster.targets import get_config_path
     if not get_config_path().exists():
@@ -93,6 +93,16 @@ def main(ctx: click.Context) -> None:
             "  Prism needs a default target configured before you can use it.\n"
         )
         ctx.invoke(setup)
+        return
+
+    # Check for updates (cached, non-blocking)
+    try:
+        from prism.updater import check_for_updates
+        msg = check_for_updates()
+        if msg:
+            console.print(f"\n  [yellow]↑[/yellow] {msg}\n")
+    except Exception:
+        pass  # Never let update checks break normal usage
 
 
 # =============================================================================
@@ -1743,6 +1753,75 @@ def setup(
         _run_setup_menu()
     else:
         _run_setup_wizard()
+
+
+# =============================================================================
+# Update command
+# =============================================================================
+
+
+@main.command()
+@click.option("--check", is_flag=True, help="Only check for updates, don't install them")
+def update(check: bool) -> None:
+    """Update Lightcone packages to the latest version.
+
+    Pulls the latest code from all Lightcone repositories and
+    reinstalls Python packages.
+
+    Examples:
+        prism update          # pull & reinstall everything
+        prism update --check  # just check what's available
+    """
+    from prism.updater import _get_lightcone_root, check_for_updates, pull_repos, reinstall_packages
+
+    root = _get_lightcone_root()
+    if root is None:
+        console.print(
+            "[red]Error:[/red] Could not find Lightcone install directory.\n"
+            "  Expected repos as siblings of the Prism repo."
+        )
+        raise SystemExit(1)
+
+    if check:
+        console.print("[bold]Checking for updates...[/bold]\n")
+        msg = check_for_updates(quiet_if_current=False)
+        if msg:
+            console.print(f"  {msg}")
+        else:
+            console.print("  [green]Everything is up to date.[/green]")
+        return
+
+    console.print(f"[bold]Updating from:[/bold] {root}\n")
+
+    # Pull repos
+    results = pull_repos(root)
+    for name, success, message in results:
+        icon = "[green]✓[/green]" if success else "[red]✗[/red]"
+        console.print(f"  {icon} {name}: {message}")
+
+    any_failed = any(not s for _, s, _ in results)
+    any_updated = any(s and "updated" in m for _, s, m in results)
+
+    # Reinstall packages
+    if any_updated or not any_failed:
+        console.print("\n[bold]Reinstalling packages...[/bold]\n")
+        pkg_results = reinstall_packages(root)
+        for name, success, message in pkg_results:
+            icon = "[green]✓[/green]" if success else "[red]✗[/red]"
+            console.print(f"  {icon} {name}: {message}")
+        if any(not s for _, s, _ in pkg_results):
+            any_failed = True
+
+    # Clear the update-check cache so the nag goes away
+    from prism.updater import _CHECK_FILE
+    if _CHECK_FILE.exists():
+        _CHECK_FILE.unlink(missing_ok=True)
+
+    if any_failed:
+        console.print("\n[yellow]Some updates failed — see errors above.[/yellow]")
+        raise SystemExit(1)
+    else:
+        console.print("\n[green bold]All packages updated successfully.[/green bold]")
 
 
 if __name__ == "__main__":

--- a/src/prism/updater.py
+++ b/src/prism/updater.py
@@ -1,0 +1,148 @@
+"""Self-update and version-check utilities for Prism."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Repos that the installer manages (relative to the lightcone root)
+_PYTHON_REPOS = ["ASTRA", "Prism"]
+_ALL_REPOS = ["ASTRA", "Prism", "Prism-UI"]
+
+_CHECK_FILE = Path.home() / ".prism" / ".update_check"
+_CHECK_INTERVAL = 86400  # 24 hours
+
+
+def _get_lightcone_root() -> Path | None:
+    """Discover the lightcone install root from Prism's editable-install location."""
+    import prism
+
+    # prism.__file__ is .../Prism/src/prism/__init__.py
+    prism_repo = Path(prism.__file__).resolve().parent.parent.parent
+    if not (prism_repo / "pyproject.toml").exists():
+        return None
+    # The lightcone root is one level above the repo dir
+    root = prism_repo.parent
+    # Sanity check: at least one sibling repo should exist
+    if (root / "ASTRA").is_dir() or (root / "Prism-UI").is_dir():
+        return root
+    return None
+
+
+def _git(repo_dir: Path, *args: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_dir), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def pull_repos(root: Path) -> list[tuple[str, bool, str]]:
+    """Pull all repos. Returns list of (name, success, message)."""
+    results: list[tuple[str, bool, str]] = []
+    for repo_name in _ALL_REPOS:
+        repo_dir = root / repo_name
+        if not (repo_dir / ".git").is_dir():
+            results.append((repo_name, False, "not found, skipping"))
+            continue
+        # Fetch first
+        fetch = _git(repo_dir, "fetch", "--quiet")
+        if fetch.returncode != 0:
+            results.append((repo_name, False, f"fetch failed: {fetch.stderr.strip()}"))
+            continue
+        # Check if behind
+        status = _git(repo_dir, "rev-list", "--count", "HEAD..@{u}")
+        if status.returncode != 0:
+            # No upstream tracking branch
+            results.append((repo_name, True, "no upstream, skipped"))
+            continue
+        behind = int(status.stdout.strip() or "0")
+        if behind == 0:
+            results.append((repo_name, True, "already up to date"))
+            continue
+        # Pull
+        pull = _git(repo_dir, "pull", "--ff-only", "--quiet")
+        if pull.returncode != 0:
+            results.append((
+                repo_name, False,
+                f"pull failed (local changes?): {pull.stderr.strip()}"
+            ))
+        else:
+            results.append((repo_name, True, f"updated ({behind} new commit{'s' if behind != 1 else ''})"))
+    return results
+
+
+def reinstall_packages(root: Path) -> list[tuple[str, bool, str]]:
+    """Re-install Python packages in editable mode."""
+    results: list[tuple[str, bool, str]] = []
+    pip = sys.executable
+    for repo_name in _PYTHON_REPOS:
+        repo_dir = root / repo_name
+        if not (repo_dir / "pyproject.toml").exists():
+            continue
+        proc = subprocess.run(
+            [pip, "-m", "pip", "install", "--quiet", "--disable-pip-version-check", "-e", str(repo_dir)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if proc.returncode == 0:
+            results.append((repo_name, True, "installed"))
+        else:
+            results.append((repo_name, False, proc.stderr.strip()[:200]))
+    return results
+
+
+def check_for_updates(quiet_if_current: bool = True) -> str | None:
+    """Check if any repos are behind their remote. Returns a message or None.
+
+    Uses a cache file to avoid hitting the network on every invocation.
+    Only checks once per _CHECK_INTERVAL seconds.
+    """
+    # Check cache
+    if _CHECK_FILE.exists():
+        try:
+            data = json.loads(_CHECK_FILE.read_text())
+            last_check = data.get("timestamp", 0)
+            if time.time() - last_check < _CHECK_INTERVAL:
+                # Return cached message if any
+                return data.get("message")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    root = _get_lightcone_root()
+    if root is None:
+        return None
+
+    behind_repos: list[str] = []
+    for repo_name in _ALL_REPOS:
+        repo_dir = root / repo_name
+        if not (repo_dir / ".git").is_dir():
+            continue
+        try:
+            fetch = _git(repo_dir, "fetch", "--quiet", timeout=10)
+            if fetch.returncode != 0:
+                continue
+            status = _git(repo_dir, "rev-list", "--count", "HEAD..@{u}", timeout=5)
+            if status.returncode != 0:
+                continue
+            behind = int(status.stdout.strip() or "0")
+            if behind > 0:
+                behind_repos.append(repo_name)
+        except (subprocess.TimeoutExpired, ValueError):
+            continue
+
+    message: str | None = None
+    if behind_repos:
+        names = ", ".join(behind_repos)
+        message = f"Updates available for: {names}. Run: [cyan]prism update[/cyan]"
+
+    # Cache result
+    _CHECK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _CHECK_FILE.write_text(json.dumps({"timestamp": time.time(), "message": message}))
+
+    return message


### PR DESCRIPTION
## Summary
- Adds `prism update` command that pulls all Lightcone repos and reinstalls Python packages
- Adds a startup version check (cached daily) that prints a one-liner when updates are available
- `prism update --check` to see what's available without installing

## How it works
- Discovers the Lightcone install root from Prism's editable-install location
- Fetches + fast-forward pulls ASTRA, Prism, and Prism-UI
- Re-runs `pip install -e` for Python packages
- Caches update-check results for 24h so there's no startup latency

## Test plan
- [x] `prism update` pulls and reinstalls successfully
- [x] `prism update --check` shows status correctly
- [x] Startup nag appears when repos are behind, disappears when current
- [x] `prism --help` lists the new `update` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- dco-signed-off-by -->
Signed-off-by: lhparker1 <liamholdenparker@gmail.com>