### PR TITLE
fix(ci): fix check-docs workflow OIDC token failure

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -13,6 +13,7 @@ jobs:
       contents: read
       issues: write         # To open an issue if docs are stale
       pull-requests: write  # To post a comment on the merged PR
+      id-token: write       # Required for OIDC token (claude-code-action)
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Summary

- Adds missing `id-token: write` permission to the `check-docs` job — `claude-code-action` requires an OIDC token to authenticate, which was causing intermittent CI failures with _"Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?"_

## Test plan

- [ ] Merge a PR and verify the `check-docs` workflow completes without the OIDC token error

🤖 Generated with [Claude Code](https://claude.com/claude-code)