### PR TITLE
fix: gracefully retire dask workers so srun exits silently

### DIFF
--- a/src/lightcone/engine/dask_cluster.py
+++ b/src/lightcone/engine/dask_cluster.py
@@ -219,10 +219,26 @@ def _slurm_backed_cluster(
             client.close()
         yield addr
     finally:
-        workers.terminate()
+        # Graceful shutdown: ask the scheduler to retire workers so each
+        # `dask worker` process exits on its own. srun then sees its task
+        # exit with code 0 and terminates silently. SIGTERM-ing srun
+        # directly (the prior path) prints "srun: forcing job
+        # termination" / "task 0: Killed" to stderr on every clean run.
         try:
-            workers.wait(timeout=10)
+            client = Client(addr, timeout="10s")
+            try:
+                client.retire_workers(close_workers=True, remove=True)
+            finally:
+                client.close()
+        except Exception:
+            pass
+        try:
+            workers.wait(timeout=20)
         except subprocess.TimeoutExpired:
-            workers.kill()
-            workers.wait()
+            workers.terminate()
+            try:
+                workers.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                workers.kill()
+                workers.wait()
         cluster.close()

--- a/src/lightcone/engine/dask_cluster.py
+++ b/src/lightcone/engine/dask_cluster.py
@@ -197,6 +197,11 @@ def _slurm_backed_cluster(
         "--resources",
         _resources_arg(shape),
         "--no-dashboard",
+        # Each srun task is a single run-scoped worker; an auto-restart
+        # nanny adds no value (srun won't relaunch the task either) and
+        # logs "Worker process died unexpectedly" when retire_workers
+        # asks the worker to exit on shutdown.
+        "--no-nanny",
     ]
     if local_directory:
         worker_cmd.extend(["--local-directory", local_directory])


### PR DESCRIPTION
## Summary
- On every clean \`lc run\` inside a SLURM allocation, the cleanup path SIGTERM-s the \`srun\` process, which prints "srun: forcing job termination", "task 0: Killed", and "Terminating StepId=…" to stderr — visible noise on a successful run.
- Ask the dask scheduler to retire workers first (\`Client.retire_workers(close_workers=True)\`). Each \`dask worker\` process exits on its own, srun's task returns code 0, and srun terminates silently.
- SIGTERM and SIGKILL remain as fallbacks if \`retire_workers\` fails or workers don't exit within 20s, so we never leak a hung srun.

## Test plan
- [x] \`uv run pytest tests/test_dask_cluster.py\` (12 passed — the fake \`Client\` in tests doesn't implement \`retire_workers\`; that's caught by the \`except Exception\` and the fallback wait path runs as before)
- [x] \`uv run ruff check\` / \`uv run mypy\` clean
- [ ] Manual: re-run \`lc run\` on NERSC inside a salloc and confirm no \`srun: forcing job termination\` lines on success; confirm a Ctrl-C / failure path still terminates srun within ~20s

## Notes
Independent of #94 (the dask logger env-var fix); both touch \`_slurm_backed_cluster\` but in different sections, so whichever lands first will need a trivial rebase of the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)