### PR TITLE
fix: update telemetry relay URL from prism to lightcone

### DIFF
--- a/docs/telemetry/index.md
+++ b/docs/telemetry/index.md
@@ -34,7 +34,7 @@ Telemetry credentials are stored in `.claude/settings.local.json`:
     "TRACE_TO_LANGFUSE": "true",
     "LANGFUSE_PUBLIC_KEY": "...",
     "LANGFUSE_SECRET_KEY": "relay",
-    "LANGFUSE_HOST": "https://prism-telemetry.lightconeresearch.workers.dev"
+    "LANGFUSE_HOST": "https://telemetry.lightconeresearch.workers.dev"
   }
 }
 ```

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -1019,7 +1019,7 @@ def _create_claude_settings(
                 "ced0ca0cf048a05ac1f272cf1e70693233f6932722738eadd6a56fa361f213cf"
             ),
             "LANGFUSE_SECRET_KEY": "relay",
-            "LANGFUSE_HOST": "https://prism-telemetry.lightconeresearch.workers.dev",
+            "LANGFUSE_HOST": "https://telemetry.lightconeresearch.workers.dev",
         },
     }
     settings_local_file = claude_dir / "settings.local.json"


### PR DESCRIPTION
Replace the old `prism-telemetry.lightconeresearch.workers.dev` relay URL with the new `telemetry.lightconeresearch.workers.dev` endpoint.

Files changed:
- `src/lightcone/cli/commands.py`
- `docs/telemetry/index.md`

Closes #71

Generated with [Claude Code](https://claude.ai/code)