### PR TITLE
feat: post-materialization result file validation

### DIFF
--- a/src/lightcone/engine/assets.py
+++ b/src/lightcone/engine/assets.py
@@ -13,7 +13,9 @@ from lightcone.engine.runner import ASTRAContainerRunner
 from lightcone.engine.tree import (
     TreeOutput,
     collect_tree_outputs,
+    resolve_output_path,
 )
+from lightcone.engine.validation import validate_output
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +150,7 @@ def build_asset_definitions(
                 local_runtime=local_runtime, external_inputs=sub_external,
                 key_prefix=key_prefix, group_name=group_name,
                 dep_keys=dep_keys, tree_output=tree_out, spec=spec,
+                output_type=output_def.get("type"),
             )
         )
 
@@ -258,6 +261,7 @@ def _build_single_asset(
     dep_keys: list[dg.AssetKey] | None = None,
     tree_output: TreeOutput | None = None,
     spec: dict[str, Any] | None = None,
+    output_type: str | None = None,
 ) -> dg.AssetsDefinition:
     """Build a single Dagster asset from an output recipe."""
     input_ids = recipe.get("inputs") or []
@@ -327,6 +331,14 @@ def _build_single_asset(
                 f"Recipe for '{output_id}' failed (exit code {result.exit_code})"
                 f"{': ' + stderr if stderr else ''}"
             )
