### PR TITLE
Flip recommended permissions from allowlist to denylist

### DIFF
--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -16,7 +16,7 @@ from rich.console import Console
 
 console = Console()
 
-PERMISSION_TIERS = {
+PERMISSION_TIERS: dict[str, dict[str, list[str]]] = {
     "yolo": {
         "allow": [
             "Bash(*)",
@@ -31,22 +31,25 @@ PERMISSION_TIERS = {
     "recommended": {
         "allow": [
             "Read",
-            "Bash(astra:*)",
-            "Bash(prism:*)",
-            "Bash(python:*)",
-            "Bash(pip:*)",
-            "Bash(echo:*)",
-            "Bash(git status:*)",
-            "Bash(git log:*)",
-            "Bash(git diff:*)",
-            "Bash(git add:*)",
-            "Bash(git commit:*)",
-            "Bash(git branch:*)",
-            "Bash(git checkout:*)",
-            "Bash(git switch:*)",
             "Edit",
+            "Write",
+            "Bash(*)",
             "WebSearch",
             "WebFetch",
+        ],
+        "deny": [
+            # Sensitive dotfiles — don't silently modify credentials/keys
+            "Edit(~/.ssh/**)",
+            "Edit(~/.aws/**)",
+            "Edit(~/.gnupg/**)",
+            # Common HPC scratch filesystems
+            "Edit(//scratch/**)",
+            "Edit(//pscratch/**)",
+            # Dangerous bash — require explicit confirmation
+            "Bash(sudo *)",
+            "Bash(rm -rf /*)",
+            "Bash(git push *)",
+            "Bash(git push)",
         ],
     },
     "minimal": {
@@ -197,16 +200,16 @@ __pycache__/
     # Create CLAUDE.md with project conventions
     _create_claude_md(directory)
 
-    # Resolve permission tier and create Claude Code settings
-    tier = _resolve_permission_tier(permissions)
-    _create_claude_settings(directory, tier)
-
-    # Write prism.yaml project config — use --target flag, or fall back to
-    # the user's default target from ~/.prism/config.yaml
+    # Resolve target and permission tier, then create Claude Code settings
     effective_target = target
     if not effective_target:
         from prism.dagster.targets import load_user_config
         effective_target = load_user_config().get("default_target", "local")
+
+    tier = _resolve_permission_tier(permissions)
+    _create_claude_settings(directory, tier, target=effective_target)
+
+    # Write prism.yaml project config
     _create_prism_config(directory, effective_target)
 
     # If user explicitly passed --target, ensure it's been configured
@@ -411,8 +414,8 @@ def _prompt_permission_tier() -> str:
     """
     console.print("\n[bold]Claude Code permission level[/bold]")
     console.print("  Controls what Claude can do without asking.\n")
-    console.print("    1. yolo — Everything auto-allowed. No prompts.")
-    console.print("    2. recommended — Prism workflow auto-allowed. Prompts for the rest.")
+    console.print("    1. yolo — Everything including MCP. No guardrails.")
+    console.print("    2. recommended — Full access with guardrails (no sudo/push/scratch).")
     console.print("    3. minimal — Only file reading. Everything else prompts.")
 
     choice_map = {"1": "yolo", "2": "recommended", "3": "minimal"}
@@ -522,8 +525,14 @@ def _update_extractor_agent_model(agents_dir: Path) -> None:
     extractor_path.write_text(content)
 
 
-def _create_claude_settings(directory: Path, tier: str = "recommended") -> None:
-    """Create Claude Code settings with Prism skills and agents."""
+def _create_claude_settings(
+    directory: Path, tier: str = "recommended", target: str = "local",
+) -> None:
+    """Create Claude Code settings with Prism skills and agents.
+
+    If a non-local target maps to a known HPC site, site-specific deny rules
+    (e.g. scratch filesystem paths) are merged into the permissions.
+    """
     claude_dir = directory / ".claude"
     claude_dir.mkdir(parents=True, exist_ok=True)
 
@@ -575,7 +584,19 @@ def _create_claude_settings(directory: Path, tier: str = "recommended") -> None:
         shutil.copytree(agents_src, agents_dst)
         _update_extractor_agent_model(agents_dst)
 
-    permissions = PERMISSION_TIERS[tier]
+    # Build permissions: start from tier, then merge site-specific deny rules
+    permissions: dict[str, list[str]] = {
+        k: list(v) for k, v in PERMISSION_TIERS[tier].items()
+    }
+    if target != "local" and "deny" in permissions:
+        from prism.dagster.site_registry import detect_site, get_site_scratch_deny_rules
+        site_key = detect_site(target)
+        if site_key:
+            site_deny = get_site_scratch_deny_rules(site_key)
+            existing = set(permissions["deny"])
+            for rule in site_deny:
+                if rule not in existing:
+                    permissions["deny"].append(rule)
 
     # Build absolute paths for hook commands
     abs_hooks = str(directory.resolve() / ".claude" / "hooks")

--- a/src/prism/dagster/site_registry.py
+++ b/src/prism/dagster/site_registry.py
@@ -59,6 +59,11 @@ SITE_DEFAULTS: dict[str, dict[str, Any]] = {
             "nodes": 1,
             "time_limit": "30m",
         },
+        "scratch_paths": [
+            "//pscratch/**",
+            "//global/cscratch1/**",
+            "//global/cfs/cdirs/**",
+        ],
     },
     "local": {
         "hostname_patterns": [],
@@ -102,3 +107,16 @@ def list_known_sites() -> list[tuple[str, str]]:
         (key, site.get("display_name", key))
         for key, site in SITE_DEFAULTS.items()
     ]
+
+
+def get_site_scratch_deny_rules(site_key: str) -> list[str]:
+    """Return Edit deny rules for a site's scratch/shared filesystem paths.
+
+    These are used in Claude Code permissions to prevent accidental writes
+    to shared HPC filesystems.
+    """
+    site = SITE_DEFAULTS.get(site_key)
+    if not site:
+        return []
+    scratch_paths = site.get("scratch_paths", [])
+    return [f"Edit({path})" for path in scratch_paths]


### PR DESCRIPTION
## Summary
- **Recommended tier** now allows `Bash(*)`, `Read`, `Edit`, `Write`, `WebSearch`, `WebFetch` with targeted deny rules instead of a narrow allowlist of specific Bash commands. Previously every `mkdir`, `ls`, `cp`, `chmod`, `sbatch` etc. triggered a permission prompt, and `Write` was missing entirely.
- **Deny rules** protect against foot-guns: credential files (`~/.ssh`, `~/.aws`, `~/.gnupg`), common HPC scratch paths (`//scratch`, `//pscratch`), and dangerous Bash (`sudo`, `rm -rf /*`, `git push`).
- **Site-specific scratch deny rules**: when the target maps to a known HPC site (e.g. Perlmutter), additional scratch filesystem deny rules are merged into permissions automatically (e.g. `//global/cscratch1/**`, `//global/cfs/cdirs/**`).

## Test plan
- [x] All 214 existing tests pass
- [x] `prism init my-project --permissions recommended` — verify `.claude/settings.json` has allow + deny structure
- [x] `prism init my-project --permissions recommended --target perlmutter-gpu` — verify Perlmutter scratch paths appear in deny list
- [x] Run a Claude Code session in a recommended-tier project — confirm no prompts for normal Bash commands, but prompts for `git push` / `sudo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- dco-signed-off-by -->
Signed-off-by: lhparker1 <liamholdenparker@gmail.com>