### PR TITLE
fix: thread analysis-level Inputs into manifest input_versions (#90)

### DIFF
--- a/src/lightcone/engine/snakefile.py
+++ b/src/lightcone/engine/snakefile.py
@@ -221,8 +221,10 @@ def _render_snakefile(
 
     Each rule descriptor has ``name`` (Snakemake-safe), ``key`` (cfg
     lookup), ``output_dir`` (wildcard pattern), and ``inputs`` (list of
-    ``(raw_id, safe_key, path_pattern)`` triples — sibling outputs only,
-    in declaration order).
+    ``(raw_id, safe_key, path_pattern)`` triples — both sibling outputs
+    and analysis-level Inputs, in declaration order). External Input
+    patterns are static source strings; sibling-output patterns carry a
+    ``{universe}`` wildcard.
 
     The rule body is a thin call into :func:`runner.run_rule`. The
     ``inputs`` dict it builds is keyed by the **raw** input IDs (with
@@ -329,26 +331,24 @@ def generate(
 
         # v0.0.7: declared upstream inputs live on the Output, not the
         # Recipe. Each ID resolves to either a sibling output (a
-        # Snakemake input slot) or an analysis-level Input (resolved
-        # to a static source string at generation time).
+        # universe-templated path) or an analysis-level Input (a static
+        # source string). Both flow through the same Snakemake ``input:``
+        # slot so write_manifest fingerprints them and Snakemake gets to
+        # enforce existence and detect mtime drift uniformly.
         declared_inputs = to.output_def.get("inputs") or []
         recipe_command = recipe.get("command", "")
 
-        # ``rule_inputs`` is the per-rule descriptor's input list, in
-        # declaration order; ``external_inputs`` is the rest, resolved
-        # to source strings used only for template substitution.
         rule_inputs: list[tuple[str, str, str]] = []  # (raw_id, safe_key, pattern)
-        external_inputs: dict[str, str] = {}
         for inp_id in declared_inputs:
             up = find_upstream_output(to, inp_id, tree_outputs)
             if up is not None:
-                rule_inputs.append(
-                    (inp_id, _safe_input_key(inp_id), _output_dir_pattern(up))
-                )
-                continue
-            ext = resolve_external_input(to, inp_id, spec)
-            if ext is not None:
-                external_inputs[inp_id] = ext
+                pattern = _output_dir_pattern(up)
+            else:
+                ext = resolve_external_input(to, inp_id, spec)
+                if ext is None:
+                    continue  # unresolvable; ``astra validate`` flags it.
+                pattern = ext
+            rule_inputs.append((inp_id, _safe_input_key(inp_id), pattern))
 
         container_image = resolve_container_spec(to, spec)
         image_tag = resolve_image(container_image)
@@ -369,18 +369,11 @@ def generate(
 
             # Build the resolved input map in declaration order so
             # ``{inputs}`` joins paths in the same order the user wrote
-            # them. Sibling-output paths get the universe wildcard
-            # substituted; external sources pass through verbatim.
-            resolved_inputs: dict[str, str] = {}
-            sibling_patterns = {raw: pat for raw, _, pat in rule_inputs}
-            for inp_id in declared_inputs:
-                if inp_id in sibling_patterns:
-                    resolved_inputs[inp_id] = sibling_patterns[inp_id].replace(
-                        "{universe}", u
-                    )
-                elif inp_id in external_inputs:
-                    resolved_inputs[inp_id] = external_inputs[inp_id]
-                # else: unresolvable; ``astra validate`` flags it.
+            # them. The ``{universe}`` substitution is a no-op for static
+            # external paths.
+            resolved_inputs: dict[str, str] = {
+                raw: pat.replace("{universe}", u) for raw, _, pat in rule_inputs
+            }
 
             output_dir = out_dir_pattern.replace("{universe}", u)
             rendered = render_recipe(

--- a/tests/test_snakefile.py
+++ b/tests/test_snakefile.py
@@ -475,3 +475,37 @@ def test_qualified_input_uses_raw_id_in_run_rule_call(tmp_path: Path) -> None:
     # The run_rule(inputs=...) dict literal uses the raw id.
     assert '"sub.real": Path(input.sub__real)' in text
 
+
+def test_external_input_flows_to_manifest(tmp_path: Path) -> None:
+    """An analysis-level Input with ``source:`` must reach the rule's
+    Snakemake input slot AND ``run_rule(inputs=...)`` so write_manifest
+    fingerprints it — otherwise ``lc verify`` reports broken_chain
+    because the spec declares an input that the manifest never recorded.
+    Regression test for issue #90.
+    """
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "table.txt").write_text("z mu\n0.1 38.0\n")
+    _spec(
+        tmp_path,
+        {
+            "inputs": [
+                {"id": "union21_table", "type": "data", "source": "data/table.txt"},
+            ],
+            "outputs": [
+                {
+                    "id": "map_fit",
+                    "inputs": ["union21_table"],
+                    "recipe": {"command": "cp {inputs.union21_table} {output}/copy.txt"},
+                }
+            ],
+        },
+    )
+    snakefile, _ = generate(tmp_path, universes=["u1"])
+    text = snakefile.read_text()
+    # The external source becomes a Snakemake input slot…
+    assert 'union21_table="data/table.txt"' in text
+    # …and threads through to run_rule's inputs dict so write_manifest
+    # records it under the raw declared id.
+    assert '"union21_table": Path(input.union21_table)' in text
+
+

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -254,6 +254,38 @@ def test_verify_detects_broken_chain_for_qualified_input(tmp_path: Path) -> None
     )
 
 
+def test_verify_passes_with_external_input(tmp_path: Path) -> None:
+    """An output whose declared inputs include an analysis-level Input
+    (resolved to a file via ``source:``) must verify cleanly: the
+    Snakefile generator threads the external path into ``run_rule``'s
+    ``inputs`` dict, so write_manifest fingerprints it. Without that
+    plumbing, verify reports broken_chain. Regression for issue #90."""
+    src = tmp_path / "data" / "table.txt"
+    src.parent.mkdir()
+    src.write_text("z mu\n0.1 38.0\n")
+    _spec(
+        tmp_path,
+        {
+            "inputs": [
+                {"id": "union21_table", "type": "data", "source": "data/table.txt"},
+            ],
+            "outputs": [
+                {
+                    "id": "map_fit",
+                    "inputs": ["union21_table"],
+                    "recipe": {"command": "cp"},
+                }
+            ],
+        },
+    )
+    _materialize(
+        tmp_path, "map_fit", "u1", recipe="cp", inputs={"union21_table": src}
+    )
+
+    [r] = list(verify_outputs(tmp_path, universe_id="u1"))
+    assert r.passed, f"unexpected failure: {r.failure} — {r.detail}"
+
+
 def test_verifyresult_dataclass(tmp_path: Path) -> None:
     _spec(tmp_path, {"outputs": [{"id": "foo", "recipe": {"command": "echo f"}}]})
     _materialize(tmp_path, "foo", "u1", recipe="echo f")


### PR DESCRIPTION
## Summary

Fixes #90. Outputs that declared an analysis-level Input (one with `source:`) failed `lc verify` with `broken_chain` because the Snakefile generator never threaded those inputs into the rule's `run_rule(inputs=...)` dict — so `write_manifest` had nothing to fingerprint, and the manifest's `input_versions` came back empty for them.

The two pre-existing input paths (sibling outputs vs. analysis-level Inputs) had grown apart unnecessarily. Collapse them: every declared input becomes a Snakemake `input:` slot — universe-templated for sibling outputs, literal for `source:` paths. `write_manifest` already falls through to `fingerprint_external` for plain files, so no change is needed in the manifest layer.

Side benefit: Snakemake now enforces existence of external sources at DAG time and reruns rules when their mtime drifts (previously silent staleness).

- `src/lightcone/engine/snakefile.py`: drop the `external_inputs` dict and `resolved_inputs` rebuild loop; one unified `rule_inputs` list.
- `tests/test_snakefile.py`: regression test that the external `source:` path appears as a Snakemake input slot AND in the `run_rule(inputs=...)` dict literal.
- `tests/test_verify.py`: end-to-end regression matching the issue scenario — `lc verify` now passes for an Output backed by an analysis-level Input.

## Test plan

- [x] `uv run pytest` — 287 passed (existing 285 + 2 new regression tests)
- [x] `uv run ruff check` — clean
- [x] Manual: reproduce issue's scenario — verify now reports `ok` instead of `broken_chain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)