### PR TITLE
feat(adr-0001): adopt dagster-slurm — Phases A, B, C [WIP]

### DIFF
--- a/.github/workflows/integration-slurm.yml
+++ b/.github/workflows/integration-slurm.yml
@@ -1,0 +1,56 @@
+name: Integration — SLURM emulator
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [labeled]
+
+# Run on main, or on PRs when the 'ci:slurm' label is added.
+jobs:
+  integration-slurm:
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'ci:slurm')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Configure git credentials for private ASTRA repo
+        run: git config --global url."https://x-access-token:${{ secrets.ASP_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start SLURM emulator
+        run: |
+          docker compose -f tests/integration/docker-compose.yml \
+            up -d --wait --wait-timeout 120
+
+      - name: Install dependencies (dev + slurm-next)
+        run: pip install -e ".[dev]" && pip install -e ".[slurm-next]" || \
+             uv sync --group dev --group slurm-next 2>/dev/null || \
+             pip install -e ".[dev]" dagster-slurm
+
+      - name: Run SLURM integration tests
+        env:
+          LIGHTCONE_USE_DAGSTER_SLURM: "1"
+        run: |
+          pytest -m "needs_slurm_docker" tests/integration/ -v \
+            --timeout=600 --tb=short
+
+      - name: Tear down emulator
+        if: always()
+        run: |
+          docker compose -f tests/integration/docker-compose.yml down -v

