### PR TITLE
astra-reference: spell out that text outside {...} is literal

### DIFF
--- a/claude/lightcone/guides/astra-reference.md
+++ b/claude/lightcone/guides/astra-reference.md
@@ -137,6 +137,8 @@ Set `container:` at analysis level (all recipes inherit); per-recipe `container:
 
 Runners expand `{...}` placeholders in `command:` before invoking it: `{inputs.<id>}` (input path), `{inputs}` (all input paths, declared order), `{decisions.<id>}` (active option ID), `{output}` (artifact path), `{{`/`}}` (literal braces). Every `{inputs.<id>}` and `{decisions.<id>}` must name something declared in the parent Output's `inputs:`/`decisions:` lists -- always **local IDs** (no `../`; bridging is declared once at the Input/Decision via `from:`).
 
+Text outside `{...}` is literal command text and isn't validated. Static constants (`--max-iter 1000`), per-output specialisations when fan-out is unrolled into one Output per value (`--tracer lrg1`), and shell features (`${VAR}`, pipes, redirects) all live as plain text. Only values that vary across the multiverse need to be `{decisions.<id>}` placeholders -- there is no separate `params` channel, and Snakemake-style wildcards (`{chunk_id}`, `{block_i}`) have no spec-level analogue: either inline the value, unroll the fan-out into one Output per value, or describe only the aggregated artifact.
+
 ### Conditional Outputs
 
 Outputs can have `when` conditions -- the output only exists when the condition is met for a given universe. Uses the same syntax as decision `when` (negation with `~`, lists AND'd).


### PR DESCRIPTION
## Summary

The Recipe section of `astra-reference.md` enumerates the four placeholder shapes (`{inputs.<id>}`, `{inputs}`, `{decisions.<id>}`, `{output}`) but never states the complementary rule that **everything else in the `command:` string is literal shell text**. A Claude agent reading only this guide plausibly infers the opposite — that every parameter-like value must fit a placeholder shape — and tries to wedge static constants, per-output specialisations, and Snakemake-style wildcards into the substitution grammar.

This bit me on the UNIONS Paper II spec audit: ~30 `INVALID_COMMAND_TEMPLATE` errors looked like a substitution-grammar problem when most of them were just "delete the braces and inline the value." The DESI DR1 spec already does the right thing (`--tracer lrg1` inlined as plain text, one Output per tracer), but the doc didn't tell me that pattern was legal.

Adds one paragraph after the placeholder enumeration covering:

- Text outside `{...}` is literal and isn't validated.
- What lives there: static constants (`--max-iter 1000`), per-output specialisations when fan-out is unrolled (`--tracer lrg1`), shell features (`\${VAR}`, pipes, redirects).
- The three legitimate fixes for Snakemake-style wildcards (`{chunk_id}`, `{block_i}`): inline the value, unroll the fan-out into one Output per value, or describe only the aggregated artifact.

The upstream `astra-spec/docs/index.md` already says this ("Static constants … belong inline in the command string. There is no separate `params` channel because varying values are decisions and constants are just command text"). This PR mirrors that guidance into the lightcone-cli reference doc that Claude agents land in.

## Test plan

- [ ] Render the doc and skim the §Command Template Substitution section for flow.
- [ ] Confirm the new paragraph reads cleanly alongside the worked example a few lines above (line 125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)