### PR TITLE
Revise decision guide to reduce over-pruning

### DIFF
--- a/claude/prism/guides/decision-guide.md
+++ b/claude/prism/guides/decision-guide.md
@@ -1,39 +1,37 @@
 # Decision Guide
 
+## What Is a Decision?
+
+A decision is a methodological choice where a different defensible option could plausibly produce a different numerical result. Include it if changing the choice could shift a quantitative outcome — even modestly. Many small decisions can compound.
+
+**Not decisions — skip these:**
+
+- **Tooling choices** that produce identical numerical results: programming language, library/framework (PyTorch vs TensorFlow), file format, parallelization strategy, plotting style.
+- **Fixed constraints** with no degrees of freedom: "use the data that exists," "satisfy the grant requirements."
+- **What to produce** — decisions control *how* something is computed, not *what* outputs exist. Outputs are fixed by the analysis structure.
+
+**These ARE decisions — do not skip:**
+
+- Algorithmic choices (MCMC vs optimization, KDE vs histogram, smoothing method)
+- Numerical parameters and thresholds (sigma clipping level, bin width, convergence criterion, iteration count)
+- Statistical method choices (bootstrap vs analytic errors, Bayesian vs frequentist)
+- Data selection criteria (quality cuts, magnitude limits, spatial boundaries)
+- Correction and calibration choices (which reddening law, which zero-point, which prior)
+
+When in doubt, include it. A multiverse with a few extra decisions is more informative than one that silently bakes in unjustified choices.
+
+---
+
 ## Decision Prioritization
 
 Evaluate every candidate decision before adding it to the spec.
 
 **Flowchart:**
-1. Does literature/domain knowledge clearly favor one option? --> Prefer that option as `default` and keep alternatives only if reviewer scrutiny is likely.
-2. Are the options expected to give similar results? --> Include alternatives if they are still useful for robustness checks.
+1. Does domain knowledge clearly favor one option? --> Prefer that option as `default`, but still include alternatives if a different choice could shift results.
+2. Are the options expected to give similar results? --> Include as a robustness check — even small effects compound across decisions.
 3. Neither clear? --> Include alternatives and record why uncertainty remains in `rationale`.
 
-**Rationale guidance:** Document why options are included and what evidence/theory supports them, e.g.: `"Literature uses both 2.5 and 3 SD cutoffs with no consensus"`.
-
----
-
-## Stability Test
-
-A decision matters if changing it changes the conclusion. If all options give qualitatively similar results, the choice is cosmetic -- skip it.
-
----
-
-## Not Decisions
-
-Skip these: fixed requirements (constraints), implementation details (build phase), obvious best practices with no defensible alternative, purely cosmetic choices, **whether or not to include an output** (decisions control *how* something is computed, not *what* is produced -- outputs are fixed by the analysis structure).
-
----
-
-## Scoping
-
-A multiverse of trivial decisions is less informative than a focused one.
-
-| Tier | Criterion |
-|------|-----------|
-| **1 -- Must vary** | Literature/domain knowledge suggests the choice matters. |
-| **2 -- Should vary** | Impact uncertain but plausible. Include if feasible. |
-| **3 -- Could vary** | Impact likely small. Defer unless core multiverse is manageable. |
+**Rationale guidance:** Document why options are included and what supports them, e.g.: `"Literature uses both 2.5 and 3 SD cutoffs with no consensus"`.
 
 ---
 
@@ -41,5 +39,6 @@ A multiverse of trivial decisions is less informative than a focused one.
 
 Use constraints when decisions are not independent.
 
+- **Conditional existence** (`when` on decision) -- downstream decision only exists given an upstream choice. E.g., `svm_kernel` only exists `when: model.svm`.
 - **Incompatibility** (`incompatible_with` on option) -- two options cannot coexist in a universe.
 - **Requirement** (`requires` on option) -- selecting one option forces another.


### PR DESCRIPTION
## Summary
- Rewrote `claude/prism/guides/decision-guide.md` to fix systematic over-pruning in the specify phase
- The old guide's three compounding filters (stability test, "Not Decisions", tier system) caused >90% of identified decisions to be dropped — in a test paper with ~40 methodological choices, only 3 survived to astra.yaml
- New guide uses a clearer definition: a decision is anything where a different defensible option could plausibly shift a numerical result
- Explicit "IS a decision" list (algorithmic choices, thresholds, statistical methods, data selection, calibration)
- Explicit "NOT a decision" list (tooling that produces identical results, fixed constraints, output selection)

## Test plan
- [ ] Re-run Paper2ASTRA specify phase on a test paper and verify more decisions survive
- [ ] Run `prism init` on a new project and verify the updated guide is copied
- [ ] Check `prism update --sync` picks up the new guide for existing projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)