### PR TITLE
docs: fix outdated content across CLI and user guides

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -6,11 +6,10 @@ Code skills, with the CLI as the durable, scriptable backstop.
 
 ## Global behavior
 
-- All commands except `setup`, `init`, and `eval` require
-  `~/.lightcone/config.yaml` to exist. If it doesn't, the command
-  errors out telling you to run `lc setup`.
-- All commands except `setup` and `init` walk up from the cwd looking
-  for `astra.yaml`. If none is found, the command errors out.
+- `~/.lightcone/config.yaml` is created automatically on first use of
+  any `lc` command. You do not need to create it manually.
+- All commands except `init` walk up from the cwd looking for
+  `astra.yaml`. If none is found, the command errors out.
 
 ## Commands
 
@@ -22,7 +21,6 @@ Code skills, with the CLI as the durable, scriptable backstop.
 | [`lc status`](status.md) | Manifest-driven status report. No Snakemake import needed. |
 | [`lc verify`](verify.md) | Recompute hashes, walk the input chain, surface tampering. |
 | [`lc export`](export.md) | Emit interoperable bundles (Workflow Run RO-Crate) for publication. |
-| [`lc setup`](setup.md) | Write a minimal `~/.lightcone/config.yaml`. |
 
 ## Global options
 
@@ -36,8 +34,8 @@ Options:
 
 ## Removed commands
 
-For historical context: `lc dev`, `lc target`, and `lc update` no
-longer exist; `lc eval` is partially wired (its sub-commands are
-defined in `src/lightcone/eval/cli.py` but the group is not registered
-on `main`, so `lc eval` will fail with "No such command"). See the
+For historical context: `lc dev`, `lc setup`, `lc target`, and `lc update` no
+longer exist as explicit commands. `lc eval` is available when the `eval`
+extra is installed (`pip install lightcone-cli[eval]`); without it the import
+is silently skipped and `lc eval` will fail with "No such command". See the
 removal pages for details.

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -1,28 +1,23 @@
-# lc setup
+# lc setup (removed)
 
-Write a minimal global configuration at `~/.lightcone/config.yaml`. Run
-once after install. There is no wizard, no prompt, no flags.
+The `lc setup` command no longer exists. The global configuration file
+(`~/.lightcone/config.yaml`) is now created automatically the first time
+you run any `lc` command — there is nothing to run manually.
 
-## Synopsis
+## Global config file
 
-```
-lc setup
-```
-
-## What it does
-
-If `~/.lightcone/config.yaml` already exists, prints the path and exits
-with no changes. Otherwise creates it with:
+`~/.lightcone/config.yaml` is created with these defaults on first use:
 
 ```yaml
 container:
   runtime: auto
 ```
 
-That's the entire file today. The rest of lightcone-cli requires
-`~/.lightcone/config.yaml` to *exist* (so it knows you've at least
-opted in once); the file's contents control container runtime
-resolution.
+Edit the file by hand to change the container runtime:
+
+```bash
+$EDITOR ~/.lightcone/config.yaml
+```
 
 ## `container.runtime` values
 
@@ -34,18 +29,6 @@ resolution.
 | `podman-hpc` | Pin to podman-hpc — typical on NERSC Perlmutter login nodes. |
 | `none` | Explicit opt-out from containers. Recipes run on the host. |
 
