### PR TITLE
Install lightcone-cli (not just astra-tools) into project venv

### DIFF
--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -214,7 +214,7 @@ def init(
     if not no_venv:
         subprocess.run(["python", "-m", "venv", ".venv"], cwd=directory, check=False)
         subprocess.run(
-            [".venv/bin/python", "-m", "pip", "install", "-q", "astra-tools"],
+            [".venv/bin/python", "-m", "pip", "install", "-q", "lightcone-cli"],
             cwd=directory,
             check=False,
         )


### PR DESCRIPTION
## Summary
- Follow-up to #100. `lc init` now pip-installs `lightcone-cli` into the new `.venv` instead of just `astra-tools`, so fresh projects get both `lc` and `astra` (transitive dep) on the venv path.
- Skipped when `--no-venv` is passed.

## Test plan
- [ ] `lc init demo`, then `demo/.venv/bin/lc --help` and `demo/.venv/bin/astra --help` both resolve.
- [ ] `lc init demo --no-venv` still works and skips the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)