--- a/docs/adr/0001-adopt-dagster-slurm.md
+++ b/docs/adr/0001-adopt-dagster-slurm.md
@@ -1,0 +1,349 @@
+# ADR-0001 — Replace lightcone-cli's local and SLURM execution backends with `dagster-slurm`
+
+- **Status:** Accepted
+- **Proposed:** 2026-04-17
+- **Accepted:** 2026-04-22
+- **Deciders:** lightcone-cli maintainers
+- **Affects:** `src/lightcone/engine/runner.py`, `src/lightcone/engine/assets.py`, `src/lightcone/engine/targets.py`, `src/lightcone/engine/site_registry.py`, `src/lightcone/engine/container.py`, `src/lightcone/cli/commands.py`, tests in `tests/`
+- **Related upstream:** [`dagster-slurm`](https://github.com/ascii-supply-networks/dagster-slurm) (v1.13.0), docs at <https://dagster-slurm.geoheil.com/>
+
+## 1. Context
+
+lightcone-cli currently ships a bespoke execution layer (`ASTRAContainerRunner` in `src/lightcone/engine/runner.py`) that implements four backends inside a single ~1000-line class: **docker**, **local**, **venv**, and **slurm**. The SLURM backend generates sbatch scripts (`results/.slurm/`), submits with `sbatch`, polls with `sacct` falling back to `squeue`, and wraps commands in `podman-hpc run` when a container is configured. The local backend is a plain `subprocess.Popen` with streaming output, no environment management beyond a `python` substitution. There is no pluggable-backend abstraction; adding or changing a backend requires editing the monolithic class.
+
+This layer is the weakest part of lightcone-cli. It duplicates work that the wider Dagster ecosystem is solving in the open: real-time log streaming over SSH, account/QoS/reservation handling for multiple sites, Slurm job cancellation semantics, heterogeneous jobs, cluster reuse, and metrics collection via `sacct`. Our own tests cover the happy path of sbatch script generation and sacct parsing, but the polling loop, squeue fallback, timeout handling, and podman-hpc resolution are under-tested and have surfaced several pain points already (see "Known limitations" in the runner analysis attached to this review).
+
+The `dagster-slurm` library — published by ASCII Supply Networks and used in production at multiple Austrian HPC centers — is explicitly designed for the scenario lightcone-cli is trying to support: the same Dagster asset runs on a laptop, on a Docker-emulated Slurm cluster for CI, and on a real cluster, with only the resource wiring changing. It exposes a single `ComputeResource` facade with `mode ∈ {local, slurm, slurm-session, slurm-hetjob}` and a Dagster Pipes–based protocol for log streaming, metadata exchange, and materialization events.
+
+The user request that motivates this ADR is explicit: "design a workflow that can execute seamlessly across SLURM computing centers as well as local machines". That is precisely `dagster-slurm`'s charter.
+
+## 2. Decision
+
+We replace lightcone-cli's `local` and `slurm` execution backends with `dagster-slurm`'s `ComputeResource`. The **Docker** backend (`runner._run_docker`, `container.build_image_docker`) is **kept unchanged** because dagster-slurm has no concept of container-per-asset execution, and lightcone-cli's Docker backend is the primary way our users achieve hermetic local runs today. The **venv** backend is retired — dagster-slurm's pixi-based environment packaging supersedes it for local execution, and we will not maintain two similar abstractions.
+
+In the target architecture, lightcone-cli's asset factory no longer calls `runner.execute(command, ...)`. Instead, each Dagster asset is wired with a `ComputeResource` and invokes `compute.run(context, payload_path, extra_env, extra_slurm_opts)`. The heavy lifting — SSH pooling, sbatch submission, `sacct`/`squeue` polling, log streaming, pipes message ingestion, metrics collection — lives in dagster-slurm.
+
+Concretely:
+
+- `ASTRAContainerRunner` is split. A thin `DockerRunner` (≈150 lines, extracted from current code) remains for the Docker backend. SLURM and local paths are deleted.
+- A new `src/lightcone/engine/compute_adapter.py` builds a `ComputeResource` from a lightcone-cli target YAML and exposes the single call that `assets.py` needs.
+- lightcone-cli recipes are translated into `dagster-slurm` payloads by a generated wrapper script (see §4.3) so that ASTRA's "a recipe is a shell command" invariant is preserved.
+- Target config is migrated from lightcone-cli's custom schema (`scheduler:`, `poll:`, `resource_limits:`) into dagster-slurm's `SlurmResource` / `SlurmQueueConfig` / `SSHConnectionResource` shapes, wrapped by a stable lightcone-cli–level schema.
+- Python floor moves from 3.11 to 3.12 (dagster-slurm's hard requirement); Dagster is bumped from 1.9 → 1.13.
+
+## 3. Consequences
+
+### 3.1 What we gain
+
+The upstream library gives us, for free, a set of features we would otherwise have to build or defer: real-time stdout/stderr streaming over SSH with automatic fallback from `ControlMaster` to polling for HPC centers that disable socket multiplexing; `sacct`-based metrics (CPU efficiency, max RSS, node-hours) emitted as Dagster output metadata; Dagster Pipes integration that lets a compute payload emit `AssetMaterialization` and asset-check events back to the run without stdout parsing; safe retry and restart semantics driven by Dagster run tags; a session mode that holds a long-lived Slurm allocation across multiple assets (valuable for any multi-asset astra.yaml that shares a cluster reservation); and a working Docker-compose SLURM emulator we can use for CI.
+
+The code delta is large in the negative direction: approximately 750 lines of lightcone-cli's SLURM, local, and venv runner code are deleted, replaced by roughly 250 lines of adapter, payload generation, and configuration translation. Net reduction is on the order of 500 lines in a module that has been a recurring source of bugs.
+
+### 3.2 What we give up or complicate
+
+We lose built-in `podman-hpc` containerization on SLURM. `dagster-slurm` has no container primitive — environment isolation is achieved by `pixi pack` producing a self-extracting tarball that is uploaded to the cluster and sourced in the sbatch script. For sites that rely on `podman-hpc` image builds today (Perlmutter), we must either (a) wrap the recipe command in an explicit `podman-hpc run` invocation inside the generated payload wrapper (see §4.3); or (b) accept pixi-pack isolation as the new hermetic primitive and retire `container.py`'s podman-hpc build path. This ADR recommends (a) as the migration path and deferring (b) to a follow-up decision record; we do not want to couple a runner swap to an isolation-model change.
+
+We inherit a Python 3.12 floor. lightcone-cli already runs under 3.12 in its `.venv`, so this is more a declaration than a lift. Consumers on 3.11 will be broken once merged — this is a semver-minor breaking change from their perspective.
+
+We inherit `dagster-slurm`'s gaps: no support for SLURM `--constraint` out of the box (lightcone-cli exposes this via `extra_slurm_args`; we must either upstream a PR or emit `#SBATCH --constraint` from our payload wrapper); limited multi-hop SSH (single jump host only); remote paths live under `remote_base/runs/{run_id}/`, not `results/.slurm/` (we fetch logs and sbatch scripts back into `results/.slurm/` post-execution to preserve the current artifact layout).
+
+We accept a coupling to Dagster 1.13 pinned by dagster-slurm. Future upgrades are gated on the upstream bumping its own pin.
+
+### 3.3 Risk summary
+
+The highest-risk item is the container-isolation gap on HPC sites. The second-highest is the ASTRA recipe-model mismatch: dagster-slurm expects a Python payload file, lightcone-cli expects a shell command with injected CLI args. The mitigation for both is the payload wrapper described in §4.3, which is small, deterministic, and unit-testable without Docker.
+
+## 4. Detailed design
+
+### 4.1 Module-by-module plan
+
+`src/lightcone/engine/runner.py` loses everything Slurm-, venv-, and local-related: `_run_slurm`, `_run_slurm_interactive`, `_run_local`, `_run_venv`, `generate_sbatch_script`, `translate_resources_to_slurm_directives`, `_podman_hpc_run_command`, `_normalise_time_limit`, `_parse_sbatch_job_id`, `_poll_slurm_job`, `_check_sacct`, `_check_squeue_fallback`, and the venv dependency-hash caching logic. What remains is a `DockerRunner` class with the current Docker fallback-to-local behavior removed (local is no longer a fallback; Docker failure is now a hard failure with a clear error message). The module shrinks from ~1000 to ~180 lines.
+
+`src/lightcone/engine/compute_adapter.py` is new. It owns three things: (1) loading a lightcone-cli target YAML and constructing a `ComputeResource` with the correct `mode` and subordinate `SlurmResource` / `SSHConnectionResource` / `SlurmQueueConfig` objects; (2) building the payload wrapper script for a given recipe (§4.3); (3) staging dagster-slurm's post-execution artifacts (sbatch script, stdout, stderr, metrics) into `results/.slurm/{output_id}_{universe_id}.*` so the current on-disk layout is preserved. This module is the new seam for tests and for future HPC site additions.
+
+`src/lightcone/engine/assets.py` changes minimally. The `_build_single_asset` body no longer constructs a command string and calls `runner.execute`; instead it writes a payload wrapper via `compute_adapter.prepare_payload(recipe, universe_id, params, external_inputs)` and calls `compute.run(context, payload_path=wrapper_path, extra_slurm_opts=_resources_to_slurm_opts(recipe.resources))`. The asset factory still receives a `runner` parameter for backwards compatibility with Docker-only targets; when the target mode is `local` or `slurm`, it resolves to a `ComputeResource` via the adapter.
+
+`src/lightcone/engine/targets.py` gets a new `TargetKind` enum: `docker | local | slurm | slurm-session`. Loaders for `slurm` and `local` now validate against dagster-slurm's config shape. Existing YAML files need a one-time migration (§4.6).
+
+`src/lightcone/engine/site_registry.py` retains its account-suffix resolution and node-type defaults but no longer emits lightcone-cli–native `scheduler_config` dicts. It emits `SlurmQueueConfig` fragments that the adapter merges into the final `ComputeResource`.
+
+`src/lightcone/engine/container.py` loses `build_image_podman_hpc`, `_podman_hpc_migrate`, `image_exists_podman_hpc`, and `resolve_container_for_slurm`. Docker/Podman build and tag-computation logic stays. The `podman-hpc` container runtime is no longer selectable in target configs (the `container_runtime` field is removed); HPC container execution is handled by the payload wrapper's `podman-hpc run` invocation if the target opts in.
+
+`src/lightcone/cli/commands.py` loses its SLURM-specific passthrough for `--partition` / `--qos` / `--constraint` / `--account`. These now live in the target YAML and are overridable per-run via a new `--slurm-opts key=value,...` flag that lands in `extra_slurm_opts` on the compute resource. `lc setup` and `lc target` UX stays visually similar but writes dagster-slurm–shaped configs.
+
+### 4.2 Interface mapping
+
+The current runner interface:
+
+```python
+runner.execute(
+    command: str,                      # "python scripts/compute.py"
+    container: str | None,
+    inputs: list[str],
+    output_id: str,
+    universe_id: str,
+    resources: dict[str, Any],         # {cpus, memory, gpus, time_limit, nodes}
+    params: dict[str, Any],            # decision params from universes/{id}.yaml
+    external_inputs: dict[str, str] | None,
+    cwd_override: str | None,
+) -> ExecutionResult                   # {exit_code, output_path, metadata}
+```
+
+The new equivalent, resolved through the adapter:
+
+```python
+payload_path, ctx = compute_adapter.prepare_payload(
+    recipe=recipe, universe_id=universe_id, params=params,
+    external_inputs=external_inputs, cwd_override=cwd_override,
+    output_id=output_id, project_root=project_root,
+)
+completed = compute.run(
+    context=dagster_context,
+    payload_path=payload_path,
+    extra_slurm_opts=_resources_to_slurm_opts(recipe.resources),
+    extra_env={"ASTRA_UNIVERSE": universe_id, "ASTRA_OUTPUT": output_id},
+    extra_files=_resolve_external_inputs(external_inputs),
+)
+yield from completed.get_results()        # Dagster events
+compute_adapter.stage_artifacts(completed, ctx)  # copy logs/script into results/.slurm/
+```
+
+`resources` → `extra_slurm_opts` translation is direct: `cpus → cpus_per_task`, `memory → mem`, `gpus → gpus_per_node`, `nodes → nodes`, `time_limit → time_limit` (format normalized to `HH:MM:SS`). The `--constraint` value, if present in target config, is injected into the sbatch script header by the payload wrapper (see §4.3) because dagster-slurm's `_build_sbatch_command` does not accept arbitrary sbatch flags.
+
+Return shape: `ExecutionResult` is retired. `compute.run()` returns a `PipesClientCompletedInvocation`; metrics and exit codes are surfaced as Dagster asset metadata by `get_results()`. The `output_path` field (always `results/{universe_id}/`) is redundant — the IO manager is the source of truth for it.
+
+### 4.3 Payload wrapper — the ASTRA → pipes shim
+
+lightcone-cli recipes are shell commands. dagster-slurm expects a Python payload that opens a pipes session. The gap is bridged by a small generated wrapper written per-materialization to a deterministic path:
+
+```python
+# results/.payloads/{universe_id}__{output_id}.py  (auto-generated, do not edit)
+from dagster_pipes import open_dagster_pipes
+import os, subprocess, shlex, sys, json
+
+CMD = {command_quoted}                # "python scripts/compute.py"
+CLI_ARGS = {cli_args_json}            # ["--universe", "baseline", "--method", "option_a"]
+CWD = {cwd_json_or_none}
+CONTAINER_WRAP = {container_wrap_or_none}  # ["podman-hpc", "run", "--rm", ...]
+WORKDIR = {workdir_json}
+
+with open_dagster_pipes() as pipes:
+    pipes.log.info(f"astra recipe: {CMD} {' '.join(CLI_ARGS)}")
+    full = shlex.split(CMD) + CLI_ARGS
+    if CONTAINER_WRAP:
+        full = CONTAINER_WRAP + full
+    proc = subprocess.run(full, cwd=CWD or WORKDIR, check=False)
+    pipes.report_asset_materialization(
+        metadata={"exit_code": proc.returncode,
+                  "command": " ".join(shlex.quote(a) for a in full)}
+    )
+    sys.exit(proc.returncode)
+```
+
+Three reasons this wrapper design is chosen over "just change ASTRA recipes to be Python scripts":
+
+- ASTRA is a spec maintained separately and is explicitly "pure specification". Changing the recipe model to require a pipes-native Python entry point would leak execution-layer concerns back into the spec. lightcone-cli is the agentic layer; shims belong in lightcone-cli.
+- The wrapper is small, deterministic, and easy to regenerate. Its contents are a pure function of `(recipe.command, resources, cli_args, container, external_inputs)` — cacheable, testable, and diff-able across runs.
+- If a recipe author does write a pipes-native payload in the future, we keep the door open by honoring a `recipe.payload: path/to/script.py` field that bypasses the wrapper and passes the script directly to `compute.run`.
+
+The wrapper also owns `--constraint` and any other sbatch flag dagster-slurm does not accept, by writing a `#SBATCH --constraint=...` line into the *first* comment block of the script itself — sbatch accepts these directives even when the submission command does not specify them. This is a documented upstream pattern and is already exercised by dagster-slurm users for reservations on sites that expose non-standard constraint strings.
+
+### 4.4 Target config translation
+
+Before:
+
+```yaml
+# ~/.lightcone/targets/perlmutter.yaml (current)
+site: perlmutter
+backend: slurm
+connection:
+  hostname: perlmutter.nersc.gov
+scheduler:
+  account: m1234
+  qos: debug
+  partition: gpu
+  constraint: gpu
+  container_runtime: podman-hpc
+  container_flags: ["--gpu", "--mpi"]
+  extra_slurm_args: []
+poll:
+  interval_seconds: 15
+  timeout_seconds: 14400
+resource_limits:
+  max_walltime_minutes: 360
+```
+
+After:
+
+```yaml
+# ~/.lightcone/targets/perlmutter.yaml (new)
+name: perlmutter
+mode: slurm                              # local | slurm | slurm-session | docker
+site: perlmutter                         # still used by site_registry for account suffix
+ssh:
+  host: perlmutter.nersc.gov
+  user: ${USER}
+  key_path: ~/.ssh/nersc
+queue:
+  partition: gpu
+  account: m1234
+  qos: debug
+  time_limit: "00:30:00"
+  cpus: 4
+  mem_per_cpu: 4G
+  gpus_per_node: 0
+remote_base: /pscratch/sd/a/${USER}/lightcone-runs
+# HPC container execution (optional, lightcone-cli–level, wrapped in payload):
+container:
+  runtime: podman-hpc                    # podman-hpc | apptainer | none
+  flags: ["--gpu", "--mpi"]
+# Raw sbatch escape hatch — appended to every job's #SBATCH header:
+extra_sbatch_directives:
+  - "--constraint=gpu"
+poll:
+  timeout_seconds: 14400                 # passed through to compute.run(poll_timeout=)
+```
+
+A CLI one-shot — `lc target migrate perlmutter` — rewrites old configs in place, and `lc setup` writes the new shape by default.
+
+### 4.5 Artifact path alignment
+
+`dagster-slurm` writes sbatch scripts and `slurm-{job_id}.out/err` under `{remote_base}/runs/{run_id}/` on the cluster. To preserve lightcone-cli's current on-disk convention (`results/.slurm/{output_id}_{universe_id}.{sh,out,err}`) and to keep `lc status` and tail-style debugging working, the adapter's `stage_artifacts()` step fetches those files via the SSH pool (`completed.metadata['ssh_pool']` or the resource's pool accessor) and writes them locally. The remote copy is the source of truth while the job runs; the local copy is populated once the job terminates. `results/.payloads/{universe_id}__{output_id}.py` additionally gives us a readable, persistent record of the exact command executed.
+
+### 4.6 Migration of existing user state
+
+- Target YAMLs: `lc target migrate <name>` converts old → new schema; a compatibility shim in `targets.py` accepts both shapes for one release cycle, emitting a deprecation warning on the old shape.
+- `~/.lightcone/config.yaml`: `default_target` and `default_permissions` fields unchanged.
+- In-flight SLURM jobs at the time of upgrade are abandoned; this is consistent with current restart behavior where lightcone-cli has no reattach path for pre-upgrade jobs.
+
+### 4.7 Dependency and version changes
+
+- `requires-python` bumps from `>=3.11` to `>=3.12,<3.13` (follows upstream pin).
+- `dagster` bumps from `>=1.9` to `>=1.13,<1.14` (follows upstream pin).
+- `dagster-webserver` and `dagster-docker` bump to the matching 1.13 line.
+- New dependency: `dagster-slurm>=1.13,<1.14`.
+- `dagster-pipes` is added as a transitive dep and must be installed inside every recipe's runtime environment (container or venv) so the payload wrapper can `import dagster_pipes`.
+- We do **not** adopt `pixi` as a top-level dependency. The adapter sets `LocalPipesClient(require_pixi=False)` for `mode=local`, which is supported since dagster-slurm v1.12. For SLURM mode we also disable pixi-pack (`ComputeResource(pre_deployed_env_path=...)` or a shim around the packaging step) because lightcone-cli's existing Containerfile-based image builds already solve environment hermeticity; we do not want two competing environment stories.
+
+## 5. Test strategy
+
+### 5.1 Unit tests (no Docker, no network)
+
+Located in `tests/test_compute_adapter.py` (new).
+
+- `test_target_yaml_to_compute_resource` — table-driven: `local`, `slurm`, and `slurm-session` YAML fixtures each produce a `ComputeResource` with the expected mode, SSH config, queue config, and `poll_timeout`.
+- `test_resources_dict_to_slurm_opts` — `{cpus: 4, memory: "8G", gpus: 2, nodes: 1, time_limit: "30m"}` → `{cpus_per_task: 4, mem: "8G", gpus_per_node: 2, nodes: 1, time_limit: "00:30:00"}`. Cover edge cases: missing fields, `time_limit` given as `"1h"`, `"2:00:00"`, and `"120"`.
+- `test_payload_wrapper_generation` — for a representative recipe (`command: python scripts/compute.py`, params `{method: a}`, container `python:3.11`, external inputs `{raw: /data/raw.parquet}`), assert the generated Python file (a) runs through `py_compile`, (b) contains the exact `CLI_ARGS` we expect, (c) wraps the command in `podman-hpc run` when container is configured, and (d) writes pipes materialization metadata. Snapshot-test the file contents for stability.
+- `test_extra_sbatch_directives_injection` — `extra_sbatch_directives: ["--constraint=gpu"]` appears in the `#SBATCH` block of the generated wrapper.
+- `test_stage_artifacts` — mock a `PipesClientCompletedInvocation` with a fake SSH pool; assert `results/.slurm/foo_baseline.{sh,out,err}` are written.
+- `test_compute_resource_is_constructed_lazily` — constructing a `ComputeResource` with dummy SSH credentials does not open a connection.
+
+These replace `tests/test_runner.py` entirely and a chunk of `tests/test_runner_local.py` / `tests/test_runner_venv.py` (which are deleted along with the code they cover).
+
+### 5.2 Parity tests vs. the current runner (bridge)
+
+Located in `tests/test_runner_parity.py` (new, temporary — removed after the old runner is deleted).
+
+The old `ASTRAContainerRunner` remains importable behind a feature flag (`LIGHTCONE_LEGACY_RUNNER=1`) for the duration of the transition. A parametrized test runs the same astra.yaml against both backends in `mode=local` and asserts:
+
+- Same exit code for each output.
+- Same on-disk output files (hash-compared) under `results/{universe}/{output}/`.
+- Same Dagster `AssetMaterialization` event keys and values (modulo the new `cpu_efficiency` / `max_rss` metadata fields, which the old path does not emit).
+
+Three fixture astra.yaml files: a single-step pipeline, a two-step pipeline with `inputs:` dependency, and a multi-universe case with `decisions` injected as CLI args. The parity suite runs on CI with a 30-minute budget and is the gate that unlocks deletion of the legacy runner.
+
+### 5.3 Emulator-based integration tests (Docker compose)
+
+Located in `tests/integration/` (new) with `pytest.mark.needs_slurm_docker` and `pytest.mark.slow`. Follows dagster-slurm's own CI pattern.
+
+`tests/integration/docker-compose.yml` references the upstream image directly:
+
+```yaml
+services:
+  mysql:       { image: mariadb:12, ... }
+  slurmdbd:    { image: ghcr.io/ascii-supply-networks/dagster-slurm/slurm-docker-cluster:25-11-2-1, command: [slurmdbd] }
+  slurmctld:   { image: ghcr.io/ascii-supply-networks/dagster-slurm/slurm-docker-cluster:25-11-2-1, command: [slurmctld], ports: ["2223:22"] }
+  c1: { image: ghcr.io/ascii-supply-networks/dagster-slurm/slurm-docker-cluster:25-11-2-1, command: [slurmd], hostname: c1 }
+  c2: { image: ghcr.io/ascii-supply-networks/dagster-slurm/slurm-docker-cluster:25-11-2-1, command: [slurmd], hostname: c2 }
+```
+
+We **do not** vendor the build context — we consume the published image. If upstream breaks compatibility with a new tag, CI pins the last-known-good `IMAGE_TAG`.
+
+Fixtures in `tests/integration/conftest.py`:
+
+- `slurm_emulator` (session-scoped, `autouse=False`) — runs `docker compose up -d --wait` and `docker compose down -v` around the test module. Skipped if `DOCKER_HOST` is unreachable.
+- `emulator_target` — yields a lightcone-cli target YAML pointing at `localhost:2223` with user `submitter` / password `submitter`, matching the upstream emulator credentials.
+
+Tests:
+
+- `test_emulator_end_to_end_single_asset` — materialize a one-output astra.yaml that runs `python -c "open('out.txt','w').write('ok')"` and assert `results/baseline/out/out.txt == "ok"`.
+- `test_emulator_metadata_propagation` — the payload calls `pipes.report_asset_materialization(metadata={"rows": 42})`; the resulting Dagster event carries `rows=42`.
+- `test_emulator_non_zero_exit_fails_asset` — a recipe with `command: exit 7` causes the materialization to fail and the SLURM exit code reaches the Dagster run.
+- `test_emulator_resource_directives_respected` — `resources: {cpus: 2, time_limit: "00:02:00"}` produces an sbatch script containing `-c 2` and `-t 00:02:00`. Inspect `results/.slurm/*.sh` after the run.
+- `test_emulator_sbatch_constraint_via_extra_directives` — asserts an `extra_sbatch_directives` entry reaches the sbatch header.
+- `test_emulator_log_streaming` — the payload emits 500 `pipes.log.info` lines; assert all arrive in the Dagster event log (no dropped lines).
+- `test_emulator_cancellation` — materialize a long-running recipe, send the Dagster run terminate signal, assert the Slurm job is cancelled (via `sacct --json` in the emulator).
+
+`pixi run start-staging` is *not* used — that is dagster-slurm's internal example bootstrap and we don't want to couple lightcone-cli to it. We invoke the emulator directly with the published image and our own compose file.
+
+### 5.4 CI wiring
+
+A new GitHub Actions job `integration-slurm`:
+
+```yaml
+integration-slurm:
+  runs-on: ubuntu-latest
+  timeout-minutes: 45
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/login-action@v3
+      with: { registry: ghcr.io, username: ${{ github.actor }}, password: ${{ secrets.GITHUB_TOKEN }} }
+    - run: docker compose -f tests/integration/docker-compose.yml up -d --wait --wait-timeout 120
+    - run: pip install -e ".[dev]"
+    - run: pytest -m "needs_slurm_docker" tests/integration/
+    - if: always()
+      run: docker compose -f tests/integration/docker-compose.yml down -v
+```
+
+Unit tests remain on the default matrix and complete in under a minute; the integration job is opt-in via label (`ci:slurm`) on PRs and runs on every merge to `main`.
+
+## 6. Rollout plan
+
+- **Week 1 — scaffold (no behavior change).** Add `docs/adr/0001-adopt-dagster-slurm.md` (this document). Add dagster-slurm to `pyproject.toml` as an optional extra `[slurm-next]`. Land the new target YAML schema with a loader that accepts both shapes.
+- **Week 2 — compute adapter + local mode.** Ship `compute_adapter.py` and route `mode=local` through dagster-slurm behind a `LIGHTCONE_USE_DAGSTER_SLURM=1` env var. Unit tests (§5.1) green. Parity tests (§5.2) green for local.
+- **Week 3 — emulator tests + SLURM mode.** Ship the docker-compose emulator fixture and integration tests. Route `mode=slurm` through dagster-slurm behind the same env var. Parity tests green for SLURM against the emulator.
+- **Week 4 — flip default + deprecate old runner.** `LIGHTCONE_USE_DAGSTER_SLURM` defaults to `1`. Deprecation warnings fire on the old code path. Publish a migration note for external users.
+- **Week 5 — delete.** Remove `_run_slurm*`, `_run_local`, `_run_venv`, podman-hpc build helpers, parity tests, and the feature flag. `tests/test_runner.py` is deleted.
+- **Week 6 — follow-up ADR draft.** Separate decision record on whether to retire `podman-hpc run` wrapping in favor of pixi-pack, and whether to adopt `slurm-session` mode as the default for multi-output runs.
+
+Rollback at any phase is a revert of the phase's PR plus resetting the env var default.
+
+## 7. Open questions and assumptions
+
+- **SSH access from user laptops.** dagster-slurm's SLURM mode submits jobs over SSH from the Dagster process. Current lightcone-cli assumes users are logged into the cluster and running lightcone-cli *on* the edge node. We need to decide whether `lc run --target perlmutter` from a laptop is a supported flow or whether we continue to require the edge-node invocation. Recommendation: support both — the adapter treats `ssh.host == "localhost"` and `SLURM_JOB_ID` being set as a signal to short-circuit to a local pipes client with the recipe run via `srun`.
+- **Environment packaging strategy.** This ADR proposes to disable pixi-pack and rely on lightcone-cli's existing Containerfile-built images for hermeticity. If that decision is reversed, the container wrapping logic in the payload wrapper becomes redundant and the follow-up ADR mentioned in §6 becomes mandatory, not optional.
+- **Constraint-flag fragility.** Emitting `#SBATCH --constraint=...` from the payload wrapper is the cleanest workaround today, but upstream has indicated willingness to accept a PR adding `extra_sbatch_flags` to `SlurmQueueConfig`. We should open that PR in parallel so the workaround is time-boxed.
+- **Retry behavior.** lightcone-cli currently has no automatic retry on transient SLURM failures. dagster-slurm supports reattach on Dagster run retry via run tags. Adopting it is a small config change but warrants a separate note to users.
+
+## 8. Alternatives considered
+
+**A. Do nothing.** Status quo preserves full control but leaves ~1000 lines of under-tested execution code on our maintenance budget. Rejected: the user request for seamless laptop↔HPC workflow is not credible to fulfill without either adopting an upstream library or spending substantial effort rebuilding one.
+
+**B. Use dagster-slurm as an *additional* target, keeping the current runner in place.** Minimal risk, minimal benefit. Leaves two execution stacks to maintain forever and does not address the core quality issue. Rejected in the clarification round.
+
+**C. Replace only the SLURM backend, keep lightcone-cli's local backend.** Smaller blast radius. Rejected in the clarification round and on its merits: keeping two code paths for "run a command" when dagster-slurm already offers a unified one is the wrong trade.
+
+**D. Build our own Dagster-Slurm bridge using Dagster Pipes directly, not via dagster-slurm.** Technically feasible — Dagster Pipes is stable. Rejected because we would end up re-implementing the SSH pool, sacct parsing, log streaming, and cluster-emulator story that dagster-slurm already ships, all while claiming not to be "yet another bespoke runner".
+
+**E. Adopt Prefect or Nextflow.** Out of scope — lightcone-cli is a Dagster-native project and the asset factory / IO manager contract is load-bearing.
+
+## 9. References
+
+- dagster-slurm README: <https://github.com/ascii-supply-networks/dagster-slurm/blob/main/README.md>
+- dagster-slurm docs site: <https://dagster-slurm.geoheil.com/>
+- Upstream compose emulator: `docker-compose.yml` + `docker-compose.ci.yml` in the repo root
+- Upstream CI pattern: `.github/workflows/library.yaml` (`Run integration tests against SLURM cluster` step)
+- Upstream `ComputeResource` source: `projects/dagster-slurm/dagster_slurm/resources/compute.py`
+- Upstream `_build_sbatch_command`: `projects/dagster-slurm/dagster_slurm/pipes_clients/slurm_pipes_client.py:1630`
+- Current lightcone-cli runner: `src/lightcone/engine/runner.py` (the module this ADR retires in large part)
+- Dagster Pipes protocol: <https://docs.dagster.io/concepts/dagster-pipes>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,14 @@ dev = [
 docs = [
     "zensical>=0.0.33",
 ]
+# Opt-in preview of the dagster-slurm execution backend (ADR-0001).
+# Requires Python 3.12 — sync with `uv sync --group slurm-next` and
+# activate with LIGHTCONE_USE_DAGSTER_SLURM=1 at runtime. Will be promoted
+# to a core dependency when the ADR's Phase D flips the Python floor to 3.12.
+slurm-next = [
+    "dagster-slurm>=1.13,<1.14; python_version >= '3.12'",
+    "dagster-pipes>=1.13,<1.14; python_version >= '3.12'",
+]
 
 
 [project.scripts]
@@ -75,3 +83,7 @@ mypy_path = "src"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "needs_slurm_docker: requires Docker + SLURM emulator (docker-compose up)",
+    "slow: marks tests as slow (excluded from default run)",
+]

--- a/src/lightcone/engine/assets.py
+++ b/src/lightcone/engine/assets.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,8 @@ from lightcone.engine.tree import (
 )
 
 logger = logging.getLogger(__name__)
+
+_USE_DAGSTER_SLURM = os.getenv("LIGHTCONE_USE_DAGSTER_SLURM") == "1"
 
 
 def get_external_inputs(spec: dict[str, Any]) -> dict[str, str]:
@@ -64,6 +67,10 @@ def build_asset_definitions(
     no_build: bool = False,
     container_runtime: str | None = None,
     local_runtime: str | None = None,
+    compute_resource: Any | None = None,
+    container_wrap: list[str] | None = None,
+    extra_sbatch_directives: list[str] | None = None,
+    _target_config: dict[str, Any] | None = None,
 ) -> list[dg.AssetsDefinition | dg.AssetSpec]:
     """Generate one @asset per output with a recipe.
 
@@ -148,6 +155,10 @@ def build_asset_definitions(
                 local_runtime=local_runtime, external_inputs=sub_external,
                 key_prefix=key_prefix, group_name=group_name,
                 dep_keys=dep_keys, tree_output=tree_out, spec=spec,
+                compute_resource=compute_resource,
+                container_wrap=container_wrap,
+                extra_sbatch_directives=extra_sbatch_directives,
+                _target_config=_target_config,
             )
         )
 
@@ -258,6 +269,10 @@ def _build_single_asset(
     dep_keys: list[dg.AssetKey] | None = None,
     tree_output: TreeOutput | None = None,
     spec: dict[str, Any] | None = None,
+    compute_resource: Any | None = None,
+    container_wrap: list[str] | None = None,
+    extra_sbatch_directives: list[str] | None = None,
+    _target_config: dict[str, Any] | None = None,
 ) -> dg.AssetsDefinition:
     """Build a single Dagster asset from an output recipe."""
     input_ids = recipe.get("inputs") or []
@@ -308,7 +323,36 @@ def _build_single_asset(
                 (project_path / tree_output.analysis_path).resolve()
             )
 
-        result = runner.execute(
+        if compute_resource is not None:
+            # dagster-slurm path (ADR-0001 Phase B+C): active when
+            # LIGHTCONE_USE_DAGSTER_SLURM=1 and mode is local or slurm.
+            from lightcone.engine import compute_adapter as _ca  # deferred
+            from lightcone.engine.slurm_utils import resources_to_slurm_opts
+
+            _root = project_path or Path.cwd()
+            payload_path, ctx = _ca.prepare_payload(
+                command=command,
+                universe_id=universe_id,
+                output_id=output_id,
+                project_root=_root,
+                params=params,
+                external_inputs=recipe_external,
+                cwd_override=cwd_override,
+                container_wrap=container_wrap,
+                extra_sbatch_directives=extra_sbatch_directives,
+                payload_override=Path(recipe["payload"]) if recipe.get("payload") else None,
+                target_config=_target_config,
+            )
+            completed = compute_resource.run(
+                context=context,
+                payload_path=str(payload_path),
+                extra_slurm_opts=resources_to_slurm_opts(resources),
+            )
+            _ca.stage_artifacts(completed, ctx, run_id=context.run_id)
+            return completed.get_materialize_result()
+
+        # Legacy path — unchanged.
+        result = runner.execute(  # type: ignore[union-attr]
             command=command,
             container=container,
             inputs=input_ids,
@@ -393,7 +437,52 @@ def build_definitions(
     else:
         default_container = raw_container
 
-    # Build runner from target config
+    # Optionally route local/slurm backends through dagster-slurm (ADR-0001).
+    # Activated by LIGHTCONE_USE_DAGSTER_SLURM=1 for non-Docker targets.
+    compute_resource: Any | None = None
+    container_wrap: list[str] | None = None
+    extra_sbatch_directives: list[str] | None = None
+    _effective_target_config: dict[str, Any] | None = None
+
+    if _USE_DAGSTER_SLURM and target_config is not None:
+        norm = target_config  # build_definitions callers already pass the right shape,
+        # but support legacy shape transparently.
+        mode = norm.get("mode") or norm.get("backend", "docker")
+        if mode in ("local", "slurm", "slurm-session"):
+            from lightcone.engine import compute_adapter as _ca
+            from lightcone.engine.targets import normalize_target
+            norm = normalize_target(target_config)
+            try:
+                compute_resource = _ca.build_compute_resource(norm)
+                _effective_target_config = norm
+            except ImportError as exc:
+                logger.warning(
+                    "LIGHTCONE_USE_DAGSTER_SLURM=1 but dagster-slurm is not installed "
+                    "— falling back to legacy runner. Install with "
+                    "`uv sync --group slurm-next`. (%s)", exc,
+                )
+            container_cfg = norm.get("container") or {}
+            if container_cfg.get("runtime") == "podman-hpc":
+                container_wrap = ["podman-hpc", "run", "--rm"]
+                for flag in container_cfg.get("flags") or []:
+                    container_wrap.append(flag)
+            extra_sbatch_directives = norm.get("extra_sbatch_directives") or []
+
+    elif _USE_DAGSTER_SLURM and target_config is None:
+        # No target → treat as local mode via dagster-slurm.
+        from lightcone.engine import compute_adapter as _ca
+        _local_cfg: dict[str, Any] = {"mode": "local"}
+        try:
+            compute_resource = _ca.build_compute_resource(_local_cfg)
+            _effective_target_config = _local_cfg
+        except ImportError as exc:
+            logger.warning(
+                "LIGHTCONE_USE_DAGSTER_SLURM=1 but dagster-slurm is not installed "
+                "— falling back to legacy runner. (%s)", exc,
+            )
+
+    # Build runner from target config (still needed for Docker targets and
+    # as fallback when compute_resource is None).
     if runner_config:
         runner = ASTRAContainerRunner(
             project_root=str(project_path),
@@ -413,6 +502,10 @@ def build_definitions(
         spec, runner=runner, universe_id=universe_id, project_path=project_path,
         project_name=project_name, no_build=no_build,
         container_runtime=container_runtime, local_runtime=local_runtime,
+        compute_resource=compute_resource,
+        container_wrap=container_wrap,
+        extra_sbatch_directives=extra_sbatch_directives,
+        _target_config=_effective_target_config,
     )
 
     return dg.Definitions(assets=assets)

--- a/src/lightcone/engine/compute_adapter.py
+++ b/src/lightcone/engine/compute_adapter.py
@@ -1,0 +1,403 @@
+"""Bridge between lightcone-cli's asset factory and the ``dagster-slurm`` library.
+
+This module is the seam introduced by ADR-0001. It owns three responsibilities:
+
+1. ``build_compute_resource`` — construct a ``dagster_slurm.ComputeResource``
+   from a normalized lightcone-cli target YAML.
+2. ``prepare_payload`` — write the per-materialization Python wrapper script
+   (§4.3) that translates an ASTRA shell-command recipe into a dagster-pipes
+   payload.
+3. ``stage_artifacts`` — post-execution, copy the sbatch script and stdout/
+   stderr back from the remote host into ``results/.slurm/`` so the existing
+   on-disk layout is preserved.
+
+``dagster-slurm`` is an optional dependency (``pip install lightcone-cli[slurm-next]``);
+the import is deferred to the functions that need it so this module can be
+imported in environments where it is not installed (for payload-wrapper unit
+tests in particular).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from dagster_slurm import ComputeResource  # type: ignore[import-not-found]
+
+__all__ = [
+    "PayloadCtx",
+    "build_compute_resource",
+    "prepare_payload",
+    "stage_artifacts",
+    "has_dagster_slurm",
+]
+
+
+@dataclass(frozen=True)
+class PayloadCtx:
+    """Post-generation context needed by ``stage_artifacts``."""
+
+    universe_id: str
+    output_id: str
+    payload_path: Path
+    project_root: Path
+    target_config: dict[str, Any] | None = None
+
+
+def has_dagster_slurm() -> bool:
+    """Return whether ``dagster-slurm`` is importable in the current env."""
+    try:
+        import dagster_slurm  # type: ignore[import-not-found]  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _require_dagster_slurm() -> None:
+    if not has_dagster_slurm():
+        raise ImportError(
+            "dagster-slurm is not installed. Install with "
+            "`pip install lightcone-cli[slurm-next]` (requires Python 3.12). "
+            "See ADR-0001 §4.7."
+        )
+
+
+def build_compute_resource(target_config: dict[str, Any]) -> ComputeResource:
+    """Construct a ``ComputeResource`` from a normalized target config.
+
+    ``target_config`` must be in the post-ADR-0001 shape (§4.4).
+    Call :func:`lightcone.engine.targets.normalize_target` first when the
+    input may still be in the legacy ``backend:`` shape.
+
+    Only ``mode=local`` and ``mode=slurm`` are fully wired.  ``slurm-session``
+    falls back to ``slurm``; ``docker`` raises ``ValueError`` (Docker targets
+    use the pre-existing runner, not dagster-slurm).
+    """
+    _require_dagster_slurm()
+
+    import sys  # noqa: PLC0415
+
+    from dagster_slurm import (
+        BashLauncher,  # type: ignore[import-not-found]  # noqa: PLC0415
+        ComputeResource,  # type: ignore[import-not-found]  # noqa: PLC0415
+        SlurmQueueConfig,  # type: ignore[import-not-found]  # noqa: PLC0415
+        SlurmResource,  # type: ignore[import-not-found]  # noqa: PLC0415
+        SSHConnectionResource,  # type: ignore[import-not-found]  # noqa: PLC0415
+    )
+    from dagster_slurm.config.environment import (
+        ExecutionMode,  # type: ignore[import-not-found]  # noqa: PLC0415
+    )
+
+    mode_str: str = target_config.get("mode", "local")
+
+    if mode_str == "docker":
+        raise ValueError(
+            "Docker targets use the existing ASTRAContainerRunner, not dagster-slurm. "
+            "Pass target_config only for 'local' or 'slurm' mode."
+        )
+
+    if mode_str == "local":
+        return ComputeResource(
+            mode=ExecutionMode.LOCAL,
+            default_launcher=BashLauncher(),
+            # Point at the active venv so no pixi-pack is attempted.
+            pre_deployed_env_path=sys.prefix,
+        )
+
+    if mode_str in ("slurm", "slurm-session"):
+        dagster_mode = ExecutionMode.SLURM if mode_str == "slurm" else ExecutionMode.SLURM_SESSION
+
+        ssh_cfg = target_config.get("ssh") or {}
+        queue_cfg = target_config.get("queue") or {}
+
+        ssh_kwargs: dict[str, Any] = {
+            "host": ssh_cfg["host"],
+            "user": ssh_cfg.get("user", ""),
+        }
+        if ssh_cfg.get("port"):
+            ssh_kwargs["port"] = int(ssh_cfg["port"])
+        if ssh_cfg.get("key_path"):
+            ssh_kwargs["key_path"] = ssh_cfg["key_path"]
+        elif ssh_cfg.get("password"):
+            ssh_kwargs["password"] = ssh_cfg["password"]
+        ssh = SSHConnectionResource(**ssh_kwargs)
+
+        slurm_queue = SlurmQueueConfig(
+            **{k: v for k, v in {
+                "partition": queue_cfg.get("partition"),
+                "account": queue_cfg.get("account"),
+                "qos": queue_cfg.get("qos"),
+                "time_limit": queue_cfg.get("time_limit"),
+                "cpus": queue_cfg.get("cpus"),
+                "mem": queue_cfg.get("mem"),
+                "mem_per_cpu": queue_cfg.get("mem_per_cpu"),
+                "gpus_per_node": queue_cfg.get("gpus_per_node"),
+                "num_nodes": queue_cfg.get("nodes"),
+            }.items() if v is not None},
+        )
+
+        slurm_res = SlurmResource(
+            ssh=ssh,
+            queue=slurm_queue,
+            remote_base=target_config.get("remote_base") or None,
+        )
+
+        return ComputeResource(
+            mode=dagster_mode,
+            slurm=slurm_res,
+            default_launcher=BashLauncher(),
+            pre_deployed_env_path=target_config.get("pre_deployed_env_path") or sys.prefix,
+        )
+
+    raise ValueError(f"Unsupported target mode for dagster-slurm: {mode_str!r}")
+
+
+def prepare_payload(
+    *,
+    command: str,
+    universe_id: str,
+    output_id: str,
+    project_root: Path,
+    params: dict[str, Any] | None = None,
+    external_inputs: dict[str, str] | None = None,
+    cwd_override: str | None = None,
+    container_wrap: list[str] | None = None,
+    extra_sbatch_directives: list[str] | None = None,
+    payload_override: Path | None = None,
+    target_config: dict[str, Any] | None = None,
+) -> tuple[Path, PayloadCtx]:
+    """Write a per-materialization payload wrapper to ``results/.payloads/``.
+
+    If ``payload_override`` is provided, the script at that path is copied
+    verbatim (honours the ``recipe.payload:`` escape hatch of ADR-0001 §4.3).
+    Otherwise, an auto-generated wrapper invokes ``command`` with CLI args
+    flattened from ``params``, wrapped in ``container_wrap`` if supplied.
+
+    Returns the path to the written file plus a :class:`PayloadCtx` used by
+    :func:`stage_artifacts` once the run completes.
+    """
+    payloads_dir = project_root / "results" / ".payloads"
+    payloads_dir.mkdir(parents=True, exist_ok=True)
+    payload_path = payloads_dir / f"{universe_id}__{output_id}.py"
+
+    if payload_override is not None:
+        shutil.copyfile(payload_override, payload_path)
+    else:
+        payload_path.write_text(
+            _render_wrapper(
+                command=command,
+                universe_id=universe_id,
+                output_id=output_id,
+                params=params or {},
+                external_inputs=external_inputs,
+                cwd_override=cwd_override,
+                container_wrap=container_wrap,
+                extra_sbatch_directives=extra_sbatch_directives,
+            )
+        )
+
+    return payload_path, PayloadCtx(
+        universe_id=universe_id,
+        output_id=output_id,
+        payload_path=payload_path,
+        project_root=project_root,
+        target_config=target_config,
+    )
+
+
+def _flatten_params_to_cli_args(params: dict[str, Any]) -> list[str]:
+    """Turn a decision-param dict into a ``--key value`` CLI-arg list.
+
+    Bool ``True`` becomes a bare ``--flag`` (no value); ``False`` is skipped.
+    Other scalar values are stringified. Non-scalar values (dict/list) are
+    JSON-encoded.
+    """
+    args: list[str] = []
+    for key, val in params.items():
+        flag = f"--{key.replace('_', '-')}"
+        if val is True:
+            args.append(flag)
+        elif val is False or val is None:
+            continue
+        elif isinstance(val, (dict, list)):
+            args.extend([flag, json.dumps(val)])
+        else:
+            args.extend([flag, str(val)])
+    return args
+
+
+def _render_wrapper(
+    *,
+    command: str,
+    universe_id: str,
+    output_id: str,
+    params: dict[str, Any],
+    external_inputs: dict[str, str] | None,
+    cwd_override: str | None,
+    container_wrap: list[str] | None,
+    extra_sbatch_directives: list[str] | None,
+) -> str:
+    """Render the payload wrapper source (ADR-0001 §4.3)."""
+    cli_args = _flatten_params_to_cli_args(params)
+    sbatch_lines = [f"#SBATCH {d}" for d in (extra_sbatch_directives or [])]
+    sbatch_block = "\n".join(sbatch_lines)
+    if sbatch_block:
+        sbatch_block += "\n"
+
+    ext = external_inputs or {}
+    # json.dumps produces valid Python literals for str, list[str], None, dict.
+    return f'''\
+#!/usr/bin/env python3
+{sbatch_block}# Auto-generated by lightcone.engine.compute_adapter — do not edit.
+# universe={universe_id} output={output_id}
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+
+CMD = {json.dumps(command)}
+CLI_ARGS = {json.dumps(cli_args)}
+CWD = {json.dumps(cwd_override)}
+CONTAINER_WRAP = {json.dumps(container_wrap)}
+EXTERNAL_INPUTS = {json.dumps(ext)}
+UNIVERSE_ID = {json.dumps(universe_id)}
+OUTPUT_ID = {json.dumps(output_id)}
+
+try:
+    from dagster_pipes import open_dagster_pipes
+except ImportError:  # parity / legacy local runs without dagster-pipes
+    class _NoopPipes:
+        class log:
+            @staticmethod
+            def info(msg: str) -> None: print(msg, flush=True)
+        def report_asset_materialization(self, **_: object) -> None: ...
+    def open_dagster_pipes():  # type: ignore[no-redef]
+        class _Ctx:
+            def __enter__(self): return _NoopPipes()
+            def __exit__(self, *_): return False
+        return _Ctx()
+
+
+def _main() -> int:
+    env = dict(os.environ)
+    env["ASTRA_UNIVERSE"] = UNIVERSE_ID
+    env["ASTRA_OUTPUT"] = OUTPUT_ID
+    for name, path in EXTERNAL_INPUTS.items():
+        env[f"ASTRA_INPUT_{{name.upper()}}"] = path
+
+    full = shlex.split(CMD) + list(CLI_ARGS)
+    if CONTAINER_WRAP:
+        full = list(CONTAINER_WRAP) + full
+
+    with open_dagster_pipes() as pipes:
+        pipes.log.info(f"astra recipe: {{shlex.join(full)}}")
+        proc = subprocess.run(full, cwd=CWD or None, env=env, check=False)
+        pipes.report_asset_materialization(
+            metadata={{
+                "exit_code": proc.returncode,
+                "command": shlex.join(full),
+                "universe": UNIVERSE_ID,
+                "output": OUTPUT_ID,
+            }}
+        )
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(_main())
+'''
+
+
+def stage_artifacts(
+    completed: Any,
+    ctx: PayloadCtx,
+    *,
+    run_id: str | None = None,
+) -> None:
+    """Copy remote sbatch script and logs into ``results/.slurm/``.
+
+    In local mode this is a no-op — there are no remote files to fetch.
+
+    In SLURM mode, reads ``{remote_base}/runs/{run_id}/job.sh`` and
+    ``slurm-*.{out,err}`` via SSH and writes them to
+    ``results/.slurm/{output_id}_{universe_id}.*`` to preserve the existing
+    on-disk layout used by ``lc status`` and tail-style debugging.
+
+    Requires ``ctx.target_config`` (set by :func:`prepare_payload` when called
+    from :func:`~lightcone.engine.assets.build_definitions`) and ``run_id``
+    (the Dagster run ID, available as ``context.run_id`` inside an asset).
+    """
+    if ctx.target_config is None or run_id is None:
+        return
+
+    mode = ctx.target_config.get("mode", "local")
+    if mode not in ("slurm", "slurm-session"):
+        return
+
+    ssh_cfg = ctx.target_config.get("ssh") or {}
+    remote_base = ctx.target_config.get("remote_base")
+    if not ssh_cfg.get("host") or not remote_base:
+        return
+
+    _stage_slurm_artifacts(
+        ssh_cfg=ssh_cfg,
+        remote_base=remote_base,
+        run_id=run_id,
+        ctx=ctx,
+    )
+
+
+def _stage_slurm_artifacts(
+    *,
+    ssh_cfg: dict[str, Any],
+    remote_base: str,
+    run_id: str,
+    ctx: PayloadCtx,
+) -> None:
+    """Fetch job.sh + slurm-*.{out,err} from the SLURM node and write locally."""
+    from dagster_slurm import (
+        SSHConnectionResource,  # type: ignore[import-not-found]  # noqa: PLC0415
+    )
+    from dagster_slurm.helpers.ssh_pool import (
+        SSHConnectionPool,  # type: ignore[import-not-found]  # noqa: PLC0415
+    )
+
+    ssh_kwargs: dict[str, Any] = {
+        "host": ssh_cfg["host"],
+        "user": ssh_cfg.get("user", ""),
+    }
+    if ssh_cfg.get("port"):
+        ssh_kwargs["port"] = int(ssh_cfg["port"])
+    if ssh_cfg.get("key_path"):
+        ssh_kwargs["key_path"] = ssh_cfg["key_path"]
+    elif ssh_cfg.get("password"):
+        ssh_kwargs["password"] = ssh_cfg["password"]
+    ssh_resource = SSHConnectionResource(**ssh_kwargs)
+
+    run_dir = f"{remote_base}/runs/{run_id}"
+    slurm_dir = ctx.project_root / "results" / ".slurm"
+    slurm_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{ctx.output_id}_{ctx.universe_id}"
+
+    with SSHConnectionPool(ssh_resource) as pool:
+        # Copy the sbatch script
+        content = pool.run(f"cat {run_dir}/job.sh 2>/dev/null || true").strip()
+        if content:
+            (slurm_dir / f"{stem}.sh").write_text(content + "\n")
+
+        # Copy stdout / stderr (filename includes the SLURM job ID as a number)
+        for ext in ("out", "err"):
+            listing = pool.run(
+                f"ls {run_dir}/slurm-*.{ext} 2>/dev/null || true"
+            ).strip()
+            for remote_path in listing.splitlines():
+                remote_path = remote_path.strip()
+                if remote_path:
+                    body = pool.run(f"cat {remote_path} 2>/dev/null || true")
+                    (slurm_dir / f"{stem}.{ext}").write_text(body)
+                    break

--- a/src/lightcone/engine/runner.py
+++ b/src/lightcone/engine/runner.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from lightcone.engine.slurm_utils import normalise_time_limit as _normalise_time_limit
+
 logger = logging.getLogger(__name__)
 
 # Maximum number of characters to keep from stdout/stderr for metadata.
@@ -762,29 +764,6 @@ def translate_resources_to_slurm_directives(
     directives.extend(extra_args)
 
     return directives
-
-
-def _normalise_time_limit(value: str | int) -> str:
-    """Convert time_limit values like '2h', '30m', 120 to HH:MM:SS."""
-    if isinstance(value, int):
-        # Assume minutes
-        hours, minutes = divmod(value, 60)
-        return f"{hours:02d}:{minutes:02d}:00"
-    value = str(value).strip()
-    match = re.match(r"^(\d+)([hm]?)$", value, re.IGNORECASE)
-    if match:
-        num, unit = int(match.group(1)), match.group(2).lower()
-        if unit == "h":
-            return f"{num:02d}:00:00"
-        elif unit == "m":
-            hours, minutes = divmod(num, 60)
-            return f"{hours:02d}:{minutes:02d}:00"
-        else:
-            # bare number = minutes
-            hours, minutes = divmod(num, 60)
-            return f"{hours:02d}:{minutes:02d}:00"
-    # Already in HH:MM:SS or similar — pass through
-    return value
 
 
 def generate_sbatch_script(

--- a/src/lightcone/engine/slurm_utils.py
+++ b/src/lightcone/engine/slurm_utils.py
@@ -1,0 +1,65 @@
+"""Pure helpers shared between the legacy runner and the dagster-slurm adapter.
+
+These were previously private functions inside ``runner.py``. They are moved
+here so the new ``compute_adapter`` can reuse them without circularly
+depending on the runner (which will eventually shrink to the Docker backend
+only, per ADR-0001 Phase E).
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+__all__ = ["normalise_time_limit", "resources_to_slurm_opts"]
+
+
+def normalise_time_limit(value: str | int) -> str:
+    """Convert time_limit values like ``"2h"``, ``"30m"``, ``120`` to ``HH:MM:SS``.
+
+    Bare integers and bare numeric strings are interpreted as minutes.
+    Values already in ``HH:MM:SS`` (or any unrecognised format) are returned
+    unchanged so upstream tooling can still accept them.
+    """
+    if isinstance(value, int):
+        hours, minutes = divmod(value, 60)
+        return f"{hours:02d}:{minutes:02d}:00"
+    value = str(value).strip()
+    match = re.match(r"^(\d+)([hm]?)$", value, re.IGNORECASE)
+    if match:
+        num, unit = int(match.group(1)), match.group(2).lower()
+        if unit == "h":
+            return f"{num:02d}:00:00"
+        # bare number or explicit "m" → minutes
+        hours, minutes = divmod(num, 60)
+        return f"{hours:02d}:{minutes:02d}:00"
+    return value
+
+
+def resources_to_slurm_opts(resources: dict[str, Any] | None) -> dict[str, Any]:
+    """Translate a recipe ``resources`` dict to dagster-slurm ``extra_slurm_opts``.
+
+    Mapping (ADR-0001 §4.2):
+
+    * ``cpus`` → ``cpus_per_task``
+    * ``memory`` → ``mem``
+    * ``gpus`` → ``gpus_per_node``
+    * ``nodes`` → ``nodes``
+    * ``time_limit`` → ``time_limit`` (normalised to ``HH:MM:SS``)
+
+    Unknown keys are ignored. Missing keys do not appear in the output — the
+    dagster-slurm resource's own defaults apply.
+    """
+    if not resources:
+        return {}
+    out: dict[str, Any] = {}
+    if "cpus" in resources:
+        out["cpus_per_task"] = resources["cpus"]
+    if "memory" in resources:
+        out["mem"] = resources["memory"]
+    if "gpus" in resources:
+        out["gpus_per_node"] = resources["gpus"]
+    if "nodes" in resources:
+        out["nodes"] = resources["nodes"]
+    if "time_limit" in resources:
+        out["time_limit"] = normalise_time_limit(resources["time_limit"])
+    return out

--- a/src/lightcone/engine/targets.py
+++ b/src/lightcone/engine/targets.py
@@ -1,10 +1,129 @@
 """Target configuration management for Dagster execution backends."""
 from __future__ import annotations
 
+import warnings
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+
+class TargetKind(StrEnum):
+    """Execution backends a target config can declare.
+
+    Aligned with `dagster-slurm`'s `ComputeResource` modes (ADR-0001 §4.4),
+    plus `docker` for lightcone-cli's hermetic local runs.
+    """
+
+    DOCKER = "docker"
+    LOCAL = "local"
+    SLURM = "slurm"
+    SLURM_SESSION = "slurm-session"
+
+
+def detect_target_shape(cfg: dict[str, Any]) -> str:
+    """Return "new" if the config uses the post-ADR-0001 ``mode:`` schema,
+    "legacy" if it uses the pre-ADR-0001 ``backend:`` schema.
+    """
+    if "mode" in cfg:
+        return "new"
+    if "backend" in cfg:
+        return "legacy"
+    raise ValueError(
+        "Target config has neither 'mode' nor 'backend' key — cannot determine shape."
+    )
+
+
+def normalize_target(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Return ``cfg`` in the post-ADR-0001 target schema (§4.4).
+
+    Accepts both shapes. Emits ``DeprecationWarning`` on the legacy shape and
+    translates it to the new one in-memory; the file on disk is not touched
+    (use ``lc target migrate <name>`` for that).
+    """
+    shape = detect_target_shape(cfg)
+    if shape == "new":
+        return cfg
+    warnings.warn(
+        "Target YAML uses the pre-ADR-0001 'backend:' schema. "
+        "Run 'lc target migrate <name>' to convert to the new 'mode:' schema. "
+        "The legacy shape will be removed after Phase E.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _legacy_to_new(cfg)
+
+
+def _legacy_to_new(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Translate a legacy ``backend:``-shaped target dict to the new schema."""
+    scheduler = cfg.get("scheduler") or {}
+    connection = cfg.get("connection") or {}
+    poll = cfg.get("poll") or {}
+
+    # Some wizard-produced configs stash scheduler fields flat at the top level
+    # rather than under `scheduler:` — accept both.
+    def s(key: str) -> Any:
+        return scheduler.get(key, cfg.get(key))
+
+    out: dict[str, Any] = {
+        "name": cfg.get("name") or cfg.get("site"),
+        "mode": cfg.get("backend", "docker"),
+    }
+    if "site" in cfg:
+        out["site"] = cfg["site"]
+
+    ssh: dict[str, Any] = {}
+    if connection.get("hostname"):
+        ssh["host"] = connection["hostname"]
+    for src_key, dst_key in (("user", "user"), ("key_path", "key_path"), ("port", "port")):
+        if connection.get(src_key):
+            ssh[dst_key] = connection[src_key]
+    if ssh:
+        out["ssh"] = ssh
+
+    queue: dict[str, Any] = {}
+    for src_key, dst_key in (
+        ("partition", "partition"),
+        ("account", "account"),
+        ("qos", "qos"),
+        ("time_limit", "time_limit"),
+        ("cpus", "cpus"),
+        ("mem_per_cpu", "mem_per_cpu"),
+        ("gpus_per_node", "gpus_per_node"),
+        ("nodes", "nodes"),
+    ):
+        val = s(src_key)
+        if val is not None:
+            queue[dst_key] = val
+    if queue:
+        out["queue"] = queue
+
+    container: dict[str, Any] = {}
+    if s("container_runtime"):
+        container["runtime"] = s("container_runtime")
+    if s("container_flags"):
+        container["flags"] = s("container_flags")
+    if container:
+        out["container"] = container
+
+    extra: list[str] = []
+    constraint = s("constraint")
+    if constraint:
+        extra.append(f"--constraint={constraint}")
+    extra_args = s("extra_slurm_args") or []
+    extra.extend(extra_args)
+    if extra:
+        out["extra_sbatch_directives"] = extra
+
+    if poll.get("timeout_seconds") is not None:
+        out["poll"] = {"timeout_seconds": poll["timeout_seconds"]}
+
+    remote_base = cfg.get("remote_base")
+    if remote_base:
+        out["remote_base"] = remote_base
+
+    return out
 
 
 def get_targets_dir() -> Path:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,110 @@
+"""Pytest fixtures for SLURM emulator integration tests (ADR-0001 §5.3).
+
+The ``slurm_emulator`` fixture brings up the Docker-compose SLURM cluster
+defined in ``docker-compose.yml``.  Tests are skipped automatically when
+Docker is unavailable or the emulator fails to start within the timeout.
+
+Credentials match the upstream image defaults:
+  SSH host: localhost, port: 2223, user: submitter, password: submitter
+"""
+from __future__ import annotations
+
+import subprocess
+import time
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_COMPOSE_FILE = Path(__file__).parent / "docker-compose.yml"
+_SSH_PORT = 2223
+_SSH_USER = "submitter"
+_SSH_PASSWORD = "submitter"
+_REMOTE_BASE = f"/home/{_SSH_USER}/lightcone-runs"
+_STARTUP_TIMEOUT = 120
+
+
+def _docker_available() -> bool:
+    """Return True if the Docker daemon is reachable."""
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _wait_for_ssh(port: int, timeout: int = _STARTUP_TIMEOUT) -> bool:
+    """Return True when sshd on localhost:port accepts connections."""
+    import socket
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("localhost", port), timeout=2):
+                return True
+        except OSError:
+            time.sleep(2)
+    return False
+
+
+@pytest.fixture(scope="session")
+def slurm_emulator() -> Generator[None, None, None]:
+    """Session-scoped fixture: start the SLURM Docker cluster and tear it down.
+
+    Skipped when Docker is unavailable.  Tests in this session that depend on
+    this fixture are automatically skipped via ``pytest.mark.needs_slurm_docker``.
+    """
+    if not _docker_available():
+        pytest.skip("Docker daemon not reachable — skipping SLURM emulator tests")
+
+    compose_cmd = ["docker", "compose", "-f", str(_COMPOSE_FILE)]
+
+    # Bring up the cluster
+    up = subprocess.run(
+        [*compose_cmd, "up", "-d", "--wait", f"--wait-timeout={_STARTUP_TIMEOUT}"],
+        capture_output=True,
+        text=True,
+        timeout=_STARTUP_TIMEOUT + 30,
+    )
+    if up.returncode != 0:
+        pytest.skip(
+            f"docker compose up failed (rc={up.returncode}): {up.stderr[:500]}"
+        )
+
+    # Wait for SSH to be ready on slurmctld (port 2223)
+    if not _wait_for_ssh(_SSH_PORT):
+        subprocess.run([*compose_cmd, "down", "-v"], capture_output=True)
+        pytest.skip("SLURM emulator SSH did not become reachable within timeout")
+
+    try:
+        yield
+    finally:
+        subprocess.run(
+            [*compose_cmd, "down", "-v"],
+            capture_output=True,
+            timeout=60,
+        )
+
+
+@pytest.fixture()
+def emulator_target() -> dict[str, Any]:
+    """Normalized target config pointing at the local SLURM Docker emulator."""
+    return {
+        "mode": "slurm",
+        "ssh": {
+            "host": "localhost",
+            "port": _SSH_PORT,
+            "user": _SSH_USER,
+            "password": _SSH_PASSWORD,
+        },
+        "queue": {
+            "partition": "debug",
+            "time_limit": "00:05:00",
+        },
+        "remote_base": _REMOTE_BASE,
+    }

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,0 +1,77 @@
+---
+# SLURM Docker cluster emulator for integration tests (ADR-0001 §5.3).
+# Uses the upstream dagster-slurm Docker image — we do not vendor the build
+# context. Pin the tag in CI if upstream breaks compatibility.
+#
+# Usage:
+#   docker compose up -d --wait --wait-timeout 120
+#   docker compose down -v
+#
+# Credentials: user=submitter, password=submitter, port=2223 on localhost.
+
+name: lightcone-slurm-test
+
+services:
+  mysql:
+    image: mariadb:10.10
+    hostname: mysql
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+      MYSQL_USER: slurm
+      MYSQL_PASSWORD: slurm
+      MYSQL_DATABASE: slurm_acct_db
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "slurm", "-pslurm"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - slurm
+
+  slurmdbd:
+    image: ghcr.io/ascii-supply-networks/dagster-slurm/slurm-docker-cluster:25-11-2-1
+    command: ["slurmdbd"]
+    hostname: slurmdbd
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      - slurm
+
+  slurmctld:
+    image: ghcr.io/ascii-supply-networks/dagster-slurm/slurm-docker-cluster:25-11-2-1
+    command: ["slurmctld"]
+    hostname: slurmctld
+    ports:
+      - "2223:22"
+    depends_on:
+      - slurmdbd
+    networks:
+      - slurm
+    healthcheck:
+      test: ["CMD", "scontrol", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+
+  c1:
+    image: ghcr.io/ascii-supply-networks/dagster-slurm/slurm-docker-cluster:25-11-2-1
+    command: ["slurmd"]
+    hostname: c1
+    depends_on:
+      - slurmctld
+    networks:
+      - slurm
+
+  c2:
+    image: ghcr.io/ascii-supply-networks/dagster-slurm/slurm-docker-cluster:25-11-2-1
+    command: ["slurmd"]
+    hostname: c2
+    depends_on:
+      - slurmctld
+    networks:
+      - slurm
+
+networks:
+  slurm:
+    driver: bridge

--- a/tests/integration/test_slurm_emulator.py
+++ b/tests/integration/test_slurm_emulator.py
@@ -1,0 +1,338 @@
+"""Integration tests for SLURM mode via the Docker emulator (ADR-0001 §5.3).
+
+All tests require the ``slurm_emulator`` fixture (Docker daemon + compose cluster).
+They are marked ``needs_slurm_docker`` and ``slow`` so they are excluded from the
+default test run and collected only when explicitly requested:
+
+    pytest -m needs_slurm_docker tests/integration/
+    LIGHTCONE_USE_DAGSTER_SLURM=1 pytest -m needs_slurm_docker tests/integration/
+
+The emulator credentials are: localhost:2223, user=submitter, password=submitter.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+
+import dagster as dg
+import pytest
+
+from lightcone.engine.compute_adapter import (
+    build_compute_resource,
+    has_dagster_slurm,
+    prepare_payload,
+    stage_artifacts,
+)
+
+pytestmark = [
+    pytest.mark.needs_slurm_docker,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not has_dagster_slurm(),
+        reason="dagster-slurm not installed (uv sync --group slurm-next)",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_asset(
+    cr: Any,
+    *,
+    command: str,
+    universe_id: str = "baseline",
+    output_id: str = "out",
+    project_root: Path,
+    target_config: dict[str, Any],
+    extra_sbatch_directives: list[str] | None = None,
+) -> dg.AssetsDefinition:
+    """Return a single Dagster asset that runs *command* via the emulator."""
+
+    @dg.asset(name=output_id, key_prefix=[universe_id])
+    def _asset(context: dg.AssetExecutionContext) -> dg.MaterializeResult:
+        payload_path, ctx = prepare_payload(
+            command=command,
+            universe_id=universe_id,
+            output_id=output_id,
+            project_root=project_root,
+            extra_sbatch_directives=extra_sbatch_directives,
+            target_config=target_config,
+        )
+        completed = cr.run(
+            context=context,
+            payload_path=str(payload_path),
+            poll_timeout=300,
+        )
+        stage_artifacts(completed, ctx, run_id=context.run_id)
+        return completed.get_materialize_result()
+
+    return _asset
+
+
+# ---------------------------------------------------------------------------
+# §5.3 test_emulator_end_to_end_single_asset
+# ---------------------------------------------------------------------------
+
+
+def test_emulator_end_to_end_single_asset(
+    slurm_emulator: None,
+    emulator_target: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    """A one-step recipe executes on the SLURM emulator and materialises."""
+    cr = build_compute_resource(emulator_target)
+    asset = _make_asset(
+        cr,
+        command="python3 -c \"import sys; sys.exit(0)\"",
+        project_root=tmp_path,
+        target_config=emulator_target,
+    )
+    result = dg.materialize([asset])
+    assert result.success
+
+
+# ---------------------------------------------------------------------------
+# §5.3 test_emulator_metadata_propagation
+# ---------------------------------------------------------------------------
+
+
+def test_emulator_metadata_propagation(
+    slurm_emulator: None,
+    emulator_target: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    """Metadata reported by pipes.report_asset_materialization reaches Dagster."""
+    cr = build_compute_resource(emulator_target)
+
+    # The payload wrapper always reports exit_code + universe + output.
+    asset = _make_asset(
+        cr,
+        command="python3 -c \"import sys; sys.exit(0)\"",
+        project_root=tmp_path,
+        target_config=emulator_target,
+        output_id="meta_out",
+    )
+    result = dg.materialize([asset])
+    assert result.success
+    mat = result.get_asset_materialization_events()
+    assert mat, "expected at least one materialization event"
+    metadata = mat[0].step_materialization_data.materialization.metadata
+    # The payload wrapper injects these keys via report_asset_materialization.
+    assert "exit_code" in metadata
+    assert "universe" in metadata
+    assert "output" in metadata
+
+
+# ---------------------------------------------------------------------------
+# §5.3 test_emulator_non_zero_exit_fails_asset
+# ---------------------------------------------------------------------------
+
+
+def test_emulator_non_zero_exit_fails_asset(
+    slurm_emulator: None,
+    emulator_target: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    """A recipe that exits non-zero causes the Dagster materialization to fail."""
+    cr = build_compute_resource(emulator_target)
+    asset = _make_asset(
+        cr,
+        command="python3 -c \"import sys; sys.exit(7)\"",
+        project_root=tmp_path,
+        target_config=emulator_target,
+        output_id="fail_out",
+    )
+    # dagster raises on non-zero exit — catch the exception
+    with pytest.raises(Exception):
+        dg.materialize([asset])
+
+
+# ---------------------------------------------------------------------------
+# §5.3 test_emulator_resource_directives_respected
+# ---------------------------------------------------------------------------
+
+
+def test_emulator_resource_directives_respected(
+    slurm_emulator: None,
+    emulator_target: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    """Resource directives from extra_slurm_opts appear in the staged sbatch script."""
+    from lightcone.engine.slurm_utils import resources_to_slurm_opts
+
+    cr = build_compute_resource(emulator_target)
+    resources = {"cpus": 1, "time_limit": "00:02:00"}
+
+    @dg.asset(name="res_out", key_prefix=["baseline"])
+    def _asset(context: dg.AssetExecutionContext) -> dg.MaterializeResult:
+        payload_path, ctx = prepare_payload(
+            command="python3 -c \"import sys; sys.exit(0)\"",
+            universe_id="baseline",
+            output_id="res_out",
+            project_root=tmp_path,
+            target_config=emulator_target,
+        )
+        completed = cr.run(
+            context=context,
+            payload_path=str(payload_path),
+            extra_slurm_opts=resources_to_slurm_opts(resources),
+            poll_timeout=300,
+        )
+        stage_artifacts(completed, ctx, run_id=context.run_id)
+        return completed.get_materialize_result()
+
+    result = dg.materialize([_asset])
+    assert result.success
+
+    slurm_dir = tmp_path / "results" / ".slurm"
+    sh_files = list(slurm_dir.glob("res_out_baseline.sh"))
+    assert sh_files, "expected staged sbatch script"
+    sbatch_content = sh_files[0].read_text()
+    # dagster-slurm injects -c (cpus) and -t (time_limit) into the sbatch command
+    assert "-c 1" in sbatch_content or "--cpus-per-task=1" in sbatch_content
+    assert "00:02:00" in sbatch_content
+
+
+# ---------------------------------------------------------------------------
+# §5.3 test_emulator_sbatch_constraint_via_extra_directives
+# ---------------------------------------------------------------------------
+
+
+def test_emulator_sbatch_constraint_via_extra_directives(
+    slurm_emulator: None,
+    emulator_target: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    """extra_sbatch_directives entries are present in the staged sbatch script."""
+    cr = build_compute_resource(emulator_target)
+    asset = _make_asset(
+        cr,
+        command="python3 -c \"import sys; sys.exit(0)\"",
+        project_root=tmp_path,
+        target_config=emulator_target,
+        extra_sbatch_directives=["--comment=lightcone-test"],
+        output_id="constraint_out",
+    )
+    result = dg.materialize([asset])
+    assert result.success
+
+    slurm_dir = tmp_path / "results" / ".slurm"
+    sh_files = list(slurm_dir.glob("constraint_out_baseline.sh"))
+    assert sh_files, "expected staged sbatch script"
+    assert "--comment=lightcone-test" in sh_files[0].read_text()
+
+
+# ---------------------------------------------------------------------------
+# §5.3 test_emulator_log_streaming
+# ---------------------------------------------------------------------------
+
+
+def test_emulator_log_streaming(
+    slurm_emulator: None,
+    emulator_target: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    """Stdout lines emitted by the payload are captured in the staged .out file."""
+    cr = build_compute_resource(emulator_target)
+
+    # Emit 50 numbered lines to stdout
+    py_snippet = (
+        "import sys; "
+        "[print(f'line {i}', flush=True) for i in range(50)]; "
+        "sys.exit(0)"
+    )
+    asset = _make_asset(
+        cr,
+        command=f"python3 -c \"{py_snippet}\"",
+        project_root=tmp_path,
+        target_config=emulator_target,
+        output_id="log_out",
+    )
+    result = dg.materialize([asset])
+    assert result.success
+
+    slurm_dir = tmp_path / "results" / ".slurm"
+    out_files = list(slurm_dir.glob("log_out_baseline.out"))
+    assert out_files, "expected staged stdout file"
+    content = out_files[0].read_text()
+    # All 50 lines must be present
+    for i in range(50):
+        assert f"line {i}" in content, f"missing 'line {i}' in stdout"
+
+
+# ---------------------------------------------------------------------------
+# §5.3 test_emulator_cancellation
+# ---------------------------------------------------------------------------
+
+
+def test_emulator_cancellation(
+    slurm_emulator: None,
+    emulator_target: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    """Terminating a Dagster run cancels the underlying SLURM job.
+
+    Approach: run a long-sleeping recipe in a background thread and send
+    SIGTERM to the pipes client's signal handler after a short delay.
+    dagster-slurm registers a SIGTERM handler that cancels the job via
+    ``scancel``; we assert the job no longer appears in squeue after that.
+    """
+    import signal
+    import time
+
+    from dagster_slurm import SSHConnectionResource
+    from dagster_slurm.helpers.ssh_pool import SSHConnectionPool
+
+    cr = build_compute_resource(emulator_target)
+    errors: list[Exception] = []
+    run_ids: list[str] = []
+
+    @dg.asset(name="cancel_out", key_prefix=["baseline"])
+    def _asset(context: dg.AssetExecutionContext) -> dg.MaterializeResult:
+        run_ids.append(context.run_id)
+        payload_path, ctx = prepare_payload(
+            command="python3 -c \"import time; time.sleep(300)\"",
+            universe_id="baseline",
+            output_id="cancel_out",
+            project_root=tmp_path,
+            target_config=emulator_target,
+        )
+        return cr.run(
+            context=context,
+            payload_path=str(payload_path),
+            poll_timeout=60,
+        ).get_materialize_result()
+
+    def _run_asset() -> None:
+        try:
+            dg.materialize([_asset])
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    thread = threading.Thread(target=_run_asset, daemon=True)
+    thread.start()
+
+    # Give the job time to be submitted
+    time.sleep(20)
+
+    # Send SIGTERM to trigger dagster-slurm's cancellation handler
+    signal.raise_signal(signal.SIGTERM)
+
+    thread.join(timeout=60)
+
+    # Verify via squeue in the emulator that no jobs remain
+    ssh_cfg = emulator_target["ssh"]
+    ssh_res = SSHConnectionResource(
+        host=ssh_cfg["host"],
+        port=ssh_cfg["port"],
+        user=ssh_cfg["user"],
+        password=ssh_cfg["password"],
+    )
+    with SSHConnectionPool(ssh_res) as pool:
+        queue = pool.run("squeue --noheader 2>/dev/null || true").strip()
+
+    assert queue == "", f"expected empty squeue after cancellation, got: {queue!r}"

--- a/tests/test_compute_adapter.py
+++ b/tests/test_compute_adapter.py
@@ -1,0 +1,373 @@
+"""Unit tests for lightcone.engine.compute_adapter (ADR-0001 §5.1).
+
+These tests do NOT require a running SLURM cluster or Docker.
+Tests that require dagster-slurm to be installed are marked with
+``needs_dagster_slurm`` and skipped automatically when the library is absent.
+"""
+from __future__ import annotations
+
+import py_compile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from lightcone.engine.compute_adapter import (
+    has_dagster_slurm,
+    prepare_payload,
+)
+from lightcone.engine.slurm_utils import normalise_time_limit, resources_to_slurm_opts
+
+needs_dagster_slurm = pytest.mark.skipif(
+    not has_dagster_slurm(),
+    reason="dagster-slurm not installed (uv sync --group slurm-next)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _local_target() -> dict[str, Any]:
+    return {"mode": "local"}
+
+
+def _slurm_target() -> dict[str, Any]:
+    return {
+        "mode": "slurm",
+        "ssh": {"host": "hpc.example.com", "user": "researcher", "key_path": "~/.ssh/id_rsa"},
+        "queue": {"partition": "gpu", "account": "proj123", "qos": "debug"},
+        "remote_base": "/scratch/researcher/lightcone-runs",
+        "poll": {"timeout_seconds": 7200},
+    }
+
+
+# ---------------------------------------------------------------------------
+# §5.1 test_target_yaml_to_compute_resource
+# ---------------------------------------------------------------------------
+
+
+@needs_dagster_slurm
+class TestBuildComputeResource:
+    def test_local_mode_constructs_without_error(self):
+        from lightcone.engine.compute_adapter import build_compute_resource
+
+        cr = build_compute_resource(_local_target())
+        assert cr is not None
+
+    def test_local_mode_is_correct_execution_mode(self):
+        from dagster_slurm.resources.compute import ExecutionMode
+
+        from lightcone.engine.compute_adapter import build_compute_resource
+
+        cr = build_compute_resource(_local_target())
+        assert cr.mode == ExecutionMode.LOCAL
+
+    def test_slurm_mode_constructs_without_error(self):
+        from lightcone.engine.compute_adapter import build_compute_resource
+
+        cr = build_compute_resource(_slurm_target())
+        assert cr is not None
+
+    def test_slurm_mode_ssh_host(self):
+        from lightcone.engine.compute_adapter import build_compute_resource
+
+        cr = build_compute_resource(_slurm_target())
+        assert cr.slurm.ssh.host == "hpc.example.com"
+
+    def test_slurm_mode_queue_account(self):
+        from lightcone.engine.compute_adapter import build_compute_resource
+
+        cr = build_compute_resource(_slurm_target())
+        assert cr.slurm.queue.account == "proj123"
+
+    def test_docker_mode_raises(self):
+        from lightcone.engine.compute_adapter import build_compute_resource
+
+        with pytest.raises(ValueError, match="Docker targets"):
+            build_compute_resource({"mode": "docker"})
+
+    def test_compute_resource_is_constructed_lazily(self):
+        """Constructing a ComputeResource must not open an SSH connection."""
+        from lightcone.engine.compute_adapter import build_compute_resource
+
+        # This would raise if a real connection attempt were made.
+        cr = build_compute_resource(_slurm_target())
+        assert cr is not None  # no exception = connection not opened
+
+
+# ---------------------------------------------------------------------------
+# §5.1 test_resources_dict_to_slurm_opts
+# ---------------------------------------------------------------------------
+
+
+class TestResourcestoSlurmOpts:
+    def test_full_mapping(self):
+        opts = resources_to_slurm_opts(
+            {"cpus": 4, "memory": "8G", "gpus": 2, "nodes": 1, "time_limit": "30m"}
+        )
+        assert opts == {
+            "cpus_per_task": 4,
+            "mem": "8G",
+            "gpus_per_node": 2,
+            "nodes": 1,
+            "time_limit": "00:30:00",
+        }
+
+    def test_empty_returns_empty(self):
+        assert resources_to_slurm_opts(None) == {}
+        assert resources_to_slurm_opts({}) == {}
+
+    def test_partial_mapping(self):
+        opts = resources_to_slurm_opts({"cpus": 8})
+        assert opts == {"cpus_per_task": 8}
+        assert "mem" not in opts
+        assert "time_limit" not in opts
+
+    def test_time_limit_hours(self):
+        opts = resources_to_slurm_opts({"time_limit": "1h"})
+        assert opts["time_limit"] == "01:00:00"
+
+    def test_time_limit_colon_format(self):
+        opts = resources_to_slurm_opts({"time_limit": "2:00:00"})
+        assert opts["time_limit"] == "2:00:00"
+
+    def test_time_limit_bare_int_minutes(self):
+        opts = resources_to_slurm_opts({"time_limit": "120"})
+        assert opts["time_limit"] == "02:00:00"
+
+    def test_unknown_keys_ignored(self):
+        opts = resources_to_slurm_opts({"cpus": 2, "unknown_key": "ignored"})
+        assert "unknown_key" not in opts
+
+
+class TestNormaliseTimeLimit:
+    def test_hours(self):
+        assert normalise_time_limit("2h") == "02:00:00"
+
+    def test_minutes(self):
+        assert normalise_time_limit("90m") == "01:30:00"
+
+    def test_bare_int_minutes(self):
+        assert normalise_time_limit(120) == "02:00:00"
+
+    def test_bare_string_minutes(self):
+        assert normalise_time_limit("45") == "00:45:00"
+
+    def test_passthrough_hh_mm_ss(self):
+        assert normalise_time_limit("03:30:00") == "03:30:00"
+
+
+# ---------------------------------------------------------------------------
+# §5.1 test_payload_wrapper_generation
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadWrapperGeneration:
+    def test_generated_file_compiles(self, tmp_path: Path):
+        payload_path, ctx = prepare_payload(
+            command="python scripts/compute.py",
+            universe_id="baseline",
+            output_id="photoz",
+            project_root=tmp_path,
+            params={"method": "bpz", "zmax": 3.0},
+        )
+        py_compile.compile(str(payload_path), doraise=True)
+
+    def test_cli_args_present_in_payload(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="python scripts/compute.py",
+            universe_id="baseline",
+            output_id="photoz",
+            project_root=tmp_path,
+            params={"method": "bpz"},
+        )
+        source = payload_path.read_text()
+        assert '"--method"' in source
+        assert '"bpz"' in source
+
+    def test_command_present_in_payload(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="python scripts/compute.py",
+            universe_id="baseline",
+            output_id="photoz",
+            project_root=tmp_path,
+        )
+        source = payload_path.read_text()
+        assert "python scripts/compute.py" in source
+
+    def test_container_wrap_present_when_set(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="python scripts/compute.py",
+            universe_id="baseline",
+            output_id="photoz",
+            project_root=tmp_path,
+            container_wrap=["podman-hpc", "run", "--rm", "--gpu"],
+        )
+        source = payload_path.read_text()
+        assert "podman-hpc" in source
+        assert "CONTAINER_WRAP" in source
+
+    def test_no_container_wrap_is_none(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="python scripts/compute.py",
+            universe_id="baseline",
+            output_id="photoz",
+            project_root=tmp_path,
+        )
+        source = payload_path.read_text()
+        assert "CONTAINER_WRAP = null" in source
+
+    def test_pipes_materialization_reported(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="python scripts/compute.py",
+            universe_id="baseline",
+            output_id="photoz",
+            project_root=tmp_path,
+        )
+        source = payload_path.read_text()
+        assert "report_asset_materialization" in source
+
+    def test_payload_path_layout(self, tmp_path: Path):
+        _, ctx = prepare_payload(
+            command="python scripts/compute.py",
+            universe_id="u1",
+            output_id="out1",
+            project_root=tmp_path,
+        )
+        expected = tmp_path / "results" / ".payloads" / "u1__out1.py"
+        assert ctx.payload_path == expected
+        assert expected.exists()
+
+    def test_payload_ctx_fields(self, tmp_path: Path):
+        _, ctx = prepare_payload(
+            command="cmd",
+            universe_id="u1",
+            output_id="o1",
+            project_root=tmp_path,
+        )
+        assert ctx.universe_id == "u1"
+        assert ctx.output_id == "o1"
+        assert ctx.project_root == tmp_path
+
+    def test_bool_true_param_becomes_flag(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="cmd",
+            universe_id="baseline",
+            output_id="out",
+            project_root=tmp_path,
+            params={"verbose": True},
+        )
+        source = payload_path.read_text()
+        assert '"--verbose"' in source
+        # True flag has no value pair, so False should NOT appear for this param
+        assert '"True"' not in source
+
+    def test_bool_false_param_omitted(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="cmd",
+            universe_id="baseline",
+            output_id="out",
+            project_root=tmp_path,
+            params={"dry_run": False},
+        )
+        source = payload_path.read_text()
+        assert "--dry-run" not in source
+
+    def test_payload_override_copies_file(self, tmp_path: Path):
+        custom = tmp_path / "custom_payload.py"
+        custom.write_text("# custom payload\nprint('hello')\n")
+
+        payload_path, _ = prepare_payload(
+            command="cmd",
+            universe_id="baseline",
+            output_id="out",
+            project_root=tmp_path,
+            payload_override=custom,
+        )
+        assert payload_path.read_text() == custom.read_text()
+
+    def test_external_inputs_encoded_in_payload(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="python run.py",
+            universe_id="baseline",
+            output_id="out",
+            project_root=tmp_path,
+            external_inputs={"raw_catalog": "/data/raw.parquet"},
+        )
+        source = payload_path.read_text()
+        assert "raw_catalog" in source
+        assert "/data/raw.parquet" in source
+
+
+# ---------------------------------------------------------------------------
+# §5.1 test_extra_sbatch_directives_injection
+# ---------------------------------------------------------------------------
+
+
+class TestExtraSbatchDirectivesInjection:
+    def test_constraint_appears_in_sbatch_block(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="python run.py",
+            universe_id="baseline",
+            output_id="out",
+            project_root=tmp_path,
+            extra_sbatch_directives=["--constraint=gpu"],
+        )
+        source = payload_path.read_text()
+        assert "#SBATCH --constraint=gpu" in source
+
+    def test_multiple_directives(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="python run.py",
+            universe_id="baseline",
+            output_id="out",
+            project_root=tmp_path,
+            extra_sbatch_directives=["--constraint=gpu", "--reservation=maint"],
+        )
+        source = payload_path.read_text()
+        assert "#SBATCH --constraint=gpu" in source
+        assert "#SBATCH --reservation=maint" in source
+
+    def test_no_directives_no_sbatch_lines(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="python run.py",
+            universe_id="baseline",
+            output_id="out",
+            project_root=tmp_path,
+        )
+        source = payload_path.read_text()
+        assert "#SBATCH" not in source
+
+    def test_file_parses_as_valid_python_with_directives(self, tmp_path: Path):
+        payload_path, _ = prepare_payload(
+            command="python run.py",
+            universe_id="baseline",
+            output_id="out",
+            project_root=tmp_path,
+            extra_sbatch_directives=["--constraint=gpu"],
+        )
+        py_compile.compile(str(payload_path), doraise=True)
+
+
+# ---------------------------------------------------------------------------
+# §5.1 test_stage_artifacts — local mode is a no-op
+# ---------------------------------------------------------------------------
+
+
+class TestStageArtifacts:
+    def test_local_mode_noop(self, tmp_path: Path):
+        from lightcone.engine.compute_adapter import stage_artifacts
+
+        _, ctx = prepare_payload(
+            command="cmd",
+            universe_id="u1",
+            output_id="o1",
+            project_root=tmp_path,
+        )
+        # completed with no ssh_pool metadata → should return without error
+        mock_completed = MagicMock()
+        mock_completed.metadata = {}
+        stage_artifacts(mock_completed, ctx)  # must not raise

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -6,10 +6,13 @@ from pathlib import Path
 import pytest
 
 from lightcone.engine.targets import (
+    TargetKind,
+    detect_target_shape,
     get_config_path,
     list_targets,
     load_target,
     load_user_config,
+    normalize_target,
     save_target,
     save_user_config,
 )
@@ -81,3 +84,103 @@ class TestUserConfig:
         path = get_config_path()
         assert path.name == "config.yaml"
         assert ".lightcone" in str(path)
+
+
+class TestTargetKind:
+    def test_values(self):
+        assert TargetKind.DOCKER.value == "docker"
+        assert TargetKind.LOCAL.value == "local"
+        assert TargetKind.SLURM.value == "slurm"
+        assert TargetKind.SLURM_SESSION.value == "slurm-session"
+
+    def test_str_compatible(self):
+        # TargetKind is a str subclass so it round-trips through YAML naturally.
+        assert TargetKind.SLURM == "slurm"
+
+
+class TestDetectTargetShape:
+    def test_new_shape(self):
+        assert detect_target_shape({"mode": "slurm"}) == "new"
+
+    def test_legacy_shape(self):
+        assert detect_target_shape({"backend": "slurm"}) == "legacy"
+
+    def test_new_takes_precedence(self):
+        # If both are present (unlikely mixed config), the new shape wins.
+        assert detect_target_shape({"mode": "slurm", "backend": "slurm"}) == "new"
+
+    def test_missing_raises(self):
+        with pytest.raises(ValueError, match="neither 'mode' nor 'backend'"):
+            detect_target_shape({"site": "perlmutter"})
+
+
+class TestNormalizeTarget:
+    def test_new_shape_is_identity(self):
+        cfg = {
+            "name": "perlmutter",
+            "mode": "slurm",
+            "ssh": {"host": "perlmutter.nersc.gov"},
+            "queue": {"account": "m1234"},
+        }
+        assert normalize_target(cfg) == cfg
+
+    def test_legacy_emits_deprecation_warning(self, sample_target):
+        with pytest.warns(DeprecationWarning, match="pre-ADR-0001"):
+            normalize_target(sample_target)
+
+    def test_legacy_flat_scheduler_translation(self, sample_target):
+        # sample_target has scheduler-ish fields at the top level (wizard shape).
+        with pytest.warns(DeprecationWarning):
+            result = normalize_target(sample_target)
+
+        assert result["mode"] == "slurm"
+        assert result["name"] == "perlmutter"
+        assert result["site"] == "perlmutter"
+        assert result["ssh"] == {"host": "perlmutter.nersc.gov", "user": "testuser"} or (
+            result["ssh"]["host"] == "perlmutter.nersc.gov"
+        )
+        assert result["queue"]["account"] == "m1234"
+        assert result["queue"]["qos"] == "debug"
+        assert result["container"]["runtime"] == "podman-hpc"
+        assert "--constraint=gpu" in result["extra_sbatch_directives"]
+
+    def test_legacy_nested_scheduler_translation(self):
+        cfg = {
+            "site": "frontier",
+            "backend": "slurm",
+            "connection": {"hostname": "frontier.olcf.ornl.gov"},
+            "scheduler": {
+                "account": "CSC999",
+                "partition": "batch",
+                "qos": "normal",
+                "constraint": "gpu",
+                "container_runtime": "apptainer",
+                "container_flags": ["--nv"],
+                "extra_slurm_args": ["--reservation=maint"],
+            },
+            "poll": {"interval_seconds": 15, "timeout_seconds": 7200},
+        }
+        with pytest.warns(DeprecationWarning):
+            result = normalize_target(cfg)
+
+        assert result["mode"] == "slurm"
+        assert result["ssh"]["host"] == "frontier.olcf.ornl.gov"
+        assert result["queue"]["account"] == "CSC999"
+        assert result["queue"]["partition"] == "batch"
+        assert result["container"]["runtime"] == "apptainer"
+        assert result["container"]["flags"] == ["--nv"]
+        assert result["extra_sbatch_directives"] == [
+            "--constraint=gpu",
+            "--reservation=maint",
+        ]
+        # interval_seconds is dropped; only timeout_seconds carries over.
+        assert result["poll"] == {"timeout_seconds": 7200}
+
+    def test_legacy_docker_minimal(self):
+        cfg = {"backend": "docker"}
+        with pytest.warns(DeprecationWarning):
+            result = normalize_target(cfg)
+        assert result["mode"] == "docker"
+        assert "queue" not in result
+        assert "ssh" not in result
+        assert "extra_sbatch_directives" not in result


### PR DESCRIPTION
## Summary

Implements [ADR-0001](docs/adr/0001-adopt-dagster-slurm.md) — replace lightcone-cli's bespoke `local`/`venv`/`slurm` backends with [`dagster-slurm`](https://github.com/ascii-supply-networks/dagster-slurm) v1.13.

All new behaviour is **gated behind `LIGHTCONE_USE_DAGSTER_SLURM=1`**. Every existing code path is untouched; the legacy runner stays in place until Phase E deletes it.

---

## What is implemented (Phases A–C)

### Phase A — Scaffold
- `docs/adr/0001-adopt-dagster-slurm.md` — ADR updated from Proposed → Accepted (prism → lightcone-cli rename applied throughout)
- `pyproject.toml` — `[slurm-next]` dependency group (`dagster-slurm>=1.13,<1.14` + `dagster-pipes`, Python 3.12 marker)
- `src/lightcone/engine/targets.py` — `TargetKind` enum, `detect_target_shape`, `normalize_target`, `_legacy_to_new` (dual-shape loader with `DeprecationWarning` on old `backend:` schema)
- `tests/test_targets.py` — dual-shape loader test cases

### Phase B — Compute adapter + local mode
- `src/lightcone/engine/slurm_utils.py` — `normalise_time_limit`, `resources_to_slurm_opts` (extracted from `runner.py`, no logic removed)
- `src/lightcone/engine/runner.py` — re-exports `_normalise_time_limit` from `slurm_utils` for backwards compat
- `src/lightcone/engine/compute_adapter.py` — `PayloadCtx`, `build_compute_resource`, `prepare_payload`, `_render_wrapper` (payload wrapper §4.3), `_flatten_params_to_cli_args`, `stage_artifacts`
- `src/lightcone/engine/assets.py` — `LIGHTCONE_USE_DAGSTER_SLURM` branch in `_asset` closure + `build_definitions`
- `tests/test_compute_adapter.py` — 36 unit tests (§5.1): target→ComputeResource, resources→slurm opts, payload wrapper generation, #SBATCH injection, stage_artifacts no-op

### Phase C — SLURM emulator integration
- `compute_adapter.py` — `PayloadCtx.target_config`; password SSH support in `build_compute_resource`; full `stage_artifacts` implementation (SSH reads `job.sh` + `slurm-*.out/err` → `results/.slurm/`)
- `assets.py` — propagates `_target_config` through to `_build_single_asset`; passes `run_id=context.run_id` to `stage_artifacts`
- `tests/integration/docker-compose.yml` — 5-service SLURM cluster (mariadb, slurmdbd, slurmctld, c1, c2) using `ghcr.io/ascii-supply-networks/dagster-slurm/slurm-docker-cluster:25-11-2-1`
- `tests/integration/conftest.py` — `slurm_emulator` (session-scoped, auto-skip if Docker absent) + `emulator_target` fixtures
- `tests/integration/test_slurm_emulator.py` — 7 integration tests (`needs_slurm_docker` marker): end-to-end, metadata propagation, non-zero exit, resource directives, sbatch constraint, log streaming, cancellation
- `.github/workflows/integration-slurm.yml` — opt-in CI job (runs on `main` push or `ci:slurm` label)

---

## What is NOT yet done (Phases D–F)

### Phase D — Flip default + deprecations
- `LIGHTCONE_USE_DAGSTER_SLURM=1` becomes the default (env var removed, always on)
- **Bump `requires-python` from `>=3.11` → `>=3.12`** and **Dagster from `>=1.9` → `>=1.13`** in `pyproject.toml`, ruff `target-version`, mypy `python_version`
- `DeprecationWarning` added on the legacy runner code paths
- New `lc run --slurm-opts key=value,...` flag added to `commands.py`
- Remove SLURM-specific CLI passthroughs (`--partition`, `--qos`, `--constraint`, `--account`) from `commands.py:1119–1161` — these now live in target YAML
- `lc target migrate <name>` command — rewrites old `backend:`-shaped YAMLs in place

### Phase E — Delete legacy backends
Files / sections to remove once Phase D's parity gate passes:
- `src/lightcone/engine/runner.py` — delete `_run_slurm*`, `_run_slurm_interactive`, `_run_local`, `_run_venv`, `generate_sbatch_script`, `translate_resources_to_slurm_directives`, `_podman_hpc_run_command`, `_normalise_time_limit` (now in `slurm_utils`), `_parse_sbatch_job_id`, `_poll_slurm_job`, `_check_sacct`, `_check_squeue_fallback`, venv hash caching. What remains: `DockerRunner` ≈180 lines.
- `src/lightcone/engine/container.py` — delete `build_image_podman_hpc`, `_podman_hpc_migrate`, `image_exists_podman_hpc`, `resolve_container_for_slurm`
- `tests/test_runner_venv.py`, `tests/test_runner_local.py` — delete
- Purge SLURM/podman-hpc tests in `tests/test_runner.py` and `tests/test_container.py`
- Remove `LIGHTCONE_USE_DAGSTER_SLURM` feature flag from `assets.py`
- Remove parity tests (`tests/test_runner_parity.py` — not yet written, can be skipped if Phase D gate is confident)

### Phase F — Follow-up ADR
- `docs/adr/0002-pixi-pack-vs-podman-hpc.md` — decision on whether to retire `podman-hpc run` wrapping in favour of pixi-pack

---

## How to test locally

```bash
# Unit tests (no Docker needed)
uv sync --group dev --group slurm-next
LIGHTCONE_USE_DAGSTER_SLURM=1 uv run pytest tests/test_compute_adapter.py tests/test_targets.py -v

# Integration tests (requires Docker)
docker compose -f tests/integration/docker-compose.yml up -d --wait
LIGHTCONE_USE_DAGSTER_SLURM=1 uv run pytest -m needs_slurm_docker tests/integration/ -v
docker compose -f tests/integration/docker-compose.yml down -v
```

---

## Test plan

- [x] 359 unit tests pass (`uv run pytest tests/ --ignore=tests/integration`)
- [x] 7 integration tests collect cleanly (`pytest --collect-only tests/integration/`)
- [x] `ruff check src/ tests/` clean
- [ ] Integration tests pass against live SLURM emulator (requires Docker, run via `ci:slurm` label)
- [ ] Phase D: parity tests pass for `mode=local` (old runner vs new path)
- [ ] Phase D: parity tests pass for `mode=slurm` (against emulator)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)