+        # Post-materialization validation: warn on suspicious output files.
+        if project_path is not None:
+            if tree_output is not None:
+                out_dir = resolve_output_path(project_path, tree_output, universe_id) / output_id
+            else:
+                out_dir = result.output_path / output_id
+            for warning in validate_output(out_dir, output_type, output_id):
+                context.log.warning(warning)
         return dg.MaterializeResult(
             metadata={
                 "exit_code": result.exit_code,

--- a/src/lightcone/engine/validation.py
+++ b/src/lightcone/engine/validation.py
@@ -1,0 +1,180 @@
+"""Post-materialization result file validation for ASTRA outputs."""
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def validate_output(
+    output_dir: Path,
+    output_type: str | None,
+    output_id: str,
+) -> list[str]:
+    """Validate result files after a successful recipe run.
+
+    Returns a list of warning strings. An empty list means no issues detected.
+    Never raises — all errors are surfaced as warning strings.
+    """
+    if not output_dir.exists():
+        return [f"Output directory missing after successful run: {output_dir}"]
+    if not output_dir.is_dir():
+        return []
+
+    try:
+        files = list(output_dir.iterdir())
+    except OSError:
+        return []
+
+    if not files:
+        return [f"Output directory is empty after successful run: {output_dir}"]
+
+    if output_type == "metric":
+        return _validate_metric(output_dir, output_id)
+    if output_type == "table":
+        return _validate_table(output_dir, output_id)
+    if output_type == "figure":
+        return _validate_figure(output_dir, output_id)
+    return []
+
+
+def _validate_metric(output_dir: Path, output_id: str) -> list[str]:
+    json_files = list(output_dir.glob("*.json"))
+    if not json_files:
+        return [
+            f"Output '{output_id}' (type: metric) produced no JSON files in {output_dir}"
+        ]
+
+    warnings: list[str] = []
+    for json_file in json_files:
+        try:
+            data: Any = json.loads(json_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            warnings.append(
+                f"Output '{output_id}': metric file '{json_file.name}' "
+                f"is not valid JSON: {exc}"
+            )
+            continue
+
+        if _all_scalars_null(data):
+            warnings.append(
+                f"Output '{output_id}': metric file '{json_file.name}' "
+                f"contains only null/NaN values"
+            )
+
+    return warnings
+
+
+def _validate_table(output_dir: Path, output_id: str) -> list[str]:
+    csv_files = list(output_dir.glob("*.csv"))
+    if not csv_files:
+        return [
+            f"Output '{output_id}' (type: table) produced no CSV files in {output_dir}"
+        ]
+
+    warnings: list[str] = []
+    for csv_file in csv_files:
+        try:
+            warnings.extend(_check_csv_nan(csv_file, output_id))
+        except (OSError, csv.Error) as exc:
+            warnings.append(
+                f"Output '{output_id}': could not validate table '{csv_file.name}': {exc}"
+            )
+    return warnings
+
+
+def _check_csv_nan(csv_file: Path, output_id: str) -> list[str]:
+    with open(csv_file, newline="", encoding="utf-8", errors="replace") as fh:
+        reader = csv.DictReader(fh)
+        rows = list(reader)
+
+    if not rows:
+        return [
+            f"Output '{output_id}': table file '{csv_file.name}' has no data rows"
+        ]
+
+    fieldnames = list(rows[0].keys())
+    all_nan_cols: list[str] = []
+    numeric_cols: list[str] = []
+
+    for col in fieldnames:
+        numeric_vals: list[float] = []
+        for row in rows:
+            raw = row.get(col, "")
+            try:
+                numeric_vals.append(float(raw))
+            except (ValueError, TypeError):
+                pass
+        if numeric_vals:
+            numeric_cols.append(col)
+            if all(math.isnan(v) for v in numeric_vals):
+                all_nan_cols.append(col)
+
+    if not numeric_cols:
+        return []
+
+    if len(all_nan_cols) == len(numeric_cols):
+        return [
+            f"Output '{output_id}': table file '{csv_file.name}' "
+            f"has all-NaN values in every numeric column"
+        ]
+    if all_nan_cols:
+        cols = ", ".join(f"'{c}'" for c in all_nan_cols)
+        return [
+            f"Output '{output_id}': table file '{csv_file.name}' "
+            f"has all-NaN values in column(s): {cols}"
+        ]
+    return []
+
+
+def _validate_figure(output_dir: Path, output_id: str) -> list[str]:
+    figure_exts = {".png", ".jpg", ".jpeg", ".svg", ".pdf", ".eps"}
+    figure_files = [
+        f for f in output_dir.iterdir()
+        if f.is_file() and f.suffix.lower() in figure_exts
+    ]
+
+    if not figure_files:
+        return [
+            f"Output '{output_id}' (type: figure) produced no image files "
+            f"(.png, .jpg, .svg, .pdf, .eps) in {output_dir}"
+        ]
+
+    return [
+        f"Output '{output_id}': figure file '{fig.name}' is empty (0 bytes)"
+        for fig in figure_files
+        if fig.stat().st_size == 0
+    ]
+
+
+def _all_scalars_null(data: Any) -> bool:
+    """Return True if every scalar in the JSON structure is null or NaN."""
+    scalars = _collect_scalars(data)
+    return bool(scalars) and all(_is_null_scalar(s) for s in scalars)
+
+
+def _collect_scalars(data: Any) -> list[Any]:
+    if isinstance(data, dict):
+        result: list[Any] = []
+        for v in data.values():
+            result.extend(_collect_scalars(v))
+        return result
+    if isinstance(data, list):
+        result = []
+        for item in data:
+            result.extend(_collect_scalars(item))
+        return result
+    return [data]
+
+
+def _is_null_scalar(v: Any) -> bool:
+    if v is None:
+        return True
+    if isinstance(v, float) and math.isnan(v):
+        return True
+    return False

--- a/src/lightcone/engine/validation.py
+++ b/src/lightcone/engine/validation.py
@@ -24,7 +24,7 @@ def validate_output(
     if not output_dir.exists():
         return [f"Output directory missing after successful run: {output_dir}"]
     if not output_dir.is_dir():
-        return []
+        return [f"Output '{output_id}': expected a directory at {output_dir}, found a file"]
 
     try:
         files = list(output_dir.iterdir())

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,199 @@
+"""Tests for post-materialization result file validation."""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from lightcone.engine.validation import validate_output
+
+
+class TestValidateOutputCommon:
+    def test_missing_directory_warns(self, tmp_path: Path) -> None:
+        warnings = validate_output(tmp_path / "nonexistent", "metric", "my_output")
+        assert len(warnings) == 1
+        assert "missing" in warnings[0]
+
+    def test_empty_directory_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "output"
+        out_dir.mkdir()
+        warnings = validate_output(out_dir, "metric", "my_output")
+        assert len(warnings) == 1
+        assert "empty" in warnings[0]
+
+    def test_unknown_type_skips_content_check(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "output"
+        out_dir.mkdir()
+        (out_dir / "data.bin").write_bytes(b"\x00" * 100)
+        assert validate_output(out_dir, "data", "my_output") == []
+
+    def test_none_type_skips_content_check(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "output"
+        out_dir.mkdir()
+        (out_dir / "data.bin").write_bytes(b"\x00" * 100)
+        assert validate_output(out_dir, None, "my_output") == []
+
+
+class TestValidateMetric:
+    def test_valid_json_no_warning(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "metric.json").write_text(json.dumps({"value": 0.95, "count": 100}))
+        assert validate_output(out_dir, "metric", "result") == []
+
+    def test_missing_json_file_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "output.txt").write_text("some text")
+        warnings = validate_output(out_dir, "metric", "result")
+        assert len(warnings) == 1
+        assert "no JSON files" in warnings[0]
+
+    def test_invalid_json_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "metric.json").write_text("not valid json {{{")
+        warnings = validate_output(out_dir, "metric", "result")
+        assert len(warnings) == 1
+        assert "not valid JSON" in warnings[0]
+
+    def test_all_null_dict_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "metric.json").write_text(json.dumps({"a": None, "b": None}))
+        warnings = validate_output(out_dir, "metric", "result")
+        assert len(warnings) == 1
+        assert "null/NaN" in warnings[0]
+
+    def test_null_scalar_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "metric.json").write_text("null")
+        warnings = validate_output(out_dir, "metric", "result")
+        assert len(warnings) == 1
+        assert "null/NaN" in warnings[0]
+
+    def test_partial_null_no_warning(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "metric.json").write_text(json.dumps({"a": None, "b": 1.0}))
+        assert validate_output(out_dir, "metric", "result") == []
+
+    def test_empty_dict_no_warning(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "metric.json").write_text("{}")
+        assert validate_output(out_dir, "metric", "result") == []
+
+    def test_nested_all_null_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "metric.json").write_text(json.dumps({"a": {"x": None, "y": None}}))
+        warnings = validate_output(out_dir, "metric", "result")
+        assert len(warnings) == 1
+        assert "null/NaN" in warnings[0]
+
+
+class TestValidateTable:
+    def test_valid_csv_no_warning(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "table.csv").write_text("col_a,col_b\n1.0,2.0\n3.0,4.0\n")
+        assert validate_output(out_dir, "table", "result") == []
+
+    def test_missing_csv_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "output.txt").write_text("some text")
+        warnings = validate_output(out_dir, "table", "result")
+        assert len(warnings) == 1
+        assert "no CSV files" in warnings[0]
+
+    def test_all_nan_all_columns_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        nan = math.nan
+        (out_dir / "table.csv").write_text(f"col_a,col_b\n{nan},{nan}\n{nan},{nan}\n")
+        warnings = validate_output(out_dir, "table", "result")
+        assert len(warnings) == 1
+        assert "all-NaN" in warnings[0]
+        assert "every numeric column" in warnings[0]
+
+    def test_all_nan_single_column_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        nan = math.nan
+        (out_dir / "table.csv").write_text(f"col_a,col_b\n1.0,{nan}\n2.0,{nan}\n")
+        warnings = validate_output(out_dir, "table", "result")
+        assert len(warnings) == 1
+        assert "col_b" in warnings[0]
+        assert "every numeric column" not in warnings[0]
+
+    def test_empty_csv_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "table.csv").write_text("col_a,col_b\n")
+        warnings = validate_output(out_dir, "table", "result")
+        assert len(warnings) == 1
+        assert "no data rows" in warnings[0]
+
+    def test_non_numeric_columns_no_warning(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "table.csv").write_text("name,label\nfoo,bar\nbaz,qux\n")
+        assert validate_output(out_dir, "table", "result") == []
+
+    def test_mixed_valid_and_nan_rows_no_warning(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        nan = math.nan
+        (out_dir / "table.csv").write_text(f"col_a,col_b\n1.0,{nan}\n{nan},4.0\n")
+        assert validate_output(out_dir, "table", "result") == []
+
+
+class TestValidateFigure:
+    def test_valid_png_no_warning(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "figure.png").write_bytes(b"\x89PNG fake content")
+        assert validate_output(out_dir, "figure", "result") == []
+
+    def test_missing_image_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "output.txt").write_text("some text")
+        warnings = validate_output(out_dir, "figure", "result")
+        assert len(warnings) == 1
+        assert "no image files" in warnings[0]
+
+    def test_empty_image_file_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "figure.png").write_bytes(b"")
+        warnings = validate_output(out_dir, "figure", "result")
+        assert len(warnings) == 1
+        assert "empty" in warnings[0]
+        assert "0 bytes" in warnings[0]
+
+    def test_svg_accepted(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "figure.svg").write_text("<svg>content</svg>")
+        assert validate_output(out_dir, "figure", "result") == []
+
+    def test_pdf_accepted(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "figure.pdf").write_bytes(b"%PDF-1.4 fake content")
+        assert validate_output(out_dir, "figure", "result") == []
+
+    def test_multiple_figures_partial_empty_warns(self, tmp_path: Path) -> None:
+        out_dir = tmp_path / "result"
+        out_dir.mkdir()
+        (out_dir / "fig1.png").write_bytes(b"\x89PNG fake content")
+        (out_dir / "fig2.png").write_bytes(b"")
+        warnings = validate_output(out_dir, "figure", "result")
+        assert len(warnings) == 1
+        assert "fig2.png" in warnings[0]


### PR DESCRIPTION
Adds post-materialization validation for ASTRA output files. When a recipe exits 0 but writes suspicious output (all-NaN table, invalid/all-null metric JSON, empty figure), Dagster now emits context warnings rather than silently reporting success.

Closes #45

Generated with [Claude Code](https://claude.ai/code)

<!-- dco-signed-off-by -->
Signed-off-by: Alexandre Boucaud <3065310+aboucaud@users.noreply.github.com>
Signed-off-by: Francois Lanusse <EiffL@users.noreply.github.com>