### PR TITLE
Move prism internals into .prism/ directory, remove boilerplate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ astra.yaml → build_definitions() → Dagster assets → ASTRAContainerRunner �
 - Per-recipe container specs override analysis-level defaults
 
 **Config resolution (used everywhere):**
-- Target: `--target` flag > `prism.yaml` > `~/.prism/config.yaml` > `"local"`
+- Target: `--target` flag > `.prism/prism.yaml` > `~/.prism/config.yaml` > `"local"`
 - Permission tier: `--permissions` flag > saved default in `~/.prism/config.yaml` > interactive prompt
 - Most commands require `astra.yaml` in cwd; exceptions: `setup`, `target`
 

--- a/claude/prism/skills/prism-build/SKILL.md
+++ b/claude/prism/skills/prism-build/SKILL.md
@@ -49,7 +49,7 @@ If validation fails, fix issues before proceeding (create `astra.yaml` via `/pri
 
 ### 2. Create implementation plan
 
-Read `astra.yaml`, `CLAUDE.md`, `universes/<UNIVERSE>.yaml`, and any existing `scripts/` directory. If the user provided a description (e.g. `/prism-build focus on the fitting script first`), use it to guide the plan's priorities and ordering. Produce an ordered implementation plan and write it to `plans/build-plan-<UNIVERSE>.md`.
+Read `astra.yaml`, `CLAUDE.md`, `universes/<UNIVERSE>.yaml`, and any existing `scripts/` directory. If the user provided a description (e.g. `/prism-build focus on the fitting script first`), use it to guide the plan's priorities and ordering. Produce an ordered implementation plan and write it to `.prism/plans/build-plan-<UNIVERSE>.md`.
 
 The plan must include:
 
@@ -66,7 +66,7 @@ Print the plan contents and ask the user via `AskUserQuestion`:
 - "Does this build plan look good?"
 - Options: "Approve and start building", "Let me edit the plan first"
 
-If the user wants changes, wait for them to edit `plans/build-plan-<UNIVERSE>.md` and re-present.
+If the user wants changes, wait for them to edit `.prism/plans/build-plan-<UNIVERSE>.md` and re-present.
 
 ## Phase 2: Activate Loop
 
@@ -88,5 +88,5 @@ This creates `.claude/ralph-loop.local.md` — the ralph-wiggum state file. The 
 ## Notes
 
 - The setup script will attempt to install the ralph-loop plugin if missing (via marketplace update). If installation fails, it errors and cleans up — the loop cannot run without the stop hook.
-- The build plan file (`plans/build-plan-<UNIVERSE>.md`) persists across crashes for easy resumption. It's deleted on successful completion.
+- The build plan file (`.prism/plans/build-plan-<UNIVERSE>.md`) persists across crashes for easy resumption. It's deleted on successful completion.
 - To cancel mid-loop: `/cancel-ralph`

--- a/claude/prism/skills/prism-build/assets/loop-prompt.md
+++ b/claude/prism/skills/prism-build/assets/loop-prompt.md
@@ -7,11 +7,11 @@ Run these commands and read their output:
 1. `prism status --universe {{UNIVERSE}}` -- what's materialized, what's pending, what has no recipe
 2. `git log --oneline -10` -- what happened recently
 3. `astra validate astra.yaml` -- is the spec valid
-4. Read `plans/build-plan-{{UNIVERSE}}.md` -- your implementation plan (cross off completed items as you go)
+4. Read `.prism/plans/build-plan-{{UNIVERSE}}.md` -- your implementation plan (cross off completed items as you go)
 
 ## Decide What to Do
 
-**Follow the plan.** Read `plans/build-plan-{{UNIVERSE}}.md` and work on the next unchecked item. The plan was designed with the right ordering — shared utilities before scripts that use them, upstream outputs before downstream ones. Trust it.
+**Follow the plan.** Read `.prism/plans/build-plan-{{UNIVERSE}}.md` and work on the next unchecked item. The plan was designed with the right ordering — shared utilities before scripts that use them, upstream outputs before downstream ones. Trust it.
 
 If the plan is fully checked off or doesn't cover what `prism status` reveals, fall back to the status-based rules below.
 
@@ -41,7 +41,7 @@ All outputs are materialized. Time to verify.
    Report all findings with file paths and line numbers. If all checks pass, end your report with exactly: VERIFIED"
    ```
 4. **If sub-agent reports issues:** fix them, commit. Exit (loop continues).
-5. **If sub-agent says VERIFIED:** Output exactly: `<promise>BUILD_COMPLETE</promise>`, then clean up the build plan (`rm plans/build-plan-{{UNIVERSE}}.md`).
+5. **If sub-agent says VERIFIED:** Output exactly: `<promise>BUILD_COMPLETE</promise>`, then clean up the build plan (`rm .prism/plans/build-plan-{{UNIVERSE}}.md`).
 
 ## Reference: How Work Gets Done
 
@@ -76,6 +76,6 @@ These are the kinds of work you'll do, guided by the plan. Not a rigid sequence 
 
 **Trust the spec.** `astra.yaml` is the source of truth. Don't ask permission, don't second-guess decisions. Build what it says.
 
-**Update the plan.** After completing work, edit `plans/build-plan-{{UNIVERSE}}.md` to cross off completed items and add notes about what you learned.
+**Update the plan.** After completing work, edit `.prism/plans/build-plan-{{UNIVERSE}}.md` to cross off completed items and add notes about what you learned.
 
 **Document blockers.** If you hit something you can't resolve (missing data, ambiguous spec, external dependency), add it to the Open Questions section in `CLAUDE.md` and move on to other work.

--- a/claude/prism/skills/prism-build/scripts/setup-prism-build.sh
+++ b/claude/prism/skills/prism-build/scripts/setup-prism-build.sh
@@ -107,8 +107,8 @@ if [[ "$MODE" == "activate" ]]; then
     fi
 
     # Check build plan exists
-    if [[ ! -f "plans/build-plan-${UNIVERSE}.md" ]]; then
-        echo "Warning: No build plan found at plans/build-plan-${UNIVERSE}.md"
+    if [[ ! -f ".prism/plans/build-plan-${UNIVERSE}.md" ]]; then
+        echo "Warning: No build plan found at .prism/plans/build-plan-${UNIVERSE}.md"
         echo "The loop will proceed without a plan."
     fi
 

--- a/claude/prism/templates/CLAUDE.md
+++ b/claude/prism/templates/CLAUDE.md
@@ -25,10 +25,12 @@ ASTRA (Agentic Schema for Transparent Research Analysis) analysis project, built
 
 ```
 astra.yaml              # Specification: decisions, inputs, outputs
-prism.yaml            # Prism config (default target, etc.)
 CLAUDE.md             # This file
 Containerfile         # Container image for execution
 requirements.txt      # Python deps (keep in sync with scripts)
+.prism/               # Prism internals
+  prism.yaml          # Prism config (default target, etc.)
+  dagster.yaml        # Dagster instance config
 universes/
   baseline.yaml       # Default decision selections
 scripts/              # Implementation scripts

--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -108,6 +108,42 @@ def main(ctx: click.Context) -> None:
 
 
 # =============================================================================
+# Path helpers
+# =============================================================================
+
+
+def _find_prism_yaml(project_path: Path) -> Path | None:
+    """Find prism.yaml, checking .prism/ first then root for backwards compat."""
+    candidate = project_path / ".prism" / "prism.yaml"
+    if candidate.exists():
+        return candidate
+    candidate = project_path / "prism.yaml"
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _find_dagster_yaml(project_path: Path) -> Path | None:
+    """Find dagster.yaml, checking .prism/ first then root for backwards compat."""
+    candidate = project_path / ".prism" / "dagster.yaml"
+    if candidate.exists():
+        return candidate
+    candidate = project_path / "dagster.yaml"
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _load_prism_config(project_path: Path) -> dict:
+    """Load prism.yaml config, returning empty dict if not found."""
+    path = _find_prism_yaml(project_path)
+    if path is None:
+        return {}
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+# =============================================================================
 # Init command
 # =============================================================================
 
@@ -162,12 +198,12 @@ def init(
         "universes",
         "scripts",
         "results",
-        "plans",
+        ".prism",
     ]
     for subdir in subdirs:
         (directory / subdir).mkdir(parents=True, exist_ok=True)
 
-    # Create dagster.yaml for Dagster instance configuration
+    # Create dagster.yaml inside .prism/
     dagster_yaml_content = {
         "storage": {
             "sqlite": {
@@ -175,7 +211,7 @@ def init(
             },
         },
     }
-    (directory / "dagster.yaml").write_text(
+    (directory / ".prism" / "dagster.yaml").write_text(
         yaml.dump(dagster_yaml_content, default_flow_style=False, sort_keys=False)
     )
 
@@ -201,8 +237,8 @@ __pycache__/
     tier = _resolve_permission_tier(permissions)
     _create_claude_settings(directory, tier)
 
-    # Write prism.yaml project config — use --target flag, or fall back to
-    # the user's default target from ~/.prism/config.yaml
+    # Write prism.yaml project config inside .prism/ — use --target flag,
+    # or fall back to the user's default target from ~/.prism/config.yaml
     effective_target = target
     if not effective_target:
         from prism.dagster.targets import load_user_config
@@ -326,44 +362,6 @@ decisions:
 """
     (directory / "universes" / "baseline.yaml").write_text(baseline_universe)
 
-    # Create README
-    _create_readme(directory, name)
-
-
-def _create_readme(directory: Path, name: str) -> None:
-    """Create a README.md for the project."""
-    readme = f"""# {name}
-
-An ASTRA (Agentic Schema for Transparent Research Analysis) analysis project, built with Prism.
-
-## Quick Start
-
-```bash
-# Open in Claude Code
-claude
-
-# Scope the analysis
-/prism-new
-
-# Then start building (Claude reads CLAUDE.md for conventions)
-```
-
-## Structure
-
-- `astra.yaml` — Analysis specification (source of truth)
-- `prism.yaml` — Prism config (compute profiles)
-- `CLAUDE.md` — Build conventions and project context for Claude Code
-- `universes/` — Decision selections (one YAML per universe)
-- `scripts/` — Implementation scripts
-- `results/` — Execution outputs (gitignored)
-
-## Documentation
-
-See [ASTRA documentation](https://github.com/LightconeResearch/ASTRA) for the specification.
-See [Prism documentation](https://github.com/LightconeResearch/Prism) for the agentic layer.
-"""
-    (directory / "README.md").write_text(readme)
-
 
 def _create_claude_md(directory: Path) -> None:
     """Create CLAUDE.md from the template in the plugin source."""
@@ -392,14 +390,16 @@ def _create_claude_md(directory: Path) -> None:
 
 
 def _create_prism_config(directory: Path, target_name: str) -> None:
-    """Create prism.yaml with target reference."""
+    """Create .prism/prism.yaml with target reference."""
     config = {
         "target": target_name,
     }
-    (directory / "prism.yaml").write_text(
+    prism_dir = directory / ".prism"
+    prism_dir.mkdir(parents=True, exist_ok=True)
+    (prism_dir / "prism.yaml").write_text(
         yaml.dump(config, default_flow_style=False, sort_keys=False)
     )
-    console.print(f"[green]✓[/green] Created prism.yaml (target: {target_name})")
+    console.print(f"[green]✓[/green] Created .prism/prism.yaml (target: {target_name})")
 
 
 
@@ -855,14 +855,11 @@ def run(
         console.print("[red]Error:[/red] No astra.yaml found in current directory.")
         raise SystemExit(1)
 
-    # Resolve target: --target flag > prism.yaml > default from user config
+    # Resolve target: --target flag > .prism/prism.yaml > default from user config
     target_name = target
     if not target_name:
-        prism_yaml = project_path / "prism.yaml"
-        if prism_yaml.exists():
-            with open(prism_yaml) as f:
-                prism_data = yaml.safe_load(f) or {}
-            target_name = prism_data.get("target")
+        prism_data = _load_prism_config(project_path)
+        target_name = prism_data.get("target")
         if not target_name:
             from prism.dagster.targets import load_user_config
             target_name = load_user_config().get("default_target")
@@ -894,9 +891,9 @@ def run(
 
     # Use a persistent DagsterInstance so run history is recorded for the
     # Dagster webserver (prism dev) to display.
-    dagster_yaml = project_path / "dagster.yaml"
-    if dagster_yaml.exists():
-        instance = dg.DagsterInstance.from_config(str(project_path))
+    dagster_yaml_path = _find_dagster_yaml(project_path)
+    if dagster_yaml_path is not None:
+        instance = dg.DagsterInstance.from_config(str(dagster_yaml_path.parent))
     else:
         instance = None
 
@@ -934,7 +931,7 @@ def build(force: bool, runtime: str | None) -> None:
     Containerfile or dependency files change.
 
     The container runtime is auto-detected from the project's target
-    config (prism.yaml → ~/.prism/targets/). Use --runtime to override.
+    config (.prism/prism.yaml → ~/.prism/targets/). Use --runtime to override.
 
     Examples:
         prism build                      # auto-detect runtime from target
@@ -958,12 +955,8 @@ def build(force: bool, runtime: str | None) -> None:
     # Resolve runtime from target config if not explicitly provided
     if runtime is None:
         from prism.dagster.targets import load_target, load_user_config
-        target_name = None
-        prism_yaml = project_path / "prism.yaml"
-        if prism_yaml.exists():
-            with open(prism_yaml) as f:
-                prism_data = yaml.safe_load(f) or {}
-            target_name = prism_data.get("target")
+        prism_data = _load_prism_config(project_path)
+        target_name = prism_data.get("target")
         if not target_name:
             target_name = load_user_config().get("default_target")
         if target_name and target_name != "local":
@@ -1157,7 +1150,9 @@ def dev(port: int, universe: str) -> None:
             f.write(defs_code)
             defs_file = f.name
 
-        env = {**os.environ, "DAGSTER_HOME": str(project_path)}
+        dagster_yaml_path = _find_dagster_yaml(project_path)
+        dagster_home = str(dagster_yaml_path.parent) if dagster_yaml_path else str(project_path)
+        env = {**os.environ, "DAGSTER_HOME": dagster_home}
         subprocess.run(
             ["dagster-webserver", "-f", defs_file, "-h", "0.0.0.0", "-p", str(port)],
             check=True,
@@ -1200,10 +1195,10 @@ def target(
     from prism.dagster.targets import list_targets, load_target
 
     if set_target:
-        # Update target key in prism.yaml
+        # Update target key in .prism/prism.yaml
         project_path = Path.cwd()
-        prism_yaml = project_path / "prism.yaml"
-        if not prism_yaml.exists():
+        prism_yaml = _find_prism_yaml(project_path)
+        if prism_yaml is None:
             console.print("[red]Error:[/red] No prism.yaml found. Run 'prism init' first.")
             raise SystemExit(1)
 
@@ -1254,8 +1249,8 @@ def target(
 
     # Default: show current project target
     project_path = Path.cwd()
-    prism_yaml = project_path / "prism.yaml"
-    if not prism_yaml.exists():
+    prism_yaml = _find_prism_yaml(project_path)
+    if prism_yaml is None:
         console.print("No prism.yaml found. Run [cyan]prism init[/cyan] first.")
         return
 
@@ -1571,7 +1566,7 @@ def _run_setup_wizard() -> list[Path]:
     console.print("\n[bold]Prism Setup — Target Configuration[/bold]")
     console.print(
         "  These settings are stored in [cyan]~/.prism/targets/[/cyan] and "
-        "referenced by projects via prism.yaml.\n"
+        "referenced by projects via .prism/prism.yaml.\n"
     )
 
     saved_paths: list[Path] = []
@@ -1782,7 +1777,7 @@ def setup(
     execution backends (SLURM). Creates one target per node type.
 
     Settings are stored at the user level (~/.prism/targets/) and
-    referenced by projects via prism.yaml.
+    referenced by projects via .prism/prism.yaml.
 
     Examples:
         prism setup                        # interactive wizard

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,7 @@ class TestInitCommand:
         assert (project_dir / "universes" / "baseline.yaml").exists()
         assert (project_dir / "scripts").is_dir()
         assert (project_dir / "results").is_dir()
+        assert (project_dir / ".prism").is_dir()
 
     def test_init_astra_yaml_content(self, runner: CliRunner, tmp_path: Path):
         """Test that the generated astra.yaml has the expected content."""
@@ -110,7 +111,7 @@ class TestInitCommand:
         assert (project_dir / "astra.yaml").exists()
 
     def test_init_creates_dagster_yaml(self, runner: CliRunner, tmp_path: Path):
-        """Test that init creates dagster.yaml."""
+        """Test that init creates .prism/dagster.yaml."""
         project_dir = tmp_path / "dagster-test"
         result = runner.invoke(
             main,
@@ -118,10 +119,10 @@ class TestInitCommand:
              "--permissions", "recommended"],
         )
         assert result.exit_code == 0
-        assert (project_dir / "dagster.yaml").exists()
+        assert (project_dir / ".prism" / "dagster.yaml").exists()
 
     def test_init_with_target_creates_prism_yaml(self, runner: CliRunner, tmp_path: Path):
-        """Test that --target creates prism.yaml with a flat target key."""
+        """Test that --target creates .prism/prism.yaml with a flat target key."""
         project_dir = tmp_path / "target-test"
         with patch("prism.dagster.targets.load_target", return_value={"site": "perlmutter"}):
             result = runner.invoke(
@@ -131,14 +132,14 @@ class TestInitCommand:
                  "--permissions", "recommended"],
             )
         assert result.exit_code == 0
-        assert (project_dir / "prism.yaml").exists()
+        assert (project_dir / ".prism" / "prism.yaml").exists()
 
         import yaml
-        config = yaml.safe_load((project_dir / "prism.yaml").read_text())
+        config = yaml.safe_load((project_dir / ".prism" / "prism.yaml").read_text())
         assert config["target"] == "perlmutter-gpu"
 
     def test_init_without_target_uses_default(self, runner: CliRunner, tmp_path: Path):
-        """Test that without --target, prism.yaml uses default target from user config."""
+        """Test that without --target, .prism/prism.yaml uses default target from user config."""
         project_dir = tmp_path / "no-target-test"
         result = runner.invoke(
             main,
@@ -146,11 +147,11 @@ class TestInitCommand:
              "--permissions", "recommended"],
         )
         assert result.exit_code == 0
-        assert (project_dir / "prism.yaml").exists()
+        assert (project_dir / ".prism" / "prism.yaml").exists()
 
         import yaml
         prism_cfg = yaml.safe_load(
-            (project_dir / "prism.yaml").read_text()
+            (project_dir / ".prism" / "prism.yaml").read_text()
         )
         # conftest sets default_target: fake
         assert prism_cfg["target"] == "fake"
@@ -509,7 +510,8 @@ class TestTargetCommand:
     def test_target_shows_current(self, runner: CliRunner, tmp_path: Path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         import yaml
-        (tmp_path / "prism.yaml").write_text(yaml.dump({"target": "perlmutter-gpu"}))
+        (tmp_path / ".prism").mkdir()
+        (tmp_path / ".prism" / "prism.yaml").write_text(yaml.dump({"target": "perlmutter-gpu"}))
         with patch("prism.dagster.targets.load_target", return_value={
             "backend": "slurm", "connection": {"hostname": "perlmutter.nersc.gov"},
         }):
@@ -520,18 +522,20 @@ class TestTargetCommand:
     def test_target_set(self, runner: CliRunner, tmp_path: Path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         import yaml
-        (tmp_path / "prism.yaml").write_text(yaml.dump({"target": "local"}))
+        (tmp_path / ".prism").mkdir()
+        (tmp_path / ".prism" / "prism.yaml").write_text(yaml.dump({"target": "local"}))
         with patch("prism.dagster.targets.load_target", return_value={"backend": "slurm"}):
             result = runner.invoke(main, ["target", "--set", "perlmutter-gpu"])
         assert result.exit_code == 0
         assert "perlmutter-gpu" in result.output
-        config = yaml.safe_load((tmp_path / "prism.yaml").read_text())
+        config = yaml.safe_load((tmp_path / ".prism" / "prism.yaml").read_text())
         assert config["target"] == "perlmutter-gpu"
 
     def test_target_set_nonexistent(self, runner: CliRunner, tmp_path: Path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         import yaml
-        (tmp_path / "prism.yaml").write_text(yaml.dump({"target": "local"}))
+        (tmp_path / ".prism").mkdir()
+        (tmp_path / ".prism" / "prism.yaml").write_text(yaml.dump({"target": "local"}))
         with patch("prism.dagster.targets.load_target", return_value=None):
             with patch("prism.dagster.targets.list_targets", return_value=["local"]):
                 result = runner.invoke(main, ["target", "--set", "nonexistent"])
@@ -593,14 +597,14 @@ class TestTargetResolution:
             "decisions": [],
         }, sort_keys=False))
 
-        # Create prism.yaml with a local target
-        (tmp_path / "prism.yaml").write_text(yaml.dump({
+        # Create .prism/ with prism.yaml and dagster.yaml
+        (tmp_path / ".prism").mkdir()
+        (tmp_path / ".prism" / "prism.yaml").write_text(yaml.dump({
             "target": "local",
         }, sort_keys=False))
 
-        # Create dagster.yaml
         (tmp_path / "results").mkdir()
-        (tmp_path / "dagster.yaml").write_text(yaml.dump({
+        (tmp_path / ".prism" / "dagster.yaml").write_text(yaml.dump({
             "storage": {"sqlite": {"base_dir": str(tmp_path / "results" / ".dagster")}}
         }, sort_keys=False))
 
@@ -621,12 +625,13 @@ class TestTargetResolution:
             "decisions": [],
         }, sort_keys=False))
 
-        (tmp_path / "prism.yaml").write_text(yaml.dump({
+        (tmp_path / ".prism").mkdir()
+        (tmp_path / ".prism" / "prism.yaml").write_text(yaml.dump({
             "target": "local",
         }, sort_keys=False))
 
         (tmp_path / "results").mkdir()
-        (tmp_path / "dagster.yaml").write_text(yaml.dump({
+        (tmp_path / ".prism" / "dagster.yaml").write_text(yaml.dump({
             "storage": {"sqlite": {"base_dir": str(tmp_path / "results" / ".dagster")}}
         }, sort_keys=False))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -43,13 +43,14 @@ decisions: {}
 
 class TestIntegration:
     def test_init_creates_dagster_yaml(self, project_dir):
-        assert (project_dir / "dagster.yaml").exists()
+        assert (project_dir / ".prism" / "dagster.yaml").exists()
 
     def test_init_creates_project_structure(self, project_dir):
         assert (project_dir / "astra.yaml").exists()
         assert (project_dir / "universes").is_dir()
         assert (project_dir / "results").is_dir()
         assert (project_dir / "scripts").is_dir()
+        assert (project_dir / ".prism").is_dir()
 
     def test_init_creates_containerfile(self, tmp_path, runner):
         project = tmp_path / "container-project"


### PR DESCRIPTION
## Summary
- Moves `prism.yaml` and `dagster.yaml` into a new `.prism/` subdirectory to reduce root-level clutter
- Removes auto-generated `README.md` from `prism init`
- Moves build plans from `plans/` to `.prism/plans/`
- Adds `_find_prism_yaml` / `_find_dagster_yaml` helpers with backwards-compat fallback to root-level files so existing projects continue to work
- Updates all CLI commands (`run`, `build`, `dev`, `target`), skills (`prism-build`), templates (`CLAUDE.md`), and tests

## Test plan
- [x] All 63 existing tests pass
- [x] Manual `prism init` produces correct structure
- [x] Verify backwards compat: existing project with root-level `prism.yaml` still resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- dco-signed-off-by -->
Signed-off-by: lhparker1 <liamholdenparker@gmail.com>