### PR TITLE
Add interactive SLURM execution and scheduling CLI flags

### DIFF
--- a/claude/prism/scripts/session-start.sh
+++ b/claude/prism/scripts/session-start.sh
@@ -132,6 +132,20 @@ ACTION REQUIRED: ${pending_count} output(s) have recipes but are not yet materia
     fi
 fi
 
+# Check if user should be on an interactive node
+if [ -z "${SLURM_JOB_ID:-}" ]; then
+    # Check if default target is SLURM
+    default_target=$(grep '^default_target:' "$HOME/.prism/config.yaml" 2>/dev/null | awk '{print $2}')
+    if [ -n "$default_target" ] && [ "$default_target" != "local" ]; then
+        target_backend=$(grep '^backend:' "$HOME/.prism/targets/${default_target}.yaml" 2>/dev/null | awk '{print $2}')
+        if [ "$target_backend" = "slurm" ]; then
+            summary="$summary
+
+NOTE: Your default target is SLURM but you are not inside an interactive allocation. For fast execution, start one with \`salloc\` before running \`prism run\`."
+        fi
+    fi
+fi
+
 # Output as JSON
 escaped_summary=$(echo "$summary" | jq -Rs .)
 echo "{\"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": $escaped_summary}}"

--- a/claude/prism/scripts/session-start.sh
+++ b/claude/prism/scripts/session-start.sh
@@ -132,20 +132,6 @@ ACTION REQUIRED: ${pending_count} output(s) have recipes but are not yet materia
     fi
 fi
 
-# Check if user should be on an interactive node
-if [ -z "${SLURM_JOB_ID:-}" ]; then
-    # Check if default target is SLURM
-    default_target=$(grep '^default_target:' "$HOME/.prism/config.yaml" 2>/dev/null | awk '{print $2}')
-    if [ -n "$default_target" ] && [ "$default_target" != "local" ]; then
-        target_backend=$(grep '^backend:' "$HOME/.prism/targets/${default_target}.yaml" 2>/dev/null | awk '{print $2}')
-        if [ "$target_backend" = "slurm" ]; then
-            summary="$summary
-
-NOTE: Your default target is SLURM but you are not inside an interactive allocation. For fast execution, start one with \`salloc\` before running \`prism run\`."
-        fi
-    fi
-fi
-
 # Output as JSON
 escaped_summary=$(echo "$summary" | jq -Rs .)
 echo "{\"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": $escaped_summary}}"

--- a/claude/prism/skills/prism-build/assets/loop-prompt.md
+++ b/claude/prism/skills/prism-build/assets/loop-prompt.md
@@ -61,14 +61,15 @@ These are the kinds of work you'll do, guided by the plan. Not a rigid sequence 
 
 1. **Add the recipe block** to `astra.yaml` under the output's `recipe:` key.
 2. **Validate:** `astra validate astra.yaml`
-3. **Run it:** `prism run <OUTPUT> --universe {{UNIVERSE}}`
-4. **If it fails:** Read the error output carefully and diagnose the root cause before retrying. Never re-run the same command without changing something first. Common causes:
+3. **Check execution environment:** If the target is SLURM, check `echo $SLURM_JOB_ID`. If empty, you are on a login node — warn the user to start an interactive allocation (`salloc`) before running. Do not submit batch jobs during the build loop; interactive execution is required for fast iteration.
+4. **Run it:** `prism run <OUTPUT> --universe {{UNIVERSE}}`
+5. **If it fails:** Read the error output carefully and diagnose the root cause before retrying. Never re-run the same command without changing something first. Common causes:
    - Container not built → `prism build`
    - Upstream not materialized → materialize dependency first
    - Script error inside container → fix the script, then re-run
    If a second attempt also fails, note the failure in your commit message and in the build plan, then move on to other work. Come back to it in a later iteration with fresh context.
-5. **If it succeeds:** Verify the result file exists at `results/{{UNIVERSE}}/<output_id>.<ext>` and looks well-formed.
-6. **Commit** with a message noting what was materialized.
+6. **If it succeeds:** Verify the result file exists at `results/{{UNIVERSE}}/<output_id>.<ext>` and looks well-formed.
+7. **Commit** with a message noting what was materialized.
 
 ## Rules
 

--- a/claude/prism/templates/CLAUDE.md
+++ b/claude/prism/templates/CLAUDE.md
@@ -51,9 +51,11 @@ Three overlapping phases:
 
 If `SLURM_JOB_ID` is set in the environment, `prism run` automatically uses `srun` (instant) instead of `sbatch` (queued). This means the user is inside an interactive allocation and execution will be fast.
 
-If `SLURM_JOB_ID` is not set and the target is SLURM, `prism run` submits via `sbatch`. Pass scheduling flags:
+If `SLURM_JOB_ID` is not set and the target is SLURM, `prism run` submits via `sbatch`. Any unknown flags are passed through as SLURM directives:
 ```bash
