### PR TITLE
fix(permissions): move scratch edits from deny to ask in recommended …

### DIFF
--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -41,12 +41,22 @@ PERMISSION_TIERS: dict[str, dict[str, list[str]]] = {
     },
     "recommended": {
         "allow": ["Read", "Edit", "Write", "Bash(*)", "WebSearch", "WebFetch"],
+        # Patterns under "ask" prompt the user before the agent can act,
+        # but don't block outright the way "deny" does. Use "ask" for
+        # paths the agent legitimately *might* need to write to but
+        # where a stray edit would be expensive — scratch filesystems
+        # being the obvious case on HPC, where projects often live in
+        # $SCRATCH and a careless edit could trash someone else's data.
+        "ask": [
+            "Edit(//scratch/**)",
+            "Edit(//pscratch/**)",
+            "Write(//scratch/**)",
+            "Write(//pscratch/**)",
+        ],
         "deny": [
             "Edit(~/.ssh/**)",
             "Edit(~/.aws/**)",
             "Edit(~/.gnupg/**)",
-            "Edit(//scratch/**)",
-            "Edit(//pscratch/**)",
             "Bash(sudo *)",
             "Bash(rm -rf *)",
             "Bash(rm -fr *)",


### PR DESCRIPTION
…tier

The recommended permission tier blanket-denied Edit(//scratch/**) and Edit(//pscratch/**), which made the agent unable to touch any file in projects rooted under $SCRATCH — exactly the layout NERSC users want because the home quota is small and DVS-mounted home doesn't honor flock(). The denies came from the Prism era when projects always lived under $HOME and scratch was just temp storage.

Move both patterns from `deny` to `ask` so the agent has to prompt the user before writing into scratch (rather than being silently blocked), and add Write(//*scratch/**) to ask too — the original deny only covered Edit, leaving Write auto-allowed which was inconsistent.

The other denies (~/.ssh, ~/.aws, ~/.gnupg, sudo, rm -rf, git push) remain — those are sensitive across all contexts.

Verified by `lc init` on a project rooted in $SCRATCH: generated settings.json puts the four scratch patterns under "ask" while keeping the SSH/AWS/sudo guards under "deny".