### PR TITLE
Add uv.lock to gitignore and fix eval wheel glob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,7 @@ __marimo__/
 
 dev
 eval-results
+
+# UV
+## lockfile should be versioned for applications but not for libraries
+uv.lock

--- a/src/prism/eval/build.py
+++ b/src/prism/eval/build.py
@@ -65,9 +65,9 @@ def _build_wheel(repo_root: Path, outdir: Path) -> Path:
     if result.returncode != 0:
         raise RuntimeError(f"Wheel build failed:\n{result.stderr}")
 
-    wheels = list(outdir.glob("prism-*.whl"))
+    wheels = list(outdir.glob("lightcone_prism-*.whl"))
     if not wheels:
-        raise RuntimeError(f"No prism wheel found in {outdir} after build")
+        raise RuntimeError(f"No lightcone_prism wheel found in {outdir} after build")
     return wheels[0]
 
 


### PR DESCRIPTION
## Summary

- Add `uv.lock` to `.gitignore`
- Fix eval CI failure: update wheel glob from `prism-*.whl` to `lightcone_prism-*.whl` to match the package rename in #62

## Test plan

- [ ] Eval CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- dco-signed-off-by -->
Signed-off-by: Alexandre Boucaud <aboucaud@apc.in2p3.fr>
Signed-off-by: Francois Lanusse <fr.eiffel@gmail.com>