### PR TITLE
Add DataStore + fsspec staging for portable input resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,11 @@ src/prism/
 ├── container.py         # Content-addressed container builds (Docker, podman-hpc)
 └── dagster/
     ├── assets.py        # Asset factory — turns astra.yaml recipes into Dagster assets
+    ├── data_store.py    # DataStore — resolves input sources (local, remote) to local paths
     ├── io_manager.py    # Maps (output, universe) → results/{universe}/{output}/
     ├── runner.py         # Execution backends: Docker, local, SLURM
     ├── site_registry.py # Known HPC site defaults (Perlmutter, etc.)
+    ├── staging.py       # fsspec-based staging — fetches remote data to local cache
     ├── status.py        # Materialization status queries
     └── targets.py       # Target config management (~/.prism/targets/)
 
@@ -49,10 +51,12 @@ mypy src/
 astra.yaml → build_definitions() → Dagster assets → ASTRAContainerRunner → results/{universe}/{output}/
                                          ↑                    ↑
                                     ASTRAIOManager        Docker / local / SLURM
+                                    DataStore (stage gate)
 ```
 
 - `build_definitions()` (assets.py) loads astra.yaml, creates one Dagster asset per output with a recipe
 - Asset dependencies come from `recipe.inputs` — Dagster resolves execution order
+- `DataStore` (data_store.py) resolves input sources to local paths before execution — local paths pass through, remote URIs (HTTP, S3, SSH, etc.) are staged to `~/.prism/cache/` via fsspec
 - `ASTRAContainerRunner` (runner.py) dispatches to Docker, local subprocess, or SLURM based on target config
 - Docker backend falls back to local execution on failure (with warning)
 - SLURM backend generates sbatch scripts, submits via `sbatch`, polls via `sacct`/`squeue`
@@ -65,6 +69,9 @@ astra.yaml → build_definitions() → Dagster assets → ASTRAContainerRunner �
 - Container image tags are deterministic: SHA256(Containerfile + dependency files) → `prism-{name}-{hash}`
 - Universe decision parameters are injected as CLI args: `--key value` passed to recipe commands
 - Per-recipe container specs override analysis-level defaults
+- Input sources can be local paths, relative paths, or remote URIs — DataStore resolves all to local paths before execution
+- Checksums in `astra.yaml` are verified on resolve (warning on mismatch, not failure)
+- Remote data is cached in `~/.prism/cache/` keyed by checksum (content-addressed) or URI hash
 
 **Config resolution (used everywhere):**
 - Target: `--target` flag > `prism.yaml` > `~/.prism/config.yaml` > `"local"`
@@ -93,6 +100,7 @@ All commands use Click. Key patterns:
 | Add an HPC site | `site_registry.py` | Add to `SITE_DEFAULTS` dict with hostname_patterns, node_types, qos_options |
 | Add an execution backend | `runner.py` | Add `_run_{backend}()` method, update `execute()` dispatch |
 | Add container features | `container.py` | `DEPENDENCY_FILES` tuple, `compute_image_tag()`, build/resolve functions |
+| Add a data source protocol | `staging.py` | Add fsspec-compatible filesystem; DataStore handles dispatch via `upath.UPath` |
 | Create a skill | `claude/prism/skills/` | SKILL.md with YAML frontmatter (`name`, `description`, `allowed-tools`) |
 | Add a telemetry hook | `claude/prism/hooks/` | Follow `langfuse_hook.py` pattern: read JSON payload, emit to Langfuse |
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,29 @@ The agent can search for papers, download PDFs by DOI, and extract insights with
 
 Complex analyses can be decomposed into nested stages, each with their own inputs, outputs, decisions, and recipes. Sub-analyses use the same schema as the top level, and can reference each other's outputs.
 
+### Data staging
+
+Input data can come from anywhere — local paths, relative paths, or remote URIs. Prism resolves all sources to local filesystem paths before execution, so recipes always see the same local paths regardless of where the data lives.
+
+```yaml
+inputs:
+  - id: sim_catalog
+    type: data
+    source: https://zenodo.org/records/12345/files/catalog.hdf5
+    checksum:
+      algorithm: sha256
+      value: a1b2c3d4e5f6...
+```
+
+Supported sources:
+- **Local/shared filesystem**: `/pscratch/sd/f/francois/data` (absolute) or `./data/input.fits` (relative to project)
+- **HTTP/HTTPS**: `https://example.com/data.tar` (built into fsspec)
+- **S3**: `s3://bucket/key` (install with `pip install 'prism[s3]'`)
+- **SSH/SFTP**: `ssh://host/path` (install with `pip install 'prism[ssh]'`)
+- **GCS**: `gs://bucket/key` (install with `pip install 'prism[gcs]'`)
+
+Remote data is cached locally in `~/.prism/cache/` and content-addressed by checksum when available. Checksums declared in `astra.yaml` are verified on download.
+
 ### Execution backends
 
 Recipes run via Docker, local subprocess, or SLURM batch submission depending on your target configuration. Recipe dependencies are resolved automatically — if output B depends on output A, A runs first. Per-recipe resource requests (CPUs, GPUs, memory, time limit) are translated to the appropriate backend flags.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,14 @@ dependencies = [
     "dagster-webserver>=1.9",
     "dagster-docker>=0.25",
     "langfuse>=2.0",
+    "fsspec>=2024.1",
+    "universal-pathlib>=0.2",
 ]
 
 [project.optional-dependencies]
