### PR TITLE
fix: insert '--' before snakemake targets to prevent --rerun-triggers consuming them

### DIFF
--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -413,21 +413,15 @@ def run(
     # Snakemake requires ``--cores`` to bound per-rule CPU; the dask
     # plugin requires ``--jobs`` to bound parallel dispatch. We surface
     # one knob and pass it as both.
-    cmd = [
-        "snakemake",
-        "-s", str(snakefile_path),
-        "-d", str(project),
-        "--cores", n,
-        "--jobs", n,
-        "--executor", "dask",
-        "--rerun-triggers", *rerun_triggers.split(","),
-    ]
-    if force:
-        # ``--force`` scopes to explicit targets; ``rule all`` itself
-        # has no recipe, so force-all is the only useful sense when no
-        # targets were named.
-        cmd.append("--force" if outputs else "--forceall")
-    cmd.extend(targets)
+    cmd = _build_snakemake_cmd(
+        snakefile_path=snakefile_path,
+        project=project,
+        n=n,
+        rerun_triggers=rerun_triggers,
+        targets=targets,
+        force=force,
+        has_outputs=bool(outputs),
+    )
 
     # Hold a project-level flock for the duration of the run. Acquiring
     # it also clears any stale snakemake lock left by a previously
@@ -504,6 +498,42 @@ def _run_silent(
             # Last-ditch: dump to stderr if scratch is unwritable.
             sys.stderr.write("".join(tail))
     return rc
+
+
+def _build_snakemake_cmd(
+    *,
+    snakefile_path: Path,
+    project: Path,
+    n: str,
+    rerun_triggers: str,
+    targets: list[str],
+    force: bool,
+    has_outputs: bool,
+) -> list[str]:
+    """Build the snakemake argv list for ``lc run``.
+
+    ``--rerun-triggers`` uses ``nargs=+`` in snakemake's argparse, so without
+    an explicit ``--`` separator it greedily consumes the first positional
+    target path as an extra trigger value, causing an "invalid choice" error.
+    """
+    cmd: list[str] = [
+        "snakemake",
+        "-s", str(snakefile_path),
+        "-d", str(project),
+        "--cores", n,
+        "--jobs", n,
+        "--executor", "dask",
+        "--rerun-triggers", *rerun_triggers.split(","),
+    ]
+    if force:
+        # ``--force`` scopes to explicit targets; ``rule all`` itself
+        # has no recipe, so force-all is the only useful sense when no
+        # targets were named.
+        cmd.append("--force" if has_outputs else "--forceall")
+    if targets:
+        cmd.append("--")
+    cmd.extend(targets)
+    return cmd
 
 
 def _target_for(project: Path, output_id: str, universe: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,3 +99,75 @@ def test_verify_clean_project_returns_zero(
     monkeypatch.chdir(project)
     result = runner.invoke(main, ["verify"])
     assert result.exit_code == 0
+
+
+# ---- lc run command building ------------------------------------------------
+
+
+def test_run_cmd_inserts_separator_before_targets() -> None:
+    """Regression test for issue #87.
+
+    snakemake's --rerun-triggers uses nargs=+ so it greedily consumes the
+    first positional target path as an extra trigger value, producing:
+        error: argument --rerun-triggers: invalid choice:
+        'results/baseline/map_fit/.lightcone-manifest.json'
+    A '--' separator between the trigger values and target paths terminates
+    argparse flag processing and prevents this.
+    """
+    from lightcone.cli.commands import _build_snakemake_cmd
+
+    targets = ["results/baseline/map_fit/.lightcone-manifest.json"]
+    cmd = _build_snakemake_cmd(
+        snakefile_path=Path("/proj/.lightcone/Snakefile"),
+        project=Path("/proj"),
+        n="4",
+        rerun_triggers="code,input,mtime,params",
+        targets=targets,
+        force=False,
+        has_outputs=True,
+    )
+
+    assert "--" in cmd, "missing '--' separator; first target will be consumed as a trigger value"
+    sep_idx = cmd.index("--")
+    rt_idx = cmd.index("--rerun-triggers")
+    assert sep_idx > rt_idx, "'--' must appear after --rerun-triggers"
+    target_idx = cmd.index(targets[0])
+    assert target_idx > sep_idx, "target path must appear after '--'"
+
+
+def test_run_cmd_no_separator_when_no_targets() -> None:
+    """When no targets are supplied snakemake runs 'rule all'; '--' is unnecessary."""
+    from lightcone.cli.commands import _build_snakemake_cmd
+
+    cmd = _build_snakemake_cmd(
+        snakefile_path=Path("/proj/.lightcone/Snakefile"),
+        project=Path("/proj"),
+        n="4",
+        rerun_triggers="code,input,mtime,params",
+        targets=[],
+        force=False,
+        has_outputs=False,
+    )
+
+    assert "--" not in cmd
+
+
+def test_run_cmd_multiple_triggers_all_before_separator() -> None:
+    """All four trigger tokens must precede the '--' separator."""
+    from lightcone.cli.commands import _build_snakemake_cmd
+
+    targets = ["results/baseline/out/.lightcone-manifest.json"]
+    cmd = _build_snakemake_cmd(
+        snakefile_path=Path("/proj/.lightcone/Snakefile"),
+        project=Path("/proj"),
+        n="1",
+        rerun_triggers="code,input,mtime,params",
+        targets=targets,
+        force=False,
+        has_outputs=True,
+    )
+
+    sep_idx = cmd.index("--")
+    for trigger in ("code", "input", "mtime", "params"):
+        assert trigger in cmd, f"trigger '{trigger}' missing from cmd"
+        assert cmd.index(trigger) < sep_idx, f"trigger '{trigger}' must come before '--'"


### PR DESCRIPTION
Fixes #87

## Summary

- Extracted `_build_snakemake_cmd()` helper in `commands.py` that owns snakemake argv construction
- Inserts `--` before any target paths to terminate argparse flag processing
- Adds three focused regression tests for the command-building logic

## Root cause

snakemake's `--rerun-triggers` uses `nargs=+` in argparse, so it greedily consumes the first positional argument after the trigger list as another trigger value. When `lc run <output>` appends target paths immediately after the trigger values, snakemake rejects the path as "invalid choice".

## Test plan

- [x] `test_run_cmd_inserts_separator_before_targets` — reproduces the bug; asserts `--` appears between triggers and targets
- [x] `test_run_cmd_no_separator_when_no_targets` — no `--` when running rule all
- [x] `test_run_cmd_multiple_triggers_all_before_separator` — all trigger tokens precede `--`

Generated with [Claude Code](https://claude.ai/code)