### PR TITLE
fix: silence dask worker INFO logs unless --verbose

### DIFF
--- a/src/lightcone/engine/dask_cluster.py
+++ b/src/lightcone/engine/dask_cluster.py
@@ -18,6 +18,7 @@ schedulers if the driver crashes.
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import socket
@@ -132,6 +133,7 @@ def _local_cluster(
         resources=_resource_dict(shape),
         dashboard_address=":0",
         local_directory=local_directory,
+        silence_logs=logging.INFO if verbose else logging.WARNING,
     )
     if verbose:
         print(
@@ -170,6 +172,7 @@ def _slurm_backed_cluster(
         host=scheduler_host,
         dashboard_address=":0",
         local_directory=local_directory,
+        silence_logs=logging.INFO if verbose else logging.WARNING,
     )
     addr = cluster.scheduler_address
 
@@ -195,6 +198,11 @@ def _slurm_backed_cluster(
         _resources_arg(shape),
         "--no-dashboard",
     ]
+    if not verbose:
+        # Hide the worker's INFO-level connection chatter (Nanny start,
+        # scheduler registration, etc.) — useful only when debugging the
+        # cluster itself. WARNING+ still surface real issues.
+        worker_cmd.extend(["--silence-logs", "warning"])
     if local_directory:
         worker_cmd.extend(["--local-directory", local_directory])
     workers = subprocess.Popen(worker_cmd)


### PR DESCRIPTION
## Summary
- The `srun`-launched `dask worker` subprocesses inherit `lc run`'s stdout/stderr and emit INFO-level connection chatter (Nanny start, scheduler registration, thread/memory advertisement) that clutters every NERSC run.
- Pass `--silence-logs warning` to the worker subprocess and `silence_logs=logging.WARNING` to both `LocalCluster` instances by default. WARNING+ still surfaces real issues; `lc run -v` restores the old INFO output for debugging the cluster itself.

## Test plan
- [x] `uv run pytest tests/test_dask_cluster.py` (12 passed)
- [x] `uv run ruff check` / `uv run mypy` clean on the modified file
- [ ] Manual: confirm `lc run` on NERSC no longer shows `distributed.nanny` / `distributed.worker` INFO lines, and that `lc run -v` still does

🤖 Generated with [Claude Code](https://claude.com/claude-code)