### PR TITLE
Copy guides/ directory during prism init and project sync

### DIFF
--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -764,6 +764,14 @@ def _create_claude_settings(
         shutil.copytree(agents_src, agents_dst)
         _update_extractor_agent_model(agents_dst)
 
+    # Copy guides
+    guides_src = plugin_source / "guides"
+    guides_dst = claude_dir / "guides"
+    if guides_src.exists():
+        if guides_dst.exists():
+            shutil.rmtree(guides_dst)
+        shutil.copytree(guides_src, guides_dst)
+
     # Build permissions: start from tier, then merge site-specific deny rules
     permissions: dict[str, list[str]] = {
         k: list(v) for k, v in PERMISSION_TIERS[tier].items()
@@ -2070,8 +2078,8 @@ def _sync_project_plugins(project_dir: Path) -> bool:
     claude_dir = project_dir / ".claude"
     claude_dir.mkdir(parents=True, exist_ok=True)
 
-    # Sync directories: skills, hooks, scripts, agents
-    for subdir in ("scripts", "hooks", "skills", "agents"):
+    # Sync directories: skills, hooks, scripts, agents, guides
+    for subdir in ("scripts", "hooks", "skills", "agents", "guides"):
         src = plugin_source / subdir
         dst = claude_dir / subdir
         if not src.exists():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -785,17 +785,17 @@ class TestUpdateCommand:
         monkeypatch.setattr("prism.updater._CHECK_FILE", Path("/tmp/.fake_update_check"))
 
     def test_update_no_reinstall_when_up_to_date(self, runner: CliRunner, monkeypatch):
-        """When all repos are up to date, skip reinstall and project sync."""
+        """When all repos are up to date, skip reinstall but still offer project sync."""
         self._patch_updater(monkeypatch, [
             ("ASTRA", True, "already up to date"),
             ("Prism", True, "already up to date"),
             ("Prism-UI", True, "already up to date"),
         ])
 
-        result = runner.invoke(main, ["update"])
+        result = runner.invoke(main, ["update"], input="skip\n")
         assert result.exit_code == 0
         assert "Reinstalling" not in result.output
-        assert "Sync updated" not in result.output
+        assert "Sync updated" in result.output
 
     def test_update_reinstalls_when_updated(self, runner: CliRunner, monkeypatch):
         """When repos have updates, reinstall packages and prompt for sync."""
@@ -859,6 +859,11 @@ class TestSyncProjectPlugins:
         hooks = plugin / "hooks"
         hooks.mkdir()
         (hooks / "langfuse_hook.py").write_text("# hook v2\n")
+        # Guides
+        guides = plugin / "guides"
+        guides.mkdir()
+        (guides / "decision-guide.md").write_text("# Decision Guide\n")
+        (guides / "ui-brand.md").write_text("# UI Brand\n")
         # Template
         templates = plugin / "templates"
         templates.mkdir()
@@ -885,6 +890,8 @@ class TestSyncProjectPlugins:
         assert (project / ".claude" / "skills" / "prism-build" / "SKILL.md").exists()
         assert (project / ".claude" / "scripts" / "session-start.sh").exists()
         assert (project / ".claude" / "hooks" / "langfuse_hook.py").exists()
+        assert (project / ".claude" / "guides" / "decision-guide.md").exists()
+        assert (project / ".claude" / "guides" / "ui-brand.md").exists()
 
     def test_sync_scripts_executable(self, tmp_path: Path):
         """Synced scripts should be executable."""


### PR DESCRIPTION
## Summary
- Skills (`prism-new`, `prism-migrate`) reference `../../guides/decision-guide.md` and `../../guides/ui-brand.md`, but the `guides/` directory was never copied into projects during `prism init` or `prism update --sync`. This meant the references were broken.
- Adds `guides/` to the `_sync_project_plugins` loop and the `_create_claude_settings` init function
- Updates test fixture and assertions to cover `guides/`
- Fixes `test_update_no_reinstall_when_up_to_date` to expect the sync prompt (follow-up from #37)

## Test plan
- [x] All 59 tests pass
- [ ] Run `prism init` on a new project — verify `.claude/guides/` is created with `decision-guide.md` and `ui-brand.md`
- [ ] Run `prism update --sync` on an existing project — verify `guides/` is synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)