-Edit the file by hand to change runtimes:
-
-```bash
-$EDITOR ~/.lightcone/config.yaml
-```
-
 Setting `runtime: none` explicitly silences the provenance warning
 that `lc run` shows when `auto` falls back to `none`. (See
 [`lc run`](run.md#provenance-gotcha).)
-
-## Removed flags
-
-The `--list`, `--show NAME`, and `--default NAME` options are gone —
-they belonged to the now-removed target system. See
-[`lc target`](target.md) for the redirect.

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -14,6 +14,7 @@ lc status [OPTIONS]
 | Option | Default | Effect |
 |--------|---------|--------|
 | `--universe`, `-u NAME` | every universe in `universes/*.yaml` | Restrict to one universe. |
+| `--json` | off | Emit machine-readable JSON instead of a styled table. |
 
 ## Output
 
@@ -55,6 +56,7 @@ unparseable, `read_manifest` returns `None` and you also see `missing`
 ```bash
 lc status                       # every output, every universe
 lc status --universe baseline   # just baseline
+lc status --json                # machine-readable JSON output
 ```
 
 ## Related

--- a/docs/cli/target.md
+++ b/docs/cli/target.md
@@ -6,7 +6,8 @@ runtime and the cluster shape from a much smaller surface:
 
 - **Container runtime** — `~/.lightcone/config.yaml` carries a single
   `container.runtime` key (`auto | docker | podman | podman-hpc | none`).
-  See [`lc setup`](setup.md) and [api/container](../api/container.md).
+  The file is created automatically on first use; edit it by hand to change
+  runtimes. See [Global config](setup.md) and [api/container](../api/container.md).
 - **Cluster shape** — derived at runtime from the environment.
   `lc run` always dispatches through a Dask cluster; the cluster manager
   picks `LocalCluster` on a workstation, `srun`-launched workers when

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -18,7 +18,7 @@ from lightcone.cli.plugin import get_plugin_source_dir
 
 src = get_plugin_source_dir()
 dst = Path(".claude")
-for sub in ("skills", "agents", "hooks", "scripts", "guides", "templates"):
+for sub in ("skills", "agents", "scripts", "guides", "templates"):
     s, d = src / sub, dst / sub
     if d.exists():
         shutil.rmtree(d)

--- a/docs/user/cluster.md
+++ b/docs/user/cluster.md
@@ -113,7 +113,6 @@ without an allocation:
 
 ```bash
 lc build                       # build images (uses podman-hpc on login node)
-lc run --dry-run               # generates the Snakefile, doesn't execute
 lc status                      # offline; reads only manifests
 ```
 

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -46,13 +46,11 @@ lc --version                # → lightcone-cli, version ...
 > that's you, installing lightcone-cli will shadow the alias —
 > rebind it (e.g. `alias l='ls --color'`).
 
-## 3. One-time setup
+## 3. Global configuration
 
-```bash
-lc setup
-```
-
-This creates `~/.lightcone/config.yaml` with:
+`~/.lightcone/config.yaml` is created automatically the first time you
+run any `lc` command. No manual setup step is needed. The file starts
+as:
 
 ```yaml
 container:
@@ -61,7 +59,7 @@ container:
 
 `auto` detects whichever of `podman`, `docker`, or `podman-hpc` is on
 your PATH (and skips docker if its daemon isn't running). You can pin
-the runtime later by editing this file.
+the runtime later by editing this file directly.
 
 ## 4. Claude Code
 
@@ -91,8 +89,8 @@ runtime:
   daemon) or [Docker](https://docs.docker.com/get-docker/).
 - HPC login node: see [Running on a Cluster](cluster.md).
 
-`lc setup`'s `auto` mode picks whichever you have. If you don't have
-either, you can still use `lc` — set `runtime: none` in
+The `auto` mode picks whichever container runtime you have. If you don't
+have either, you can still use `lc` — set `runtime: none` in
 `~/.lightcone/config.yaml` and recipes will run on the host without
 isolation.
 

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -3,16 +3,22 @@
 Common issues and how to unstick them. Roughly ordered by how often
 they come up.
 
-## "No global configuration found. Run `lc setup` first."
+## "No global configuration found."
 
-You haven't created `~/.lightcone/config.yaml` yet.
+`~/.lightcone/config.yaml` is normally created automatically on first
+use, but it may be missing if the home directory was unavailable or if
+the file was deleted manually. Re-create it by hand:
 
 ```bash
-lc setup
+mkdir -p ~/.lightcone
+cat > ~/.lightcone/config.yaml <<'EOF'
+container:
+  runtime: auto
+EOF
 ```
 
-That writes a one-line config and you're on your way. There are no
-prompts.
+Or just run any `lc` command (e.g. `lc --version`) — the auto-creation
+runs before every command.
 
 ## "No astra.yaml found in current directory or any parent."
 
@@ -151,7 +157,7 @@ from pathlib import Path
 from lightcone.cli.plugin import get_plugin_source_dir
 src = get_plugin_source_dir()
 dst = Path(".claude")
-for sub in ("skills", "agents", "hooks", "scripts", "guides", "templates"):
+for sub in ("skills", "agents", "scripts", "guides", "templates"):
     s, d = src / sub, dst / sub
     if d.exists(): shutil.rmtree(d)
     if s.exists(): shutil.copytree(s, d)


### PR DESCRIPTION
## Summary

- `lc setup` no longer exists — rewrote `docs/cli/setup.md` as a "removed" page and updated all references in `install.md`, `troubleshooting.md`, `target.md`, and `cli/index.md` to reflect that `~/.lightcone/config.yaml` is auto-created on first use
- `lc eval` status corrected in `cli/index.md`: it is registered on `main` when the `eval` extra is installed, not permanently broken
- Added missing `--json` flag to `docs/cli/status.md` options table and examples
- Removed non-existent `lc run --dry-run` from `docs/user/cluster.md`
- Removed `hooks` from the plugin copy loop in `troubleshooting.md` and `update.md` — the `hooks/` subdirectory is never shipped; hooks are wired via `settings.json`

## Test plan

- [x] Verify `lc --help` output matches command table in `cli/index.md`
- [ ] Confirm `~/.lightcone/config.yaml` is auto-created on a fresh install without running any setup command
- [x] Check `lc status --json` emits valid JSON
- [x] Build docs site (`just docs`) and confirm no broken links to removed anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- dco-signed-off-by -->
Signed-off-by: Alexandre Boucaud <aboucaud@apc.in2p3.fr>
Signed-off-by: Francois Lanusse <EiffL@users.noreply.github.com>