### PR TITLE
fix(ci): add dedicated lint workflow and fix mypy errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          activate-environment: true
+
+      - name: Configure git credentials for private ASTRA repo
+        run: git config --global url."https://x-access-token:${{ secrets.ASP_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Ruff
+        run: ruff check src/ tests/
+
+      - name: Mypy
+        run: mypy src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,16 @@ ignore_missing_imports = true
 follow_untyped_imports = true
 
 [[tool.mypy.overrides]]
-module = ["rocrate.*", "astra.*"]
+module = ["rocrate.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["astra.*"]
+ignore_missing_imports = true
+follow_untyped_imports = true
+
+[[tool.mypy.overrides]]
+module = ["daytona_sdk", "daytona_sdk.*", "dotenv", "dotenv.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -172,7 +172,7 @@ def init(
     # src/. We hold off on git init until our own files are in place so
     # the initial commit captures the full project state.
     try:
-        astra_init.callback(directory=directory, no_git=True)
+        astra_init.callback(directory=directory, no_git=True)  # type: ignore[misc]
     except SystemExit as e:
         raise click.ClickException(
             f"astra init failed (exit code {e.code})."

--- a/src/lightcone/eval/build.py
+++ b/src/lightcone/eval/build.py
@@ -45,11 +45,11 @@ def _get_git_info(repo_root: Path) -> VersionInfo:
         pass
 
     try:
-        result = subprocess.run(
+        dirty = subprocess.run(
             ["git", "diff", "--quiet", "HEAD"],
             capture_output=True, cwd=repo_root,
         )
-        info.lightcone_dirty = result.returncode != 0
+        info.lightcone_dirty = dirty.returncode != 0
     except subprocess.CalledProcessError:
         info.lightcone_dirty = True
 


### PR DESCRIPTION
## Summary

- **New `lint.yml` workflow**: runs `ruff check src/ tests/` and `mypy src/` on Python 3.13, in parallel with the test matrix, skipped on draft PRs. Linting was previously absent from CI.
- **`pyproject.toml`**: split `rocrate.*` and `astra.*` into separate mypy overrides — `follow_untyped_imports = true` only on `astra.*` (applying it to `rocrate.*` caused `no-untyped-call` cascades in `wrroc.py`); added override for `daytona_sdk` and `dotenv` which are eval-only deps not installed in the dev group.
- **`commands.py`**: `# type: ignore[misc]` on `astra_init.callback()` — Click types `callback` as `Optional[Callable]` but it is always set at decoration time.
- **`eval/build.py`**: renamed `result` → `dirty` to fix `CompletedProcess[bytes]` assigned to a variable typed as `CompletedProcess[str]`.

Both `ruff check src/ tests/` and `mypy src/` pass cleanly locally before this PR.

## Test plan

- [ ] Confirm the new `Lint` workflow appears and passes on this PR
- [ ] Confirm `ruff` step passes
- [ ] Confirm `mypy` step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)