### PR TITLE
fix: drive dask worker log level via env var (newer CLI dropped --silence-logs)

### DIFF
--- a/src/lightcone/engine/dask_cluster.py
+++ b/src/lightcone/engine/dask_cluster.py
@@ -198,14 +198,17 @@ def _slurm_backed_cluster(
         _resources_arg(shape),
         "--no-dashboard",
     ]
-    if not verbose:
-        # Hide the worker's INFO-level connection chatter (Nanny start,
-        # scheduler registration, etc.) — useful only when debugging the
-        # cluster itself. WARNING+ still surface real issues.
-        worker_cmd.extend(["--silence-logs", "warning"])
     if local_directory:
         worker_cmd.extend(["--local-directory", local_directory])
-    workers = subprocess.Popen(worker_cmd)
+    # Hide the worker's INFO-level connection chatter (Nanny start,
+    # scheduler registration, etc.) — useful only when debugging the
+    # cluster itself. WARNING+ still surface real issues. The newer
+    # `dask worker` CLI dropped `--silence-logs`, so we drive it via
+    # Dask's config env var instead; srun inherits env by default.
+    worker_env = dict(os.environ)
+    if not verbose:
+        worker_env.setdefault("DASK_LOGGING__DISTRIBUTED", "warning")
+    workers = subprocess.Popen(worker_cmd, env=worker_env)
 
     try:
         from dask.distributed import Client

--- a/tests/test_dask_cluster.py
+++ b/tests/test_dask_cluster.py
@@ -155,8 +155,9 @@ def test_slurm_backed_cluster_binds_to_routable_host(
             pass
 
     class _FakePopen:
-        def __init__(self, cmd: list[str]) -> None:
+        def __init__(self, cmd: list[str], **kwargs: object) -> None:
             captured["worker_cmd"] = cmd
+            captured["worker_kwargs"] = kwargs
 
         def terminate(self) -> None:
             pass
@@ -217,7 +218,7 @@ def test_slurm_backed_cluster_falls_back_to_gethostname(
             pass
 
     class _FakePopen:
-        def __init__(self, cmd: list[str]) -> None:
+        def __init__(self, cmd: list[str], **kwargs: object) -> None:
             pass
 
         def terminate(self) -> None:


### PR DESCRIPTION
## Summary
- Follow-up to #92. The `--silence-logs warning` flag added there errors out on the newer namespaced `dask worker` CLI on NERSC: `Error: No such option: --silence-logs`.
- Drop the flag and instead set `DASK_LOGGING__DISTRIBUTED=warning` in the worker subprocess env. `srun` propagates env to remote tasks by default, so each launched worker picks it up. WARNING+ still surfaces; `lc run -v` leaves the var unset and restores the old INFO output.
- Updated the two `_FakePopen` test doubles to accept `**kwargs` so they tolerate the new `env=` argument on `subprocess.Popen`.

## Test plan
- [x] `uv run pytest tests/test_dask_cluster.py` (12 passed)
- [x] `uv run ruff check` / `uv run mypy` clean
- [ ] Manual: re-run `lc run` on NERSC and confirm it no longer crashes with "No such option: --silence-logs", and that the `distributed.worker` INFO chatter stays hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)