+ssh = ["sshfs>=2024.1"]
+s3 = ["s3fs>=2024.1"]
+gcs = ["gcsfs>=2024.1"]
 dev = [
     "pytest>=8.0",
     "pytest-cov",

--- a/src/prism/dagster/assets.py
+++ b/src/prism/dagster/assets.py
@@ -9,13 +9,26 @@ import dagster as dg
 from astra.helpers import get_inputs, get_outputs, load_yaml
 
 from prism.container import resolve_container_for_slurm, resolve_container_spec
+from prism.dagster.data_store import DataStore
 from prism.dagster.runner import ASTRAContainerRunner
 
 logger = logging.getLogger(__name__)
 
 
-def get_external_inputs(spec: dict[str, Any]) -> dict[str, str]:
-    """Return {input_id: source_path} for inputs with a filesystem source."""
+def get_external_inputs(
+    spec: dict[str, Any],
+    data_store: DataStore | None = None,
+    universe_id: str = "baseline",
+) -> dict[str, str]:
+    """Return {input_id: source_path} for inputs with a source.
+
+    When *data_store* is provided, resolves all source types (local paths,
+    relative paths, remote URIs) via the DataStore.  Without a DataStore,
+    preserves backward-compatible behavior: only absolute paths.
+    """
+    if data_store:
+        return data_store.resolve_external_inputs(spec, universe_id)
+    # Backward compat: only absolute paths
     result = {}
     for inp in get_inputs(spec):
         source = inp.get("source")
@@ -52,6 +65,7 @@ def build_asset_definitions(
     project_name: str | None = None,
     no_build: bool = False,
     container_runtime: str | None = None,
+    data_store: DataStore | None = None,
 ) -> list[dg.AssetsDefinition | dg.AssetSpec]:
     """Generate one @asset per output with a recipe."""
     outputs = get_outputs(spec)
@@ -68,7 +82,7 @@ def build_asset_definitions(
         default_container = raw_default if isinstance(raw_default, str) else None
 
     # Collect external inputs (inputs with filesystem source paths)
-    external = get_external_inputs(spec)
+    external = get_external_inputs(spec, data_store=data_store, universe_id=universe_id)
     asset_specs = [
         dg.AssetSpec(inp_id, metadata={"source": source, "external": True})
         for inp_id, source in external.items()
@@ -235,10 +249,18 @@ def build_definitions(
             default_container=default_container,
         )
 
+    # Create DataStore for input resolution
+    cache_dir: Path | None = None
+    if target_config:
+        data_config = target_config.get("data", {})
+        if isinstance(data_config, dict) and data_config.get("cache_dir"):
+            cache_dir = Path(data_config["cache_dir"])
+    data_store = DataStore(project_root=project_path, cache_dir=cache_dir)
+
     assets = build_asset_definitions(
         spec, runner=runner, universe_id=universe_id, project_path=project_path,
         project_name=project_name, no_build=no_build,
-        container_runtime=container_runtime,
+        container_runtime=container_runtime, data_store=data_store,
     )
 
     return dg.Definitions(assets=assets)

--- a/src/prism/dagster/data_store.py
+++ b/src/prism/dagster/data_store.py
@@ -1,0 +1,135 @@
+"""DataStore — resolves ASTRA input definitions to local filesystem paths."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from astra.helpers import get_inputs
+
+from prism.dagster.staging import (
+    _is_local,
+    _resolve_local,
+    stage_uri,
+    verify_checksum,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ResolvedInput:
+    """A resolved input with its local path and provenance metadata."""
+
+    input_id: str
+    local_path: Path
+    source_uri: str
+    checksum: dict[str, str] | None
+    verified: bool
+    staged: bool
+
+
+class DataStore:
+    """Resolves ASTRA input sources to local filesystem paths.
+
+    Handles local absolute paths, relative paths, and remote URIs.
+    Remote data is staged to a local cache directory via fsspec.
+    """
+
+    def __init__(
+        self,
+        project_root: Path,
+        cache_dir: Path | None = None,
+    ) -> None:
+        self.project_root = project_root
+        self.cache_dir = cache_dir or Path.home() / ".prism" / "cache"
+
+    def resolve_input(
+        self,
+        input_def: dict[str, Any],
+        universe_id: str,
+    ) -> ResolvedInput:
+        """Resolve a single input definition to a local path.
+
+        Parameters
+        ----------
+        input_def:
+            An input dict from ``astra.yaml`` (must have ``"id"``; may have
+            ``"source"`` and ``"checksum"``).
+        universe_id:
+            The universe being materialized (used for internal inputs).
+
+        Returns
+        -------
+        ResolvedInput
+            Resolved input with a local filesystem path.
+        """
+        source = input_def.get("source")
+        input_id: str = input_def["id"]
+        checksum = input_def.get("checksum")
+
+        if not source:
+            # Internal input — sibling output
+            local_path = self.project_root / "results" / universe_id / input_id
+            return ResolvedInput(
+                input_id=input_id,
+                local_path=local_path,
+                source_uri=f"results://{universe_id}/{input_id}",
+                checksum=None,
+                verified=False,
+                staged=False,
+            )
+
+        if _is_local(source):
+            local_path = _resolve_local(source, self.project_root)
+            if not local_path.exists():
+                logger.warning(
+                    "Input '%s' source not found: %s (from source: %s). "
+                    "It may appear before execution.",
+                    input_id, local_path, source,
+                )
+            verified = (
+                verify_checksum(local_path, checksum)
+                if checksum and local_path.exists()
+                else False
+            )
+            return ResolvedInput(
+                input_id=input_id,
+                local_path=local_path,
+                source_uri=source,
+                checksum=checksum,
+                verified=verified,
+                staged=False,
+            )
+
+        # Remote source — stage via fsspec
+        local_path = stage_uri(source, self.cache_dir, checksum=checksum)
+        verified = verify_checksum(local_path, checksum) if checksum else False
+        return ResolvedInput(
+            input_id=input_id,
+            local_path=local_path,
+            source_uri=source,
+            checksum=checksum,
+            verified=verified,
+            staged=True,
+        )
+
+    def resolve_external_inputs(
+        self,
+        spec: dict[str, Any],
+        universe_id: str,
+    ) -> dict[str, str]:
+        """Resolve all inputs with sources to ``{input_id: local_path_str}``.
+
+        Drop-in replacement for ``get_external_inputs()`` — returns the same
+        dict shape but supports any URI, not just absolute paths.
+        """
+        result: dict[str, str] = {}
+        for inp in get_inputs(spec):
+            source = inp.get("source")
+            if not source:
+                continue
+            resolved = self.resolve_input(inp, universe_id)
+            result[resolved.input_id] = str(resolved.local_path)
+        return result

--- a/src/prism/dagster/staging.py
+++ b/src/prism/dagster/staging.py
@@ -1,0 +1,126 @@
+"""fsspec-based staging — fetches remote data to a local cache directory."""
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _is_local(source: str) -> bool:
+    """Check if source is a local/shared filesystem reference."""
+    return source.startswith("/") or source.startswith("./") or source.startswith("../")
+
+
+def _resolve_local(source: str, project_root: Path) -> Path:
+    """Resolve a local source to an absolute Path."""
+    if source.startswith("/"):
+        return Path(source)
+    return (project_root / source).resolve()
+
+
+def _cache_key(uri: str, checksum: dict[str, str] | None) -> str:
+    """Compute a deterministic cache key for a URI.
+
+    If a checksum is provided, uses the checksum value directly (content-addressed).
+    Otherwise, hashes the URI itself.
+    """
+    if checksum and checksum.get("value"):
+        return f"{checksum['algorithm']}-{checksum['value']}"
+    return "uri-" + hashlib.sha256(uri.encode()).hexdigest()
+
+
+def stage_uri(uri: str, cache_dir: Path, checksum: dict[str, str] | None = None) -> Path:
+    """Stage remote data to a local cache directory.
+
+    If a cached copy exists with a matching cache key, returns the cached path
+    without re-downloading.  Otherwise fetches via ``upath.UPath`` and stores
+    in the cache.
+
+    Parameters
+    ----------
+    uri:
+        Remote URI (``https://``, ``s3://``, ``ssh://``, etc.).
+    cache_dir:
+        Local directory for cached files.
+    checksum:
+        Optional ``{"algorithm": "sha256", "value": "..."}`` dict.  When
+        provided the checksum value is used as the cache key and the cached
+        file is verified after download.
+
+    Returns
+    -------
+    Path
+        Local filesystem path to the staged data.
+    """
+    key = _cache_key(uri, checksum)
+    cached_path = cache_dir / key
+
+    if cached_path.exists():
+        logger.debug("Cache hit for %s → %s", uri, cached_path)
+        return cached_path
+
+    try:
+        from upath import UPath
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            f"universal-pathlib is required to stage remote URIs ({uri}). "
+            "Install it with: pip install 'prism[remote]' or pip install universal-pathlib"
+        ) from exc
+
+    logger.info("Staging %s → %s", uri, cached_path)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    remote = UPath(uri)
+    if remote.is_dir():
+        cached_path.mkdir(parents=True, exist_ok=True)
+        for item in remote.rglob("*"):
+            if item.is_file():
+                rel = item.relative_to(remote)
+                dest = cached_path / str(rel)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(item.read_bytes())
+    else:
+        cached_path.write_bytes(remote.read_bytes())
+
+    return cached_path
+
+
+def verify_checksum(path: Path, checksum: dict[str, str]) -> bool:
+    """Verify a file's checksum.
+
+    Parameters
+    ----------
+    path:
+        Local file path to verify.
+    checksum:
+        ``{"algorithm": "sha256", "value": "abcdef..."}`` dict.
+
+    Returns
+    -------
+    bool
+        ``True`` if the checksum matches, ``False`` otherwise.
+    """
+    algorithm = checksum.get("algorithm", "sha256")
+    expected = checksum.get("value", "")
+    if not expected:
+        return False
+
+    h = hashlib.new(algorithm)
+    if path.is_dir():
+        # Hash all files in sorted order for directory checksums
+        for fpath in sorted(path.rglob("*")):
+            if fpath.is_file():
+                h.update(fpath.read_bytes())
+    else:
+        h.update(path.read_bytes())
+
+    actual = h.hexdigest()
+    if actual != expected:
+        logger.warning(
+            "Checksum mismatch for %s: expected %s=%s, got %s",
+            path, algorithm, expected, actual,
+        )
+        return False
+    return True

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -1,0 +1,186 @@
+"""Tests for DataStore input resolution."""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from prism.dagster.data_store import DataStore
+
+
+@pytest.fixture
+def project(tmp_path):
+    """Create a minimal project structure."""
+    (tmp_path / "results" / "baseline").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def store(project):
+    """DataStore with a cache dir in tmp_path."""
+    cache = project / ".cache"
+    return DataStore(project_root=project, cache_dir=cache)
+
+
+class TestResolveInputLocal:
+    def test_absolute_path(self, store, tmp_path):
+        """Absolute paths resolve directly (backward compat)."""
+        data_file = tmp_path / "external" / "catalog.hdf5"
+        data_file.parent.mkdir(parents=True)
+        data_file.write_bytes(b"catalog data")
+
+        result = store.resolve_input(
+            {"id": "sim_data", "source": str(data_file)},
+            universe_id="baseline",
+        )
+        assert result.input_id == "sim_data"
+        assert result.local_path == data_file
+        assert result.staged is False
+        assert result.source_uri == str(data_file)
+
+    def test_relative_path(self, store, project):
+        """Relative paths resolve to project root."""
+        data_file = project / "data" / "input.fits"
+        data_file.parent.mkdir(parents=True)
+        data_file.write_bytes(b"fits data")
+
+        result = store.resolve_input(
+            {"id": "obs", "source": "./data/input.fits"},
+            universe_id="baseline",
+        )
+        assert result.local_path == data_file.resolve()
+        assert result.staged is False
+
+    def test_missing_local_source_warns(self, store):
+        """Missing local file should warn but still resolve."""
+        result = store.resolve_input(
+            {"id": "missing", "source": "/nonexistent/path"},
+            universe_id="baseline",
+        )
+        assert result.local_path == Path("/nonexistent/path")
+        assert result.staged is False
+        assert result.verified is False
+
+    def test_internal_input(self, store, project):
+        """Inputs without a source are internal (sibling outputs)."""
+        result = store.resolve_input(
+            {"id": "cleaned", "type": "data"},
+            universe_id="baseline",
+        )
+        assert result.local_path == project / "results" / "baseline" / "cleaned"
+        assert result.staged is False
+        assert result.source_uri == "results://baseline/cleaned"
+
+
+class TestResolveInputChecksum:
+    def test_checksum_verified_on_match(self, store, tmp_path):
+        data = b"verified data"
+        data_file = tmp_path / "ext" / "verified.dat"
+        data_file.parent.mkdir(parents=True)
+        data_file.write_bytes(data)
+        sha = hashlib.sha256(data).hexdigest()
+
+        result = store.resolve_input(
+            {
+                "id": "verified",
+                "source": str(data_file),
+                "checksum": {"algorithm": "sha256", "value": sha},
+            },
+            universe_id="baseline",
+        )
+        assert result.verified is True
+
+    def test_checksum_mismatch_warns(self, store, tmp_path):
+        data_file = tmp_path / "ext" / "bad.dat"
+        data_file.parent.mkdir(parents=True)
+        data_file.write_bytes(b"data")
+
+        result = store.resolve_input(
+            {
+                "id": "bad",
+                "source": str(data_file),
+                "checksum": {"algorithm": "sha256", "value": "00000bad"},
+            },
+            universe_id="baseline",
+        )
+        assert result.verified is False
+
+    def test_no_checksum_not_verified(self, store, tmp_path):
+        data_file = tmp_path / "ext" / "data.dat"
+        data_file.parent.mkdir(parents=True)
+        data_file.write_bytes(b"data")
+
+        result = store.resolve_input(
+            {"id": "data", "source": str(data_file)},
+            universe_id="baseline",
+        )
+        assert result.verified is False
+
+
+class TestResolveInputRemote:
+    def test_remote_uri_stages(self, store, tmp_path):
+        """Remote URIs are staged to cache via fsspec."""
+        source = tmp_path / "remote" / "data.fits"
+        source.parent.mkdir(parents=True)
+        source.write_bytes(b"remote data")
+
+        result = store.resolve_input(
+            {"id": "remote", "source": f"file://{source}"},
+            universe_id="baseline",
+        )
+        assert result.staged is True
+        assert result.local_path.exists()
+        assert result.local_path.read_bytes() == b"remote data"
+
+
+class TestResolveExternalInputs:
+    def test_returns_same_shape_as_old_function(self, store, tmp_path):
+        """resolve_external_inputs returns {id: path_str} like get_external_inputs."""
+        data_file = tmp_path / "ext" / "catalog.hdf5"
+        data_file.parent.mkdir(parents=True)
+        data_file.write_bytes(b"data")
+
+        spec = {
+            "inputs": [
+                {"id": "sim_data", "type": "data", "source": str(data_file)},
+                {"id": "raw", "type": "data"},  # internal — no source
+            ],
+            "outputs": [],
+        }
+        result = store.resolve_external_inputs(spec, "baseline")
+        assert isinstance(result, dict)
+        assert "sim_data" in result
+        assert result["sim_data"] == str(data_file)
+        assert "raw" not in result  # internal inputs excluded
+
+    def test_relative_sources_resolved(self, store, project):
+        """Relative sources are resolved and included."""
+        data_file = project / "data" / "input.fits"
+        data_file.parent.mkdir(parents=True)
+        data_file.write_bytes(b"fits")
+
+        spec = {
+            "inputs": [
+                {"id": "obs", "type": "data", "source": "./data/input.fits"},
+            ],
+            "outputs": [],
+        }
+        result = store.resolve_external_inputs(spec, "baseline")
+        assert "obs" in result
+        assert result["obs"] == str(data_file.resolve())
+
+    def test_empty_inputs(self, store):
+        assert store.resolve_external_inputs({"inputs": [], "outputs": []}, "baseline") == {}
+        assert store.resolve_external_inputs({"outputs": []}, "baseline") == {}
+
+
+class TestDataStoreInit:
+    def test_default_cache_dir(self, project):
+        ds = DataStore(project_root=project)
+        assert ds.cache_dir == Path.home() / ".prism" / "cache"
+
+    def test_custom_cache_dir(self, project, tmp_path):
+        custom = tmp_path / "my_cache"
+        ds = DataStore(project_root=project, cache_dir=custom)
+        assert ds.cache_dir == custom

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1,0 +1,171 @@
+"""Tests for fsspec staging functions."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from prism.dagster.staging import (
+    _cache_key,
+    _is_local,
+    _resolve_local,
+    stage_uri,
+    verify_checksum,
+)
+
+
+class TestIsLocal:
+    def test_absolute_path(self):
+        assert _is_local("/pscratch/sd/f/francois/data") is True
+
+    def test_relative_dot_slash(self):
+        assert _is_local("./data/input.fits") is True
+
+    def test_relative_dot_dot_slash(self):
+        assert _is_local("../shared/catalog.hdf5") is True
+
+    def test_https_url(self):
+        assert _is_local("https://example.com/data.tar") is False
+
+    def test_s3_uri(self):
+        assert _is_local("s3://bucket/key/data.fits") is False
+
+    def test_ssh_uri(self):
+        assert _is_local("ssh://host/path/data.fits") is False
+
+    def test_bare_relative(self):
+        # Without ./ prefix — not considered local
+        assert _is_local("data/input.fits") is False
+
+
+class TestResolveLocal:
+    def test_absolute_path_unchanged(self, tmp_path):
+        result = _resolve_local("/pscratch/data", tmp_path)
+        assert result == Path("/pscratch/data")
+
+    def test_relative_path_resolved_to_project_root(self, tmp_path):
+        result = _resolve_local("./data/input.fits", tmp_path)
+        assert result == (tmp_path / "data" / "input.fits").resolve()
+
+    def test_dot_dot_relative(self, tmp_path):
+        result = _resolve_local("../shared/catalog.hdf5", tmp_path)
+        assert result == (tmp_path / ".." / "shared" / "catalog.hdf5").resolve()
+
+
+class TestCacheKey:
+    def test_with_checksum(self):
+        checksum = {"algorithm": "sha256", "value": "abc123"}
+        key = _cache_key("https://example.com/data.fits", checksum)
+        assert key == "sha256-abc123"
+
+    def test_without_checksum(self):
+        key = _cache_key("https://example.com/data.fits", None)
+        assert key.startswith("uri-")
+        assert len(key) > 10
+
+    def test_same_uri_same_key(self):
+        k1 = _cache_key("https://example.com/data.fits", None)
+        k2 = _cache_key("https://example.com/data.fits", None)
+        assert k1 == k2
+
+    def test_different_uri_different_key(self):
+        k1 = _cache_key("https://example.com/a.fits", None)
+        k2 = _cache_key("https://example.com/b.fits", None)
+        assert k1 != k2
+
+
+class TestVerifyChecksum:
+    def test_matching_checksum(self, tmp_path):
+        import hashlib
+
+        data = b"hello world"
+        f = tmp_path / "test.dat"
+        f.write_bytes(data)
+        expected = hashlib.sha256(data).hexdigest()
+        checksum = {"algorithm": "sha256", "value": expected}
+        assert verify_checksum(f, checksum) is True
+
+    def test_mismatching_checksum(self, tmp_path):
+        f = tmp_path / "test.dat"
+        f.write_bytes(b"hello world")
+        checksum = {"algorithm": "sha256", "value": "0000bad"}
+        assert verify_checksum(f, checksum) is False
+
+    def test_empty_value(self, tmp_path):
+        f = tmp_path / "test.dat"
+        f.write_bytes(b"data")
+        assert verify_checksum(f, {"algorithm": "sha256", "value": ""}) is False
+
+    def test_directory_checksum(self, tmp_path):
+        import hashlib
+
+        d = tmp_path / "dir"
+        d.mkdir()
+        (d / "a.txt").write_bytes(b"aaa")
+        (d / "b.txt").write_bytes(b"bbb")
+
+        h = hashlib.sha256()
+        for fpath in sorted(d.rglob("*")):
+            if fpath.is_file():
+                h.update(fpath.read_bytes())
+        expected = h.hexdigest()
+
+        assert verify_checksum(d, {"algorithm": "sha256", "value": expected}) is True
+
+
+class TestStageUri:
+    def test_stage_local_file_uri(self, tmp_path):
+        """Stage a file:// URI (no network needed)."""
+        source = tmp_path / "source.dat"
+        source.write_bytes(b"test data")
+        cache = tmp_path / "cache"
+
+        result = stage_uri(f"file://{source}", cache)
+        assert result.exists()
+        assert result.read_bytes() == b"test data"
+
+    def test_cache_hit(self, tmp_path):
+        """Second call should return cached path without re-fetching."""
+        source = tmp_path / "source.dat"
+        source.write_bytes(b"test data")
+        cache = tmp_path / "cache"
+
+        path1 = stage_uri(f"file://{source}", cache)
+        path2 = stage_uri(f"file://{source}", cache)
+        assert path1 == path2
+
+    def test_cache_hit_with_checksum(self, tmp_path):
+        """Checksum-keyed cache hit."""
+        import hashlib
+
+        data = b"test data"
+        source = tmp_path / "source.dat"
+        source.write_bytes(data)
+        cache = tmp_path / "cache"
+        checksum = {
+            "algorithm": "sha256",
+            "value": hashlib.sha256(data).hexdigest(),
+        }
+
+        path1 = stage_uri(f"file://{source}", cache, checksum=checksum)
+        # Remove source to prove cache is used
+        source.unlink()
+        path2 = stage_uri(f"file://{source}", cache, checksum=checksum)
+        assert path1 == path2
+        assert path2.read_bytes() == data
+
+    def test_missing_upath_raises_clear_error(self, tmp_path, monkeypatch):
+        """If universal-pathlib is not installed, give a clear error."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "upath":
+                raise ModuleNotFoundError("No module named 'upath'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        cache = tmp_path / "cache"
+        with pytest.raises(RuntimeError, match="universal-pathlib is required"):
+            stage_uri("https://example.com/data.fits", cache)


### PR DESCRIPTION
## What this does

Prism currently hardcodes input data as local filesystem paths — if `astra.yaml` says `source: /pscratch/sd/f/francois/sim_v3/catalog.hdf5`, that path must exist on the machine running the workflow. This means workflows can't move between sites without editing every `source` path, and there's no way to reference data on the web, in S3, or on a remote HPC filesystem.

This PR introduces a **DataStore** abstraction that sits between `astra.yaml` and the runner as a "stage gate":

```
astra.yaml sources          DataStore                    Runner (unchanged)
─────────────────    ──────────────────────────    ─────────────────────────────
/abs/path         →  validate exists              →  {id: "/abs/path"}
./relative/path   →  resolve to project root      →  {id: "/project/relative/path"}
https://url/data  →  fsspec stage to cache        →  {id: "~/.prism/cache/sha256-abc"}
s3://bucket/key   →  fsspec stage to cache        →  {id: "~/.prism/cache/sha256-def"}
ssh://host/path   →  fsspec stage to cache        →  {id: "~/.prism/cache/sha256-ghi"}
```

**Recipes and the runner don't change at all.** They still receive `dict[str, str]` with local filesystem paths. The staging happens transparently before `runner.execute()` is called.

## Why this matters

- **Portability**: Workflows can reference data by URL or URI and run on any machine
- **Integrity**: Checksums declared in `astra.yaml` are verified when data is resolved
- **Caching**: Remote data is fetched once to `~/.prism/cache/` and reused — content-addressed by checksum when available
- **Backward compatibility**: Existing workflows with absolute paths work identically

## What changed

### New files

| File | Purpose |
|---|---|
| `src/prism/dagster/data_store.py` | `DataStore` class — resolves input definitions to local paths |
| `src/prism/dagster/staging.py` | fsspec staging functions — `stage_uri()`, checksum verification, local path helpers |
| `tests/test_data_store.py` | 13 tests covering local, relative, remote, checksum, and edge cases |
| `tests/test_staging.py` | 22 tests covering `_is_local`, `_resolve_local`, `stage_uri`, `verify_checksum`, cache behavior |

### Modified files

| File | Change |
|---|---|
| `src/prism/dagster/assets.py` | `get_external_inputs()` delegates to DataStore when provided; `build_definitions()` creates and threads a DataStore through |
| `pyproject.toml` | Added `fsspec` and `universal-pathlib` to core deps; added `ssh`, `s3`, `gcs` optional extras |
| `CLAUDE.md` | Updated repo structure, architecture diagram, key invariants, and extending table |
| `README.md` | Added "Data staging" capabilities section with supported protocols and examples |

### What did NOT change

- **`runner.py`**: Still receives `dict[str, str]` with local paths — zero changes
- **`io_manager.py`**: Output paths unchanged
- **`cli.py`**: No changes — DataStore is wired in `build_definitions()`
- **Recipe commands**: Still see `data/{input_id}` mounted in containers
- **ASTRA schema**: `inputs[].source` already accepts any string — URIs work immediately

## Example

```yaml
# Before (only works on one machine):
inputs:
  - id: sim_catalog
    type: data
    source: /pscratch/sd/f/francois/sim_v3/catalog.hdf5

# After (portable, with integrity check):
inputs:
  - id: sim_catalog
    type: data
    source: https://zenodo.org/records/12345/files/catalog.hdf5
    checksum:
      algorithm: sha256
      value: a1b2c3d4e5f6...
```

Absolute paths still work unchanged (backward compat).

## Test plan

- [x] All 35 new tests pass (`test_data_store.py` + `test_staging.py`)
- [x] All 249 tests pass (full suite — no regressions)
- [x] `ruff check` passes on all new/modified files
- [x] `mypy` passes on new files (only pre-existing `astra` stub warning)
- [ ] Manual smoke test: create an `astra.yaml` with an HTTPS source, run `prism run`, verify data is staged and recipe executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)