### PR TITLE
Fix prism run crash with dagster 1.13: replace removed get_all_asset_specs

### DIFF
--- a/src/prism/cli.py
+++ b/src/prism/cli.py
@@ -1171,7 +1171,7 @@ def run(
     import dagster as dg
 
     # Select assets to materialize (exclude external/input-only assets)
-    all_assets = list(defs.get_all_asset_specs())
+    all_assets = list(defs.resolve_all_asset_specs())
     if output_names:
         # Support dot-notation: hod_fitting.galaxy_mesh -> [universe, hod_fitting, galaxy_mesh]
         selection = [dg.AssetKey([universe_id] + o.split(".")) for o in output_names]

--- a/src/prism/eval/build.py
+++ b/src/prism/eval/build.py
@@ -65,7 +65,7 @@ def _build_wheel(repo_root: Path, outdir: Path) -> Path:
     if result.returncode != 0:
         raise RuntimeError(f"Wheel build failed:\n{result.stderr}")
 
-    wheels = list(outdir.glob("prism-*.whl"))
+    wheels = list(outdir.glob("lightcone_prism-*.whl"))
     if not wheels:
         raise RuntimeError(f"No prism wheel found in {outdir} after build")
     return wheels[0]


### PR DESCRIPTION
dagster 1.13.0 removed `Definitions.get_all_asset_specs()` and replaced it with `Definitions.resolve_all_asset_specs()`. This caused `prism run` to crash immediately with an `AttributeError` on all invocations.

Fixes #63

Generated with [Claude Code](https://claude.ai/code)