### PR TITLE
Deploy zensical docs to docs.lightconeresearch.org via Cloudflare Workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,7 @@ eval-results
 # UV
 ## lockfile should be versioned for applications but not for libraries
 uv.lock
+
+# Cloudflare Wrangler / Node
+.wrangler/
+node_modules/

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Cloudflare Pages build script for docs.lightconeresearch.org.
-# Installs uv, syncs the docs group, and runs `zensical build` → site/.
+# Build script for docs.lightconeresearch.org, run by Cloudflare Workers
+# (Static Assets). Installs uv, syncs the docs group, runs zensical → site/.
 set -euo pipefail
 
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Cloudflare Pages build script for docs.lightconeresearch.org.
+# Installs uv, syncs the docs group, and runs `zensical build` → site/.
+set -euo pipefail
+
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+uv sync --group docs
+uv run zensical build

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "lightcone-cli",
+  "compatibility_date": "2026-05-07",
+  "assets": {
+    "directory": "./site",
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `build-docs.sh` (installs uv, runs `zensical build` → `site/`) for Cloudflare's build environment.
- Adds `wrangler.jsonc` declaring the `lightcone-cli` Worker as a static-assets deploy of `./site`, with `404-page` handling for unknown paths.
- Gitignores `.wrangler/` and `node_modules/`.

Build pipeline on every push to `main` after merge:
1. Cloudflare clones the commit
2. `./build-docs.sh` produces `site/`
3. `npx wrangler deploy` reads `wrangler.jsonc`, uploads `site/`, promotes the new version → `docs.lightconeresearch.org`

Dashboard config (already set on the Worker):
- Build command: `./build-docs.sh`
- Deploy command: `npx wrangler deploy`
- Env vars: `SKIP_DEPENDENCY_INSTALL=1`, `PYTHON_VERSION=3.11`

Theming (matching the marketing site / paper-views) is intentionally deferred — this PR is just the deploy plumbing.

## Test plan
- [ ] Latest preview deployment for branch `docs-cloudflare-test` renders the zensical docs (not the hello-world template).
- [ ] After merge to `main`, `docs.lightconeresearch.org` serves the same content.
- [ ] Subsequent pushes to `main` auto-redeploy without manual promotion.
- [ ] 404 path serves zensical's generated `404.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)