### PR TITLE
fix(ci): don't run expensive workflows on draft PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   eval:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,24 +7,27 @@ on:
 
 jobs:
   test:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          activate-environment: true
 
       - name: Configure git credentials for private ASTRA repo
         run: git config --global url."https://x-access-token:${{ secrets.ASP_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: uv sync --group dev
 
       - name: Run tests
         run: pytest


### PR DESCRIPTION
## Summary

- **`claude-code-review`**: added `if: github.event.pull_request.draft == false` — Claude review shouldn't run on work in progress
- **`eval`**: added draft guard while preserving `workflow_dispatch` — `if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false`
- **`tests`**: added draft guard (`if: github.event_name == 'push' || github.event.pull_request.draft == false`); also migrates from `pip install` + `actions/setup-python` to `uv sync` + `astral-sh/setup-uv` (consistent with the rest of CI); adds Python 3.13 to the test matrix

## Test plan

- [ ] Open a draft PR and confirm none of the three workflows trigger
- [ ] Mark the PR ready for review and confirm all three run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- dco-signed-off-by -->
Signed-off-by: Alexandre Boucaud <aboucaud@apc.in2p3.fr>