-prism run --qos shared --constraint gpu
+prism run --qos shared --constraint gpu      # NERSC
+prism run --partition gpu-a100               # TACC, SDSC, etc.
+prism run --gres=gpu:4 --partition batch     # any cluster
 ```
 
 Recipe `resources` (gpus, memory, cpus, time_limit) are portable and used for batch scheduling. They are ignored in interactive mode since the allocation already provides them.
@@ -217,7 +219,7 @@ astra schema show analysis                    # Show JSON schema
 
 # prism -- execution operations
 prism run [OUTPUT] [--universe NAME]        # Execute recipes via Dagster (auto-builds)
-prism run --qos shared --constraint gpu     # Batch with specific scheduling
+prism run --partition gpu --qos shared      # Extra flags passed to SLURM
 prism run --no-build                        # Skip automatic container builds
 prism build [--force] [--runtime docker]    # Build container images from specs
 prism status [--universe NAME]              # Materialization + container status

--- a/claude/prism/templates/CLAUDE.md
+++ b/claude/prism/templates/CLAUDE.md
@@ -47,6 +47,17 @@ Three overlapping phases:
 
 **An output is not done until `prism run` produces it.** Running scripts directly is for debugging only — final results must always come from `prism run` so they are reproducible inside containers.
 
+### HPC / Interactive Execution
+
+If `SLURM_JOB_ID` is set in the environment, `prism run` automatically uses `srun` (instant) instead of `sbatch` (queued). This means the user is inside an interactive allocation and execution will be fast.
+
+If `SLURM_JOB_ID` is not set and the target is SLURM, `prism run` submits via `sbatch`. Pass scheduling flags:
+```bash
+prism run --qos shared --constraint gpu
+```
+
+Recipe `resources` (gpus, memory, cpus, time_limit) are portable and used for batch scheduling. They are ignored in interactive mode since the allocation already provides them.
+
 ### Spec-Code Invariant
 
 **`astra.yaml` must always reflect the code and vice versa.** When you change one, update the other immediately:
@@ -206,7 +217,7 @@ astra schema show analysis                    # Show JSON schema
 
 # prism -- execution operations
 prism run [OUTPUT] [--universe NAME]        # Execute recipes via Dagster (auto-builds)
-prism run --target perlmutter-gpu           # Execute on a specific SLURM target
+prism run --qos shared --constraint gpu     # Batch with specific scheduling
 prism run --no-build                        # Skip automatic container builds
 prism build [--force] [--runtime docker]    # Build container images from specs
 prism status [--universe NAME]              # Materialization + container status

--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -1051,11 +1051,15 @@ def _create_venv(directory: Path, no_venv: bool) -> bool:
 @click.argument("outputs", nargs=-1)
 @click.option("--universe", "-u", default=None, help="Universe to materialize for")
 @click.option("--target", "-t", default=None, help="Execution target name")
+@click.option("--qos", default=None, help="SLURM QOS (e.g. shared, debug, regular)")
+@click.option("--constraint", default=None, help="SLURM constraint (e.g. gpu, cpu)")
 @click.option("--no-build", is_flag=True, help="Skip automatic container image builds")
 def run(
     outputs: tuple[str, ...],
     universe: str | None,
     target: str | None,
+    qos: str | None,
+    constraint: str | None,
     no_build: bool,
 ) -> None:
     """Materialize ASTRA outputs via Dagster.
@@ -1069,7 +1073,8 @@ def run(
         prism run accuracy                  # specific output
         prism run --universe baseline       # specific universe
         prism run accuracy -u baseline      # specific output + universe
-        prism run --target perlmutter-gpu   # run on SLURM
+        prism run --target perlmutter       # run on SLURM
+        prism run --qos shared --constraint gpu  # override scheduling
         prism run --no-build                # skip container builds
     """
     from prism.dagster.assets import build_definitions
@@ -1093,6 +1098,29 @@ def run(
     target_config = None
     if target_name and target_name != "local":
         target_config = load_target(target_name)
+
+    # Apply CLI overrides for scheduling
+    if (qos or constraint) and target_config:
+        if qos:
+            target_config["qos"] = qos
+        if constraint:
+            target_config["constraint"] = constraint
+
+    # Warn if submitting a batch job without qos/constraint specified
+    import os
+    if (target_config and target_config.get("backend") == "slurm"
+            and not os.environ.get("SLURM_JOB_ID")):
+        if not target_config.get("qos"):
+            console.print(
+                "[yellow]Warning:[/yellow] No --qos specified for batch submission. "
+                "SLURM may reject the job or use site defaults. "
+                "Use --qos (e.g. shared, debug) or run from an interactive salloc session."
+            )
+        if not target_config.get("constraint"):
+            console.print(
+                "[yellow]Warning:[/yellow] No --constraint specified for batch submission. "
+                "Use --constraint (e.g. gpu, cpu) or run from an interactive salloc session."
+            )
 
     universe_id = universe or "baseline"
     defs = build_definitions(

--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -306,13 +306,10 @@ def init(
             from prism.dagster.targets import load_target
             target_config = load_target(target_name)
             if target_config and target_config.get("backend") == "slurm":
-                account = target_config.get("account", "<account>")
                 console.print(
-                    "\n[bold]Tip:[/bold] You're on a SLURM cluster. For fast execution, "
-                    "start an interactive allocation before launching Claude Code:"
-                    f"\n\n  [cyan]salloc -A {account} -q interactive -t 30 -n 1[/cyan]"
-                    "\n  [cyan]claude[/cyan]"
-                    "\n\n  This lets [cyan]prism run[/cyan] execute instantly via srun "
+                    "\n[bold]Tip:[/bold] For fast execution, start an interactive "
+                    "allocation ([cyan]salloc[/cyan]) before launching Claude Code. "
+                    "This lets [cyan]prism run[/cyan] execute instantly via srun "
                     "instead of waiting in the batch queue."
                 )
 

--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -1850,69 +1850,107 @@ def _run_setup_wizard() -> list[Path]:
         # --- HPC site selection ---
         known = list_known_sites()
         hpc_sites = [(k, d) for k, d in known if k != "local"]
-        console.print("\n  [bold]Known HPC sites:[/bold]")
+        console.print("\n  [bold]HPC sites:[/bold]")
         for i, (_key, display) in enumerate(hpc_sites, 1):
             console.print(f"    {i}. {display}")
+        console.print(f"    {len(hpc_sites) + 1}. Other SLURM cluster")
 
-        site_choices = [str(i) for i in range(1, len(hpc_sites) + 1)]
+        site_choices = [str(i) for i in range(1, len(hpc_sites) + 2)]
         site_idx = click.prompt(
             "\n  Select site",
             type=click.Choice(site_choices),
             default="1",
         )
-        site_key = hpc_sites[int(site_idx) - 1][0]
-        site = get_site_defaults(site_key) or {}
+        selected_idx = int(site_idx) - 1
 
-        display = site.get("display_name", site_key)
-        hostname = site.get("connection", {}).get("hostname", "")
-        console.print(
-            f"  Detected: [cyan]{display}[/cyan] ({hostname})\n"
-        )
+        if selected_idx < len(hpc_sites):
+            # --- Known site ---
+            site_key = hpc_sites[selected_idx][0]
+            site = get_site_defaults(site_key) or {}
 
-        # --- Connection ---
-        username = click.prompt(
-            "  Username",
-            default=os.environ.get("USER", ""),
-        )
-        account = click.prompt("  Account/allocation")
-
-        # --- Container runtime ---
-        site_runtimes = site.get("container_runtimes", [])
-        if len(site_runtimes) > 1:
-            console.print("\n  [bold]Container runtime:[/bold]")
-            for i, rt in enumerate(site_runtimes, 1):
-                console.print(f"    {i}. {rt}")
-
-            rt_choices = [
-                str(i) for i in range(1, len(site_runtimes) + 1)
-            ]
-            rt_idx = click.prompt(
-                "  Select runtime",
-                type=click.Choice(rt_choices),
-                default="1",
+            display = site.get("display_name", site_key)
+            hostname = site.get("connection", {}).get("hostname", "")
+            console.print(
+                f"  Detected: [cyan]{display}[/cyan] ({hostname})\n"
             )
-            container_runtime = site_runtimes[int(rt_idx) - 1]
-        elif site_runtimes:
-            container_runtime = site_runtimes[0]
+
+            username = click.prompt(
+                "  Username",
+                default=os.environ.get("USER", ""),
+            )
+            account = click.prompt("  Account/allocation")
+
+            # Container runtime — auto-select if only one
+            site_runtimes = site.get("container_runtimes", [])
+            if len(site_runtimes) > 1:
+                console.print("\n  [bold]Container runtime:[/bold]")
+                for i, rt in enumerate(site_runtimes, 1):
+                    console.print(f"    {i}. {rt}")
+                rt_choices = [
+                    str(i) for i in range(1, len(site_runtimes) + 1)
+                ]
+                rt_idx = click.prompt(
+                    "  Select runtime",
+                    type=click.Choice(rt_choices),
+                    default="1",
+                )
+                container_runtime = site_runtimes[int(rt_idx) - 1]
+            elif site_runtimes:
+                container_runtime = site_runtimes[0]
+            else:
+                container_runtime = None
+
+            default_name = f"{site_key}-{account}"
+            target_name = click.prompt("  Target name", default=default_name)
+
+            target_config: dict[str, Any] = {
+                "site": site_key,
+                "backend": site.get("backend", "slurm"),
+                "connection": {
+                    "hostname": hostname,
+                    "username": username,
+                },
+                "account": account,
+            }
+            if container_runtime:
+                target_config["container_runtime"] = container_runtime
+
         else:
-            container_runtime = site.get(
-                "scheduler", {},
-            ).get("container_runtime", "docker")
+            # --- Custom SLURM cluster ---
+            console.print("\n  [bold]Custom SLURM cluster[/bold]\n")
 
-        # --- Target name ---
-        default_name = f"{site_key}-{account}"
-        target_name = click.prompt("  Target name", default=default_name)
+            cluster_name = click.prompt("  Cluster name (e.g. frontier, summit)")
+            hostname = click.prompt("  Hostname", default=cluster_name)
+            username = click.prompt(
+                "  Username",
+                default=os.environ.get("USER", ""),
+            )
+            account = click.prompt("  Account/allocation")
 
-        target_config: dict[str, Any] = {
-            "site": site_key,
-            "backend": site.get("backend", "slurm"),
-            "connection": {
-                "hostname": hostname,
-                "username": username,
-            },
-            "account": account,
-            "container_runtime": container_runtime,
-        }
+            use_containers = click.confirm(
+                "  Use a container runtime?",
+                default=False,
+            )
+            container_runtime = None
+            if use_containers:
+                container_runtime = click.prompt(
+                    "  Container runtime",
+                    default="singularity",
+                )
+
+            default_name = f"{cluster_name}-{account}"
+            target_name = click.prompt("  Target name", default=default_name)
+
+            target_config = {
+                "backend": "slurm",
+                "connection": {
+                    "hostname": hostname,
+                    "username": username,
+                },
+                "account": account,
+            }
+            if container_runtime:
+                target_config["container_runtime"] = container_runtime
 
         path = save_target(target_name, target_config)
         saved_paths.append(path)

--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -1047,19 +1047,20 @@ def _create_venv(directory: Path, no_venv: bool) -> bool:
 # =============================================================================
 
 
-@main.command()
-@click.argument("outputs", nargs=-1)
+@main.command(context_settings={
+    "ignore_unknown_options": True,
+    "allow_extra_args": True,
+})
+@click.argument("outputs", nargs=-1, type=click.UNPROCESSED)
 @click.option("--universe", "-u", default=None, help="Universe to materialize for")
 @click.option("--target", "-t", default=None, help="Execution target name")
-@click.option("--qos", default=None, help="SLURM QOS (e.g. shared, debug, regular)")
-@click.option("--constraint", default=None, help="SLURM constraint (e.g. gpu, cpu)")
 @click.option("--no-build", is_flag=True, help="Skip automatic container image builds")
+@click.pass_context
 def run(
+    ctx: click.Context,
     outputs: tuple[str, ...],
     universe: str | None,
     target: str | None,
-    qos: str | None,
-    constraint: str | None,
     no_build: bool,
 ) -> None:
     """Materialize ASTRA outputs via Dagster.
@@ -1068,17 +1069,26 @@ def run(
     outputs for all universes. Container build specs are automatically
     built before execution unless --no-build is given.
 
+    Any unknown flags are passed through as SLURM scheduling directives
+    (e.g. --partition, --qos, --constraint, --gres).
+
     Examples:
         prism run                           # all outputs, all universes
         prism run accuracy                  # specific output
         prism run --universe baseline       # specific universe
         prism run accuracy -u baseline      # specific output + universe
         prism run --target perlmutter       # run on SLURM
-        prism run --qos shared --constraint gpu  # override scheduling
+        prism run --qos shared --constraint gpu  # SLURM scheduling flags
+        prism run --partition gpu-a100      # works for any cluster
         prism run --no-build                # skip container builds
     """
     from prism.dagster.assets import build_definitions
     from prism.dagster.targets import load_target
+
+    # Separate output names from SLURM flags in the combined args
+    all_args = list(outputs) + ctx.args
+    output_names = [a for a in all_args if not a.startswith("-")]
+    slurm_args = [a for a in all_args if a.startswith("-")]
 
     project_path = Path.cwd()
     if not (project_path / "astra.yaml").exists():
@@ -1099,28 +1109,9 @@ def run(
     if target_name and target_name != "local":
         target_config = load_target(target_name)
 
-    # Apply CLI overrides for scheduling
-    if (qos or constraint) and target_config:
-        if qos:
-            target_config["qos"] = qos
-        if constraint:
-            target_config["constraint"] = constraint
-
-    # Warn if submitting a batch job without qos/constraint specified
-    import os
-    if (target_config and target_config.get("backend") == "slurm"
-            and not os.environ.get("SLURM_JOB_ID")):
-        if not target_config.get("qos"):
-            console.print(
-                "[yellow]Warning:[/yellow] No --qos specified for batch submission. "
-                "SLURM may reject the job or use site defaults. "
-                "Use --qos (e.g. shared, debug) or run from an interactive salloc session."
-            )
-        if not target_config.get("constraint"):
-            console.print(
-                "[yellow]Warning:[/yellow] No --constraint specified for batch submission. "
-                "Use --constraint (e.g. gpu, cpu) or run from an interactive salloc session."
-            )
+    # Pass through any extra SLURM flags
+    if slurm_args and target_config:
+        target_config["extra_slurm_args"] = slurm_args
 
     universe_id = universe or "baseline"
     defs = build_definitions(
@@ -1134,8 +1125,8 @@ def run(
 
     # Select assets to materialize (exclude external/input-only assets)
     all_assets = list(defs.get_all_asset_specs())
-    if outputs:
-        selection = [dg.AssetKey([universe_id, o]) for o in outputs]
+    if output_names:
+        selection = [dg.AssetKey([universe_id, o]) for o in output_names]
     else:
         selection = [
             spec.key for spec in all_assets

--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -296,6 +296,26 @@ def init(
         "in [cyan].claude/settings.local.json[/cyan]."
     )
 
+    # Detect SLURM environment and suggest interactive allocation
+    if shutil.which("salloc") and not os.environ.get("SLURM_JOB_ID"):
+        target_name = target
+        if not target_name:
+            from prism.dagster.targets import load_user_config
+            target_name = load_user_config().get("default_target")
+        if target_name and target_name != "local":
+            from prism.dagster.targets import load_target
+            target_config = load_target(target_name)
+            if target_config and target_config.get("backend") == "slurm":
+                account = target_config.get("account", "<account>")
+                console.print(
+                    "\n[bold]Tip:[/bold] You're on a SLURM cluster. For fast execution, "
+                    "start an interactive allocation before launching Claude Code:"
+                    f"\n\n  [cyan]salloc -A {account} -q interactive -t 30 -n 1[/cyan]"
+                    "\n  [cyan]claude[/cyan]"
+                    "\n\n  This lets [cyan]prism run[/cyan] execute instantly via srun "
+                    "instead of waiting in the batch queue."
+                )
+
     console.print(f"\n[bold]cd {directory}[/bold] && [bold]claude[/bold]")
     console.print("Then run [cyan]/prism-new[/cyan] to scope your research question.")
 

--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -1900,7 +1900,8 @@ def _run_setup_wizard() -> list[Path]:
             ).get("container_runtime", "docker")
 
         # --- Target name ---
-        target_name = click.prompt("  Target name", default=site_key)
+        default_name = f"{site_key}-{account}"
+        target_name = click.prompt("  Target name", default=default_name)
 
         target_config: dict[str, Any] = {
             "site": site_key,

--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -1899,62 +1899,8 @@ def _run_setup_wizard() -> list[Path]:
                 "scheduler", {},
             ).get("container_runtime", "docker")
 
-        # --- Node type selection ---
-        node_types = site.get("node_types", {})
-        resource_limits = site.get("resource_limits", {})
-        nt_keys = list(node_types.keys())
-
-        if len(nt_keys) > 1:
-            console.print("\n  [bold]Node types:[/bold]")
-            for i, nt_key in enumerate(nt_keys, 1):
-                desc = node_types[nt_key].get("description", nt_key)
-                console.print(f"    {i}. {nt_key} — {desc}")
-
-            nt_choices = [str(i) for i in range(1, len(nt_keys) + 1)]
-            nt_idx = click.prompt(
-                "  Select node type",
-                type=click.Choice(nt_choices),
-                default="1",
-            )
-            selected_nt = nt_keys[int(nt_idx) - 1]
-        elif nt_keys:
-            selected_nt = nt_keys[0]
-        else:
-            selected_nt = "default"
-
-        # --- QOS selection ---
-        qos_options = site.get("qos_options", {})
-        qos_keys = list(qos_options.keys())
-
-        if len(qos_keys) > 1:
-            # Find default QOS
-            qos_default_idx = "1"
-            for i, qk in enumerate(qos_keys, 1):
-                if qos_options[qk].get("default"):
-                    qos_default_idx = str(i)
-                    break
-
-            console.print("\n  [bold]QOS:[/bold]")
-            for i, qk in enumerate(qos_keys, 1):
-                desc = qos_options[qk].get("description", qk)
-                console.print(f"    {i}. {qk} — {desc}")
-
-            qos_choices = [str(i) for i in range(1, len(qos_keys) + 1)]
-            qos_idx = click.prompt(
-                "  Select QOS",
-                type=click.Choice(qos_choices),
-                default=qos_default_idx,
-            )
-            selected_qos = qos_keys[int(qos_idx) - 1]
-        elif qos_keys:
-            selected_qos = qos_keys[0]
-        else:
-            selected_qos = site.get("safe_defaults", {}).get("qos", "regular")
-
         # --- Target name ---
-        nt_info = node_types.get(selected_nt, {})
-        default_name = f"{site_key}-{selected_nt}"
-        target_name = click.prompt("  Target name", default=default_name)
+        target_name = click.prompt("  Target name", default=site_key)
 
         target_config: dict[str, Any] = {
             "site": site_key,
@@ -1965,35 +1911,7 @@ def _run_setup_wizard() -> list[Path]:
             },
             "account": account,
             "container_runtime": container_runtime,
-            "constraint": nt_info.get("constraint", selected_nt),
-            "qos": selected_qos,
         }
-
-        # --- Resource limits ---
-        console.print("\n  [bold]Resource limits[/bold]")
-        console.print("  (these cap what Claude can request per job)\n")
-
-        max_nodes = click.prompt(
-            "  Max nodes per job",
-            type=int,
-            default=resource_limits.get("max_nodes", 4),
-        )
-        target_config["max_nodes"] = max_nodes
-
-        max_walltime = click.prompt(
-            "  Max walltime (minutes)",
-            type=int,
-            default=resource_limits.get("max_walltime_minutes", 360),
-        )
-        target_config["max_walltime_minutes"] = max_walltime
-
-        max_concurrent = click.prompt(
-            "  Max concurrent jobs",
-            type=int,
-            default=resource_limits.get("max_concurrent_jobs", 8),
-        )
-        target_config["max_concurrent_jobs"] = max_concurrent
-
 
         path = save_target(target_name, target_config)
         saved_paths.append(path)

--- a/src/prism/dagster/assets.py
+++ b/src/prism/dagster/assets.py
@@ -217,7 +217,7 @@ def build_definitions(
         # Transform flat target_config into the shape the runner expects
         runner_config = {"connection": target_config.get("connection", {})}
         scheduler = {}
-        for key in ("account", "qos", "constraint", "node_type",
+        for key in ("site", "account", "qos", "constraint", "node_type",
                      "container_runtime", "container_flags",
                      "nodes", "time_limit"):
             if target_config.get(key) is not None:

--- a/src/prism/dagster/assets.py
+++ b/src/prism/dagster/assets.py
@@ -219,7 +219,7 @@ def build_definitions(
         scheduler = {}
         for key in ("site", "account", "qos", "constraint", "node_type",
                      "container_runtime", "container_flags",
-                     "nodes", "time_limit"):
+                     "nodes", "time_limit", "extra_slurm_args"):
             if target_config.get(key) is not None:
                 scheduler[key] = target_config[key]
         if scheduler:

--- a/src/prism/dagster/runner.py
+++ b/src/prism/dagster/runner.py
@@ -582,22 +582,36 @@ def translate_resources_to_slurm_directives(
     scheduler_config = scheduler_config or {}
     directives: list[str] = []
 
-    account = scheduler_config.get("account")
-    constraint = scheduler_config.get("constraint")
+    # Extra SLURM args from CLI passthrough (e.g. --partition, --qos, --constraint)
+    extra_args = scheduler_config.get("extra_slurm_args", [])
 
+    # Helper to check if a flag is already in extra args (CLI overrides target)
+    def _in_extra(flag: str) -> bool:
+        return any(a.startswith(flag) for a in extra_args)
+
+    # Extract constraint from extra args for account suffix resolution
+    constraint = scheduler_config.get("constraint")
+    for arg in extra_args:
+        if arg.startswith("--constraint"):
+            constraint = arg.split("=", 1)[1] if "=" in arg else None
+
+    account = scheduler_config.get("account")
     # Apply site-specific account suffix (e.g. _g for GPU on Perlmutter)
-    if account:
+    if account and not _in_extra("--account"):
         site_key = scheduler_config.get("site")
         if site_key and constraint:
             from prism.dagster.site_registry import resolve_account
             account = resolve_account(site_key, account, constraint)
         directives.append(f"--account={account}")
-    if partition := scheduler_config.get("partition"):
-        directives.append(f"--partition={partition}")
-    if qos := scheduler_config.get("qos"):
-        directives.append(f"--qos={qos}")
-    if constraint:
-        directives.append(f"--constraint={constraint}")
+    if not _in_extra("--partition"):
+        if partition := scheduler_config.get("partition"):
+            directives.append(f"--partition={partition}")
+    if not _in_extra("--qos"):
+        if qos := scheduler_config.get("qos"):
+            directives.append(f"--qos={qos}")
+    if not _in_extra("--constraint"):
+        if constraint:
+            directives.append(f"--constraint={constraint}")
 
     if nodes := resources.get("nodes"):
         directives.append(f"--nodes={nodes}")
@@ -605,8 +619,9 @@ def translate_resources_to_slurm_directives(
         directives.append(f"--cpus-per-task={cpus}")
     if memory := resources.get("memory"):
         directives.append(f"--mem={memory}")
-    if gpus := resources.get("gpus"):
-        directives.append(f"--gpus={gpus}")
+    if not _in_extra("--gpus"):
+        if gpus := resources.get("gpus"):
+            directives.append(f"--gpus={gpus}")
     if time_limit := resources.get("time_limit"):
         directives.append(f"--time={_normalise_time_limit(time_limit)}")
     elif resource_limits is not None:
@@ -619,6 +634,9 @@ def translate_resources_to_slurm_directives(
             default_minutes,
         )
         directives.append(f"--time={_normalise_time_limit(default_minutes)}")
+
+    # Append any extra SLURM flags passed through from the CLI
+    directives.extend(extra_args)
 
     return directives
 

--- a/src/prism/dagster/runner.py
+++ b/src/prism/dagster/runner.py
@@ -356,6 +356,76 @@ class ASTRAContainerRunner:
             marker.write_text(current_hash + "\n")
         self._venv_deps_checked = True
 
+    def _run_slurm_interactive(
+        self,
+        command: str,
+        container: str | None,
+        output_id: str,
+        universe_id: str,
+        resources: dict[str, Any],
+        external_inputs: dict[str, str] | None = None,
+    ) -> ExecutionResult:
+        """Execute a recipe via srun inside an existing interactive allocation.
+
+        Runs synchronously — no job submission or polling needed.
+        """
+        scheduler = self.target_config.get("scheduler", {})
+        container_runtime = scheduler.get("container_runtime", "podman-hpc")
+
+        output_path = self.project_root / "results" / universe_id
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        # Build the execution command
+        if container and container_runtime == "podman-hpc":
+            exec_command = _podman_hpc_run_command(
+                command, container, self.project_root, resources, scheduler,
+                external_inputs=external_inputs,
+            )
+        else:
+            # No container — symlink external inputs into data/ directory
+            if external_inputs:
+                data_dir = self.project_root / "data"
+                data_dir.mkdir(parents=True, exist_ok=True)
+                for input_id, source in sorted(external_inputs.items()):
+                    link = data_dir / input_id
+                    if link.is_symlink() or link.exists():
+                        link.unlink()
+                    link.symlink_to(source)
+            exec_command = command
+
+        cmd = ["srun", "bash", "-c", exec_command]
+
+        logger.info(
+            "Running %s/%s interactively (SLURM_JOB_ID=%s)",
+            output_id, universe_id, os.environ.get("SLURM_JOB_ID"),
+        )
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=str(self.project_root),
+            )
+        except FileNotFoundError:
+            return ExecutionResult(
+                exit_code=127,
+                output_path=output_path,
+                metadata={"stderr": "srun: command not found"},
+            )
+
+        return ExecutionResult(
+            exit_code=result.returncode,
+            output_path=output_path,
+            metadata={
+                "backend": "slurm-interactive",
+                "slurm_job_id": os.environ.get("SLURM_JOB_ID", ""),
+                "container_runtime": container_runtime if container else None,
+                "stdout": result.stdout[-2000:] if result.stdout else "",
+                "stderr": result.stderr[-2000:] if result.stderr else "",
+            },
+        )
+
     def _run_slurm(
         self,
         command: str,
@@ -366,13 +436,24 @@ class ASTRAContainerRunner:
         resources: dict[str, Any],
         external_inputs: dict[str, str] | None = None,
     ) -> ExecutionResult:
-        """Execute a recipe via SLURM on a login node.
+        """Execute a recipe via SLURM.
 
-        Generates an sbatch script with the appropriate container runtime
-        (podman-hpc or shifter), submits it, and polls for completion.
-        Assumes we are running on a login node with access to sbatch/squeue/sacct
-        and the project directory is on a shared filesystem.
+        When ``SLURM_JOB_ID`` is set (i.e. we are inside an interactive
+        ``salloc`` session), runs the command synchronously via ``srun``
+        for fast iteration.  Otherwise, generates an sbatch script,
+        submits it, and polls for completion.
         """
+        # Fast path: interactive allocation detected
+        if os.environ.get("SLURM_JOB_ID"):
+            return self._run_slurm_interactive(
+                command=command,
+                container=container,
+                output_id=output_id,
+                universe_id=universe_id,
+                resources=resources,
+                external_inputs=external_inputs,
+            )
+
         scheduler = self.target_config.get("scheduler", {})
         container_runtime = scheduler.get("container_runtime", "podman-hpc")
 

--- a/src/prism/dagster/runner.py
+++ b/src/prism/dagster/runner.py
@@ -582,13 +582,21 @@ def translate_resources_to_slurm_directives(
     scheduler_config = scheduler_config or {}
     directives: list[str] = []
 
-    if account := scheduler_config.get("account"):
+    account = scheduler_config.get("account")
+    constraint = scheduler_config.get("constraint")
+
+    # Apply site-specific account suffix (e.g. _g for GPU on Perlmutter)
+    if account:
+        site_key = scheduler_config.get("site")
+        if site_key and constraint:
+            from prism.dagster.site_registry import resolve_account
+            account = resolve_account(site_key, account, constraint)
         directives.append(f"--account={account}")
     if partition := scheduler_config.get("partition"):
         directives.append(f"--partition={partition}")
     if qos := scheduler_config.get("qos"):
         directives.append(f"--qos={qos}")
-    if constraint := scheduler_config.get("constraint"):
+    if constraint:
         directives.append(f"--constraint={constraint}")
 
     if nodes := resources.get("nodes"):

--- a/src/prism/dagster/site_registry.py
+++ b/src/prism/dagster/site_registry.py
@@ -59,6 +59,10 @@ SITE_DEFAULTS: dict[str, dict[str, Any]] = {
             "nodes": 1,
             "time_limit": "30m",
         },
+        "account_suffixes": {
+            "gpu": "_g",
+            "gpu&hbm80g": "_g",
+        },
         "scratch_paths": [
             "//pscratch/**",
             "//global/cscratch1/**",
@@ -107,6 +111,22 @@ def list_known_sites() -> list[tuple[str, str]]:
         (key, site.get("display_name", key))
         for key, site in SITE_DEFAULTS.items()
     ]
+
+
+def resolve_account(site_key: str, account: str, constraint: str | None) -> str:
+    """Apply site-specific account suffix based on constraint.
+
+    For example, on Perlmutter GPU jobs require ``m4031_g`` instead of
+    ``m4031``.  If the account already has the suffix, it is not added again.
+    """
+    site = SITE_DEFAULTS.get(site_key)
+    if not site or not constraint:
+        return account
+    suffixes = site.get("account_suffixes", {})
+    suffix = suffixes.get(constraint)
+    if suffix and not account.endswith(suffix):
+        return account + suffix
+    return account
 
 
 def get_site_scratch_deny_rules(site_key: str) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -361,27 +361,24 @@ class TestSetupCommand:
                             lambda: tmp_path / "config.yaml")
 
         # hpc=yes, site=1(perlmutter), username, account,
-        # node_type=1(gpu), qos=2(debug), target_name=default,
-        # resource limits=defaults (4x Enter)
-        input_lines = "y\n1\ntestuser\nm1234\n1\n2\n\n\n\n\n\n"
+        # target_name=default (accept perlmutter-m1234)
+        input_lines = "y\n1\ntestuser\nm1234\n\n"
         result = runner.invoke(main, ["setup"], input=input_lines)
         assert result.exit_code == 0
-        assert "Default target: perlmutter-gpu" in result.output
+        assert "Default target: perlmutter-m1234" in result.output
 
-        # Should create only the selected node type + local
-        assert (targets_dir / "perlmutter-gpu.yaml").exists()
-        assert not (targets_dir / "perlmutter-gpu_hbm80.yaml").exists()
-        assert not (targets_dir / "perlmutter-cpu.yaml").exists()
+        # Should create the target + local
+        assert (targets_dir / "perlmutter-m1234.yaml").exists()
         assert (targets_dir / "local.yaml").exists()
         assert (tmp_path / "config.yaml").exists()
 
-        # Verify target shape — flat, no defaults nesting
+        # Verify target shape — site, backend, connection, account
         import yaml
-        target = yaml.safe_load((targets_dir / "perlmutter-gpu.yaml").read_text())
-        assert target["constraint"] == "gpu"
-        assert target["qos"] == "debug"
+        target = yaml.safe_load((targets_dir / "perlmutter-m1234.yaml").read_text())
+        assert target["site"] == "perlmutter"
         assert target["backend"] == "slurm"
-        assert target["max_nodes"] == 4
+        assert target["account"] == "m1234"
+        assert target["container_runtime"] == "podman-hpc"
 
         # Verify closing message
         assert "prism target --list" in result.output
@@ -423,15 +420,14 @@ class TestSetupCommand:
                             lambda: tmp_path / "config.yaml")
 
         # hpc=yes, site=1(perlmutter), username, account,
-        # node_type=1(gpu), qos=2(debug), target_name=default,
-        # resource limits=defaults (4x Enter)
-        input_lines = "y\n1\ntestuser\nm1234\n1\n2\n\n\n\n\n\n"
+        # target_name=default (accept perlmutter-m1234)
+        input_lines = "y\n1\ntestuser\nm1234\n\n"
         result = runner.invoke(main, ["setup"], input=input_lines)
         assert result.exit_code == 0
 
         import yaml
         config = yaml.safe_load((tmp_path / "config.yaml").read_text())
-        assert config["default_target"] == "perlmutter-gpu"
+        assert config["default_target"] == "perlmutter-m1234"
 
     def test_setup_default_local(self, runner: CliRunner, tmp_path: Path, monkeypatch):
         """Test --default local works without a target config file."""


### PR DESCRIPTION
## Summary

- **Interactive SLURM execution:** When `SLURM_JOB_ID` is set (user is inside `salloc`), `prism run` automatically uses `srun` for instant synchronous execution instead of `sbatch` + polling
- **SLURM flag passthrough:** Any unknown flags on `prism run` are forwarded as `#SBATCH` directives, making it work for any SLURM cluster (e.g. `--partition gpu-a100`, `--qos shared`, `--constraint gpu`, `--gres=gpu:4`)
- **Simplified setup wizard:** Target config is now just site + account + container runtime. Node type, QOS, and resource limits removed from setup
- **Custom cluster support:** Setup wizard has "Other SLURM cluster" option for non-NERSC sites
- **Auto GPU account suffix:** NERSC `_g` account suffix applied automatically based on constraint via site registry
- **Target naming:** Defaults to `sitename-account` (e.g. `perlmutter-m4031`) for multi-account users
- **Build loop awareness:** Loop prompt checks for interactive allocation before materializing on SLURM targets

## Test plan

- [ ] Run `prism run` inside an `salloc` session — verify it uses `srun` and executes immediately
- [ ] Run `prism run --qos shared --constraint gpu` outside `salloc` — verify flags appear in sbatch script
- [ ] Run `prism run --partition gpu-a100` — verify passthrough works for non-NERSC flags
- [ ] Run `prism setup` — verify simplified wizard (no node type/QOS prompts)
- [ ] Run `prism setup` and select "Other SLURM cluster" — verify custom cluster flow
- [ ] Verify GPU account suffix: m4031 + --constraint gpu produces --account=m4031_g in sbatch
- [ ] Verify existing batch submission path still works unchanged