### PR TITLE
Fix: Curl needs to be installed in python slim

### DIFF
--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -313,6 +313,12 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY requirements.txt .
+
+# Install curl and certificates, then clean up to keep image size small
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:$PATH"


### PR DESCRIPTION
CURL is no longer shipped with python slim images