### PR TITLE
JupyterHub on GCP: transparent Cloud Build images + run-scoped Dask Gateway clusters (LCR-174)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ src/lightcone/              # namespace — NO __init__.py
 │   ├── manifest.py         # write_manifest, sha256_dir, code_version — the integrity layer
 │   ├── snakefile.py        # generates .lightcone/Snakefile from astra.yaml
 │   ├── container.py        # Content-addressed container builds (Docker, podman-hpc, apptainer)
+│   ├── cloudbuild.py       # GCP Cloud Build backend (JupyterHub deployments; no local OCI runtime)
 │   ├── status.py           # Manifest-driven status walker (no Snakemake import)
 │   ├── verify.py           # Recompute hashes; validate provenance chain
 │   ├── tree.py             # Sub-analysis tree traversal (kept from before)

--- a/docs/api/cloudbuild.md
+++ b/docs/api/cloudbuild.md
@@ -1,0 +1,63 @@
+# lightcone.engine.cloudbuild
+
+Remote image builds through GCP Cloud Build — the build backend for
+deployments with no OCI runtime on the host (a JupyterHub user pod on
+GKE). Pure `urllib` REST against the metadata server, GCS, the Cloud
+Build API, and the Docker Registry v2 API; no SDK dependency, no
+stored credentials, no git remote required.
+
+Source: `src/lightcone/engine/cloudbuild.py`.
+
+## Deployment contract
+
+Env vars injected into every user pod by the deployment (see the
+hub-deploy `lightcone` hub config):
+
+| Env var | Meaning |
+|---------|---------|
+| `LIGHTCONE_REGISTRY` | Artifact Registry prefix (`<region>-docker.pkg.dev/<project>/<repo>`); also names the GCP project builds run in. Declared in `engine.container` (`REGISTRY_ENV`). |
+| `LIGHTCONE_BUILD_BUCKET` | GCS bucket for build sources and logs. Its presence (with the registry) selects this backend — `cloudbuild_available()`. |
+| `LIGHTCONE_BUILD_SERVICE_ACCOUNT` | Optional dedicated build SA; the deployment grants it registry-writer rights only. |
+
+Auth is the pod's Workload Identity, spoken to the GCE metadata server
+(`_metadata_access_token()`). The pod's identity needs
+`cloudbuild.builds.editor`, `iam.serviceAccountUser` on the build SA,
+object create/view on the bucket, and `artifactregistry.reader` for
+the freshness probe.
+
+## `ensure_image(project, containerfile_spec, *, project_name, force=False, on_progress=None) → str`
+
+Make sure the project's image is in the registry; return its ref.
+Content-addressed and git-free:
+
+1. Compute the ref `$LIGHTCONE_REGISTRY/lc-<project>:<hash>` — the
+   same `image_identity()` digest as the local `lc-<project>-<hash>`
+   tag, spelled for a registry.
+2. `registry_image_exists(ref)` — one HEAD on the Docker Registry v2
+   manifest endpoint. Present → done (no build, no upload). `force`
+   skips this probe.
+3. Tar the **staged build context** (`_populate_build_context` — the
+   exact file set the tag hashes) and upload it to the bucket under a
+   content-addressed object name.
+4. Submit the build (docker builder step, image push, logs to
+   `gs://<bucket>/logs` with `GCS_ONLY` — required for custom SAs and
+   the source of the failure tail), poll to a terminal status.
+5. Non-`SUCCESS` → `CloudBuildError` carrying the build-log tail.
+
+`on_progress(phase, detail)` phases: `cached`, `staging`, then Cloud
+Build statuses lowercased (`queued`, `working`, `success`, …).
+
+## `registry_image_exists(ref) → bool | None`
+
+`None` — not `False` — when unknowable (no metadata credentials,
+registry unreachable), so callers can distinguish "absent, build it"
+from "can't tell". Artifact Registry accepts the OAuth2 access token
+directly as a Bearer on `/v2/` endpoints.
+
+## Tests
+
+`tests/test_cloudbuild.py` mocks the two HTTP seams
+(`_metadata_access_token`, `_request`) and exercises the real control
+flow: backend selection, freshness probe, staging, submission
+(including the custom-SA payload), polling, failure-tail reporting,
+and the staged-tarball ↔ hashed-context equivalence.

--- a/docs/api/container.md
+++ b/docs/api/container.md
@@ -32,8 +32,12 @@ Resolve the runtime to use. Reads `container.runtime` from
 `~/.lightcone/config.yaml`:
 
 - `auto` (default) → first available, else `"none"` with `explicit=False`.
+  On a site declaring `container_runtime: kubernetes` (a Dask Gateway
+  deployment), auto resolves to `kubernetes` with no PATH probing.
 - `docker | podman | podman-hpc` → explicit; binary must exist or
   raises `ContainerBuildError`.
+- `kubernetes` → explicit; no binary involved (the worker pod is the
+  container).
 - `none` → explicit opt-out.
 - Anything else → `ContainerBuildError`.
 
@@ -111,6 +115,9 @@ No-op cases (`recipe` returned unchanged):
 
 - `image is None`
 - `runtime == "none"`
+- `runtime == "kubernetes"` — the Dask worker pod executing the recipe
+  was started from `image`; wrapping would containerize twice. The
+  image still flows into `code_version` and the manifest.
 
 Otherwise produces:
 
@@ -140,14 +147,16 @@ outputs typically share a Containerfile; resolving re-hashes the file
 plus all dependency files (lockfiles can be megabytes), so caching by
 spec string for the lifetime of the caller's loop matters.
 
-### `resolve_image_for_run(spec, *, project_path, project_name) → str | None`
+### `resolve_image_for_run(spec, *, project_path, project_name, registry=None) → str | None`
 
 Translate an `astra.yaml` `container:` value into the image tag the
 runtime will execute:
 
 - `None` / empty → `None`
 - Containerfile path → `lc-<name>-<hash>` (the tag `lc build` would
-  produce)
+  produce), or `<registry>/lc-<name>:<hash>` when `registry` is given
+  (a deployment with a remote builder — same content-addressed
+  identity, spelled for a registry)
 - Anything else → returned as-is
 
 ## Status

--- a/docs/api/dask_cluster.md
+++ b/docs/api/dask_cluster.md
@@ -33,10 +33,18 @@ server-side — create per run, cull on exit (the deployment's idle
 timeout is the backstop). Create-per-run is also what makes image
 updates seamless: a Gateway cluster's image is fixed at creation.
 
-The Gateway branch fails fast on two silent-hang failure modes: zero
-workers within the timeout (unpullable image, unschedulable pool), and
-workers that don't advertise the `cpus`/`memory` resource contract
-(a deployment that forgot `DASK_DISTRIBUTED__WORKER__RESOURCES__*`).
+The Gateway branch self-provisions the worker environment through the
+deployment's **standard `environment` cluster option** (no
+lightcone-specific injection needed server-side): the
+`DASK_DISTRIBUTED__WORKER__RESOURCES__*` scheduling contract mirrored
+from the declared `worker_cores`/`worker_memory` option values, the
+driver's `HOME`/`USER`/`LOGNAME` (passwd-less uid-1000 images crash
+`getpass.getuser()` without them), and `LIGHTCONE_WORKER_IMAGE` as
+manifest ground truth. It also fails fast on two silent-hang failure
+modes: zero workers within the timeout (unpullable image,
+unschedulable pool), and workers that don't advertise the
+`cpus`/`memory` resource contract (a deployment that doesn't expose
+the `environment` option).
 
 ## Resource keys
 

--- a/docs/api/dask_cluster.md
+++ b/docs/api/dask_cluster.md
@@ -1,24 +1,42 @@
 # lightcone.engine.dask_cluster
 
 Cluster lifecycle for `lc run`. One context manager (`cluster_for_run`),
-three branches, no service to manage.
+four branches, no service to manage.
 
 Source: `src/lightcone/engine/dask_cluster.py`.
 
-## `cluster_for_run(*, verbose=False) → Iterator[str]`
+## `cluster_for_run(*, verbose=False, worker_image=None, max_workers=None) → Iterator[dict[str, str]]`
 
-Yields a Dask scheduler address valid for the duration of `lc run`.
-Three branches in priority order:
+Yields the env overlay the child snakemake needs to reach the cluster
+(the executor plugin lives in a different process, so connection info
+travels via environment variables). Four branches in priority order:
 
-1. **`DASK_SCHEDULER_ADDRESS` already set** → yield as-is. We don't
+1. **`DASK_SCHEDULER_ADDRESS` already set** → yield it as-is. We don't
    own the cluster, so we don't tear it down.
-2. **`SLURM_JOB_ID` set** → start an in-process scheduler bound to the
+2. **`DASK_GATEWAY__ADDRESS` set** (a JupyterHub deployment) →
+   **create** a run-scoped Dask Gateway cluster with `worker_image` as
+   its `image` cluster option, scale it adaptively `1..max_workers`,
+   wait (bounded by `LIGHTCONE_GATEWAY_WORKER_TIMEOUT`, default 600 s)
+   for the first worker, and shut the cluster down on exit — success
+   or failure. Yields `{LIGHTCONE_GATEWAY_CLUSTER: <name>}`: Gateway
+   schedulers speak a `gateway://` comm scheme a bare `Client` cannot
+   dial, so the executor rejoins by name through the Gateway API.
+3. **`SLURM_JOB_ID` set** → start an in-process scheduler bound to the
    driver's SLURM hostname (`SLURMD_NODENAME` or `gethostname()`),
    then `srun` one `dask worker` per node across the allocation.
-3. **Neither** → `LocalCluster()` sized to the local machine.
+4. **None of the above** → `LocalCluster()` sized to the local machine.
 
-The scheduler is always in-process, so its lifetime equals the run's
-lifetime: no orphaned schedulers if the driver crashes.
+Outside the Gateway branch the scheduler is always in-process, so its
+lifetime equals the run's lifetime: no orphaned schedulers if the
+driver crashes. On the Gateway branch the same contract is enforced
+server-side — create per run, cull on exit (the deployment's idle
+timeout is the backstop). Create-per-run is also what makes image
+updates seamless: a Gateway cluster's image is fixed at creation.
+
+The Gateway branch fails fast on two silent-hang failure modes: zero
+workers within the timeout (unpullable image, unschedulable pool), and
+workers that don't advertise the `cpus`/`memory` resource contract
+(a deployment that forgot `DASK_DISTRIBUTED__WORKER__RESOURCES__*`).
 
 ## Resource keys
 

--- a/docs/api/dask_executor.md
+++ b/docs/api/dask_executor.md
@@ -36,9 +36,13 @@ Inherits from `snakemake_interface_executor_plugins.executors.remote.RemoteExecu
 ### `__init__(workflow, logger)`
 
 Imports `dask.distributed` lazily; raises `WorkflowError` if missing
-("`pip install distributed`"). Reads `DASK_SCHEDULER_ADDRESS` from the
-environment and opens a `Client(addr)`. Raises `WorkflowError` if the
-env var is unset — `lc run` is responsible for setting it.
+("`pip install distributed`"). Connects via `_connect_client()`: if
+`LIGHTCONE_GATEWAY_CLUSTER` is set, rejoins that Dask Gateway cluster
+through `Gateway().connect(name)` (with `shutdown_on_close=False` —
+the executor is a guest; `lc run` owns the cluster lifecycle);
+otherwise dials `DASK_SCHEDULER_ADDRESS` with a bare `Client`. Raises
+`WorkflowError` if neither is set — `lc run` is responsible for
+setting one.
 
 ### `run_job(job)`
 
@@ -53,18 +57,29 @@ client.submit(
 )
 ```
 
-`_run_shell` just runs `subprocess.run(cmd, shell=True, check=False)`
-on the worker and returns the exit code. The recipe is already
-container-wrapped at Snakefile generation time, so the worker has no
-runtime logic of its own.
+`_run_shell` runs `subprocess.run(cmd, shell=True, check=False)` on
+the worker and returns `(exit_code, output_block)`. The block is the
+child snakemake's sentinel-prefixed lines (see
+`lightcone.engine.runner.SENTINEL`), kept verbatim; on a failure that
+produced no sentinel line at all (the child died before the rule body
+— import error, missing package in the worker image) a bounded raw
+tail is sentinel-framed instead so bootstrap failures don't vanish
+into worker logs. Returning output through the task result is the only
+channel that works uniformly across LocalCluster threads, srun-launched
+workers, and Gateway worker pods (whose stdout goes to pod logs). The
+recipe is already container-wrapped at Snakefile generation time, so
+the worker has no runtime logic of its own.
 
 ### `check_active_jobs(active_jobs)`
 
 Async generator: for each submitted job, check `future.done()`. Yield
-back jobs that are still in flight. For finished jobs:
+back jobs that are still in flight. For finished jobs, unpack the
+result via `_unpack_result` (which also accepts the bare-int result of
+a worker running an older lightcone-cli release), write the output
+block to stdout — `lc run` filters and forwards it — then:
 
 - `future.exception() is not None` → `report_job_error(...)`
-- `future.result() != 0` → `report_job_error(...)`
+- exit code `!= 0` → `report_job_error(...)`
 - otherwise → `report_job_success(...)`
 
 ### `cancel_jobs(active_jobs)`

--- a/docs/cli/build.md
+++ b/docs/cli/build.md
@@ -14,7 +14,7 @@ lc build [OPTIONS]
 | Option | Default | Effect |
 |--------|---------|--------|
 | `--force` | off | Rebuild / re-pull even if the tag already exists locally. |
-| `--runtime {docker,podman,podman-hpc}` | resolved from `~/.lightcone/config.yaml` | Override the runtime for this build. |
+| `--runtime {docker,podman,podman-hpc,kubernetes}` | resolved from `~/.lightcone/config.yaml` | Override the runtime for this build. |
 
 ## What it does
 
@@ -28,6 +28,16 @@ sub-analysis, or recipe-level):
   pull it into the local image store. This is what lets `lc run` pass
   `--pull=never` to the runtime, sidestepping `unqualified-search-registries`
   resolution issues with content-addressed tags.
+
+On the `kubernetes` runtime (a lightcone JupyterHub deployment, where
+no local OCI runtime exists) the same command builds through the
+deployment's **GCP Cloud Build** service instead: the staged build
+context is uploaded to the deployment's build bucket and the resulting
+image is pushed as `$LIGHTCONE_REGISTRY/lc-<project>:<sha256[:12]>` —
+the same content-addressed identity, so an unchanged environment is a
+single registry check and no build at all. Pre-built registry images
+are left alone (worker pods pull them directly). Auth is the pod's
+Workload Identity; nothing to configure.
 
 If the runtime is `none` (either by config or because `auto` couldn't
 find one), `lc build` prints a friendly note and exits 0. There is

--- a/docs/user/cluster.md
+++ b/docs/user/cluster.md
@@ -1,23 +1,54 @@
 # Running on a Cluster
 
 When local laptop time isn't enough, you can take the same project to
-a SLURM HPC system. There's no separate configuration to learn — the
-same `lc run` command works inside an allocation, just with more
-hardware to spread across.
+a SLURM HPC system or a lightcone JupyterHub deployment. There's no
+separate configuration to learn — the same `lc run` command works
+everywhere, just with more hardware to spread across.
 
 ## The big picture
 
-`lc run` always dispatches through a Dask cluster. Three branches:
+`lc run` always dispatches through a Dask cluster. Four branches:
 
 1. On your laptop → a `LocalCluster` sized to the machine.
-2. **Inside a SLURM allocation** → an in-process scheduler bound to
+2. **On a JupyterHub deployment** (Dask Gateway detected) → a
+   run-scoped Gateway cluster created with your project's container
+   image and shut down when the run finishes.
+3. **Inside a SLURM allocation** → an in-process scheduler bound to
    the driver's hostname, with one `dask worker` per allocated node
    launched via `srun`.
-3. With `DASK_SCHEDULER_ADDRESS` set → connect to whatever scheduler
+4. With `DASK_SCHEDULER_ADDRESS` set → connect to whatever scheduler
    you've pointed at.
 
 You don't pick — `lc run` detects which case applies. The only thing
-you do differently on a cluster is request the nodes.
+you do differently on a cluster is request the nodes (and on
+JupyterHub, not even that).
+
+## JupyterHub deployments (Kubernetes + Dask Gateway)
+
+On a lightcone JupyterHub (GKE with Dask Gateway and Cloud Build),
+everything is zero-configuration — the deployment injects the whole
+contract into your session (`DASK_GATEWAY__*`, `LIGHTCONE_REGISTRY`,
+`LIGHTCONE_BUILD_BUCKET`), and `lc` picks it up:
+
+- `lc init` scaffolds a **worker-capable** Containerfile: the project
+  image doubles as the Dask worker pod image, so it carries
+  dask/dask-gateway/snakemake/lightcone-cli pinned to the hub's
+  versions on top of your own dependencies.
+- `lc build` builds through the deployment's **GCP Cloud Build**
+  service (there's no docker in your session) and pushes
+  `<registry>/lc-<project>:<content-hash>` to the hub's Artifact
+  Registry. Unchanged files never rebuild — freshness is one registry
+  check.
+- `lc run` makes sure the image is up to date, **creates a Dask
+  Gateway cluster with that image**, runs the pipeline in worker pods
+  (recipes execute directly in the image — no nested containers), and
+  **culls the cluster when the run finishes**. Your NFS home is
+  mounted in every worker pod at the same path, so outputs land in
+  the project tree exactly as they do locally.
+
+A cluster's image is fixed at creation, so create-per-run is also what
+keeps the environment fresh: edit the Containerfile, `lc run`, and the
+next cluster runs the rebuilt image.
 
 ## Pre-flight: pick the right container runtime
 

--- a/docs/user/cluster.md
+++ b/docs/user/cluster.md
@@ -30,10 +30,11 @@ everything is zero-configuration — the deployment injects the whole
 contract into your session (`DASK_GATEWAY__*`, `LIGHTCONE_REGISTRY`,
 `LIGHTCONE_BUILD_BUCKET`), and `lc` picks it up:
 
-- `lc init` scaffolds a **worker-capable** Containerfile: the project
-  image doubles as the Dask worker pod image, so it carries
-  dask/dask-gateway/snakemake/lightcone-cli pinned to the hub's
-  versions on top of your own dependencies.
+- The scaffolded project image doubles as the Dask worker pod image
+  with no hub-specific content: `lc init` pins `lightcone-cli` in
+  `requirements.txt`, which brings the whole execution stack
+  (snakemake, dask, distributed, dask-gateway) on top of your own
+  dependencies — the same image runs anywhere.
 - `lc build` builds through the deployment's **GCP Cloud Build**
   service (there's no docker in your session) and pushes
   `<registry>/lc-<project>:<content-hash>` to the hub's Artifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ docs = [
 ]
 
 
+[project.optional-dependencies]
+# Dask Gateway client for JupyterHub/Kubernetes deployments. The
+# client's minor version should match the deployment's gateway server.
+gateway = ["dask-gateway>=2024.1"]
+
 [project.scripts]
 lc = "lightcone.cli:main"
 
@@ -100,7 +105,7 @@ explicit_package_bases = true
 mypy_path = "src"
 
 [[tool.mypy.overrides]]
-module = ["dask.*", "distributed.*"]
+module = ["dask.*", "distributed.*", "dask_gateway", "dask_gateway.*"]
 ignore_missing_imports = true
 follow_untyped_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,11 @@ dev = [
     "ruff",
     "mypy",
     "types-PyYAML",
+    # Real gateway client in the dev env: the image-override contract
+    # (lc's explicit image kwarg must beat the deployment's ambient
+    # DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE default) is pinned by a
+    # regression test against the actual client merge logic.
+    "dask-gateway>=2024.1",
 ]
 docs = [
     "zensical>=0.0.33",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,9 +110,17 @@ explicit_package_bases = true
 mypy_path = "src"
 
 [[tool.mypy.overrides]]
-module = ["dask.*", "distributed.*", "dask_gateway", "dask_gateway.*"]
+module = ["dask.*", "distributed.*"]
 ignore_missing_imports = true
 follow_untyped_imports = true
+
+[[tool.mypy.overrides]]
+# Untyped and without explicit re-exports; skip so `from dask_gateway
+# import Gateway` doesn't trip strict no_implicit_reexport when the
+# package happens to be installed (it's a dev/extra dependency).
+module = ["dask_gateway", "dask_gateway.*"]
+ignore_missing_imports = true
+follow_imports = "skip"
 
 [[tool.mypy.overrides]]
 module = ["rocrate.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
     "snakemake-interface-common>=1.14",
     "dask>=2024.1",
     "distributed>=2024.1",
+    # Dask Gateway client for JupyterHub/Kubernetes deployments. A
+    # normal dependency (not an extra) so `lc run` works out of the box
+    # on a hub and scaffolded project images inherit it via their
+    # lightcone-cli pin.
+    "dask-gateway>=2024.1",
     "rocrate>=0.11",
 ]
 
@@ -53,21 +58,11 @@ dev = [
     "ruff",
     "mypy",
     "types-PyYAML",
-    # Real gateway client in the dev env: the image-override contract
-    # (lc's explicit image kwarg must beat the deployment's ambient
-    # DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE default) is pinned by a
-    # regression test against the actual client merge logic.
-    "dask-gateway>=2024.1",
 ]
 docs = [
     "zensical>=0.0.33",
 ]
 
-
-[project.optional-dependencies]
-# Dask Gateway client for JupyterHub/Kubernetes deployments. The
-# client's minor version should match the deployment's gateway server.
-gateway = ["dask-gateway>=2024.1"]
 
 [project.scripts]
 lc = "lightcone.cli:main"
@@ -116,8 +111,7 @@ follow_untyped_imports = true
 
 [[tool.mypy.overrides]]
 # Untyped and without explicit re-exports; skip so `from dask_gateway
-# import Gateway` doesn't trip strict no_implicit_reexport when the
-# package happens to be installed (it's a dev/extra dependency).
+# import Gateway` doesn't trip strict no_implicit_reexport.
 module = ["dask_gateway", "dask_gateway.*"]
 ignore_missing_imports = true
 follow_imports = "skip"

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -182,6 +182,7 @@ def init(
 
     from lightcone.engine.site_registry import detect_current_site
 
+    site = detect_current_site()
     directory = directory.resolve()
 
     if (directory / "astra.yaml").exists():
@@ -206,8 +207,17 @@ def init(
             "container: python:3.12-slim", "container: Containerfile", 1
         )
     )
-    (directory / "Containerfile").write_text(_CONTAINERFILE)
-    (directory / "requirements.txt").write_text(_REQUIREMENTS)
+    # On a Dask Gateway deployment the project image doubles as the
+    # worker pod image, so the scaffold must be worker-capable: the
+    # dask/gateway/snakemake/lightcone stack at the versions the hub
+    # runs, and a uid-1000 user matching the mounted NFS home.
+    on_hub = site.get("backend") == "kubernetes"
+    (directory / "Containerfile").write_text(
+        _CONTAINERFILE_WORKER if on_hub else _CONTAINERFILE
+    )
+    (directory / "requirements.txt").write_text(
+        _REQUIREMENTS + _worker_stack_pins() if on_hub else _REQUIREMENTS
+    )
 
     # Append lightcone-specific entries to the .gitignore astra wrote.
     gitignore_path = directory / ".gitignore"
@@ -294,7 +304,6 @@ def init(
     # state (snakemake metadata, dask spill, cross-node locks). On NERSC
     # this is critical: $HOME and CFS are mounted via DVS (no flock, slow
     # small-file I/O), so lightcone keeps everything on $SCRATCH (Lustre).
-    site = detect_current_site()
     if site:
         scratch_expr = scratch_override or site.get("scratch_root")
         if scratch_expr:
@@ -343,6 +352,47 @@ _REQUIREMENTS = """\
 numpy
 pandas
 """
+
+
+_CONTAINERFILE_WORKER = """\
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# This image runs as a Dask Gateway worker pod with the user's NFS home
+# mounted at /home/jovyan. A uid-1000 passwd entry keeps outputs owned
+# by the user and getpass.getuser() (called by snakemake) working.
+RUN useradd --create-home --uid 1000 jovyan
+USER jovyan
+"""
+
+
+def _worker_stack_pins() -> str:
+    """Requirements lines for the Dask Gateway worker stack.
+
+    A Gateway worker must speak the deployment's dask protocol and run
+    the child snakemake that executes each rule, so the project image
+    carries dask/distributed/dask-gateway/snakemake/lightcone-cli. Pins
+    mirror the environment ``lc init`` is running in — the notebook pod
+    matches the hub's gateway version, so pinning to it keeps the
+    worker in lockstep. Unpinned fallback for anything not installed
+    here (or installed as a dev build).
+    """
+    from importlib.metadata import PackageNotFoundError, version
+
+    lines = ["", "# Dask Gateway worker stack (pinned to this hub's versions)"]
+    for dist in ("dask", "distributed", "dask-gateway", "snakemake", "lightcone-cli"):
+        try:
+            v = version(dist)
+        except PackageNotFoundError:
+            v = ""
+        lines.append(f"{dist}=={v}" if v and "dev" not in v else dist)
+    return "\n".join(lines) + "\n"
 
 
 _GITIGNORE_APPEND = """
@@ -537,13 +587,14 @@ def run(
     """Materialize outputs declared in astra.yaml.
 
     Always dispatches through a Dask cluster: a ``LocalCluster`` on a
-    workstation, srun-launched workers inside a SLURM allocation, or an
+    workstation, srun-launched workers inside a SLURM allocation, a
+    run-scoped Dask Gateway cluster on a JupyterHub deployment, or an
     existing scheduler if ``DASK_SCHEDULER_ADDRESS`` is set.
     """
     _abort_on_perlmutter_login()
 
     from lightcone.engine.container import load_runtime
-    from lightcone.engine.dask_cluster import cluster_for_run
+    from lightcone.engine.dask_cluster import cluster_for_run, gateway_branch_active
     from lightcone.engine.scratch import (
         RunLockBusyError,
         acquire_run_lock,
@@ -568,10 +619,25 @@ def run(
         console.print(f"[dim]Scratch root:[/dim] {resolve_scratch_root(project)}")
 
     choice = load_runtime(project_path=project)
-    _ensure_images(project, runtime=choice.runtime)
+    images = _ensure_images(project, runtime=choice.runtime)
     snakefile_path, cfg_path = generate(
         project, universes=universes, runtime=choice.runtime
     )
+
+    # On the Gateway branch the cluster is created with one image — the
+    # worker pod is the container for every rule, so a spec declaring
+    # several distinct containers cannot be honoured per-rule.
+    worker_image: str | None = None
+    if gateway_branch_active():
+        if len(images) > 1:
+            raise click.ClickException(
+                "This deployment runs recipes natively in worker pods, "
+                "which supports one container image per run; astra.yaml "
+                "declares several: " + ", ".join(images) + ". "
+                "Consolidate on a single Containerfile (or one shared "
+                "prebuilt image)."
+            )
+        worker_image = images[0] if images else None
 
     # Provenance guard: when ``runtime: auto`` silently fell back to
     # ``none`` and the spec declares any containers, the recipe will run
@@ -624,6 +690,7 @@ def run(
         targets=targets,
         force=force,
         has_outputs=bool(outputs),
+        gateway=gateway_branch_active(),
     )
 
     # Hold a project-level flock for the duration of the run. Acquiring
@@ -638,57 +705,80 @@ def run(
         raise click.ClickException(str(e))
 
     with cluster_for_run(
-        verbose=verbose, local_directory=str(rundirs.dask_local)
-    ) as scheduler_addr:
-        env = {
-            **os.environ,
-            "DASK_SCHEDULER_ADDRESS": scheduler_addr,
-            # The dask plugin's worker-side ``_run_shell`` takes this
-            # ``flock`` before forwarding a rule's lightcone output, so
-            # parallel rules' blocks never interleave at the line level
-            # — even across nodes. The lockfile sits under our scratch
-            # root specifically to avoid DVS on NERSC.
-            "LIGHTCONE_OUT_LOCK": str(rundirs.lock_path),
-        }
+        verbose=verbose,
+        local_directory=str(rundirs.dask_local),
+        worker_image=worker_image,
+        max_workers=int(n),
+    ) as cluster_env:
+        env = {**os.environ, **cluster_env}
         if verbose:
             console.print(f"[dim]$ {' '.join(cmd)}[/dim]")
-            sys.exit(subprocess.run(cmd, env=env).returncode)
-        sys.exit(_run_silent(cmd, env=env, scratch_root=rundirs.root))
+        sys.exit(
+            _run_snakemake(
+                cmd, env=env, scratch_root=rundirs.root, verbose=verbose
+            )
+        )
 
 
-def _run_silent(
+def _run_snakemake(
     cmd: list[str],
     *,
     env: dict[str, str],
     scratch_root: Path,
+    verbose: bool,
 ) -> int:
-    """Run snakemake with its own output suppressed.
+    """Run snakemake, forwarding the run's narrative output.
 
-    All user-facing output for the run flows through dask workers
-    (``_run_shell`` in the executor plugin → terminal stdout under
-    ``flock``). The parent snakemake process here only emits its own
-    bootstrap chatter (DAG building, rule selection, "Workflow finished")
-    plus, on failure, a workflow-level diagnostic. We discard stdout
-    wholesale and tail stderr into a bounded ring buffer so a workflow
-    crash leaves a real log behind without that log being visible
-    during a successful run.
+    The executor plugin prints each finished rule's block of
+    sentinel-prefixed lines (see :data:`lightcone.engine.runner.SENTINEL`)
+    on the snakemake process's stdout. We forward those lines — prefix
+    stripped — to the terminal and drop everything else snakemake emits
+    (DAG chatter, job stats), so a run reads as a clean narrative.
+    Verbose mode forwards the noise too.
+
+    stderr is tailed into a bounded ring buffer so a workflow crash
+    leaves a real log behind without it being visible during a
+    successful run (verbose passes stderr straight through instead).
     """
     from collections import deque
+
+    from lightcone.engine.runner import SENTINEL
 
     proc = subprocess.Popen(
         cmd,
         env=env,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=None if verbose else subprocess.PIPE,
         text=True,
         bufsize=1,
     )
-    assert proc.stderr is not None
+    assert proc.stdout is not None
     tail: deque[str] = deque(maxlen=400)
-    for line in proc.stderr:
-        tail.append(line)
+
+    def _pump_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            tail.append(line)
+
+    import threading
+
+    stderr_thread: threading.Thread | None = None
+    if not verbose:
+        stderr_thread = threading.Thread(target=_pump_stderr, daemon=True)
+        stderr_thread.start()
+
+    for line in proc.stdout:
+        if line.startswith(SENTINEL):
+            sys.stdout.write(line[len(SENTINEL):])
+            sys.stdout.flush()
+        elif verbose:
+            sys.stdout.write(line)
+            sys.stdout.flush()
+
     rc = proc.wait()
-    if rc != 0:
+    if stderr_thread is not None:
+        stderr_thread.join(timeout=5)
+    if rc != 0 and not verbose:
         log = scratch_root / f"snakemake-stderr-{os.getpid()}.log"
         try:
             log.parent.mkdir(parents=True, exist_ok=True)
@@ -712,12 +802,26 @@ def _build_snakemake_cmd(
     targets: list[str],
     force: bool,
     has_outputs: bool,
+    gateway: bool = False,
 ) -> list[str]:
     """Build the snakemake argv list for ``lc run``.
 
     ``--rerun-triggers`` uses ``nargs=+`` in snakemake's argparse, so without
     an explicit ``--`` separator it greedily consumes the first positional
     target path as an extra trigger value, causing an "invalid choice" error.
+
+    *gateway* adapts the invocation to Dask Gateway worker pods:
+
+    * ``--latency-wait 120`` — NFS home volumes sync slowly between
+      worker pods and the driver (measured up to ~60 s on the dev hub,
+      LCR-177); snakemake's default 5 s output-wait would fail
+      successful rules spuriously.
+    * ``--shared-fs-usage`` without ``software-deployment`` — with it
+      (the default) the child snakemake command embeds the *driver's*
+      ``sys.executable``, a path that doesn't exist inside the worker
+      image; without it, workers invoke plain ``python`` from their own
+      PATH. Everything else stays shared: the NFS home carries the
+      project, sources, and snakemake persistence.
     """
     cmd: list[str] = [
         "snakemake",
@@ -734,6 +838,17 @@ def _build_snakemake_cmd(
         "--rerun-triggers",
         *rerun_triggers.split(","),
     ]
+    if gateway:
+        cmd += [
+            "--latency-wait",
+            "120",
+            "--shared-fs-usage",
+            "persistence",
+            "input-output",
+            "sources",
+            "storage-local-copies",
+            "source-cache",
+        ]
     if force:
         # ``--force`` scopes to explicit targets; ``rule all`` itself
         # has no recipe, so force-all is the only useful sense when no
@@ -890,7 +1005,10 @@ def verify(universe: str | None) -> None:
 @click.option(
     "--runtime",
     default=None,
-    help="docker | podman | podman-hpc (overrides ~/.lightcone/config.yaml)",
+    help=(
+        "docker | podman | podman-hpc | kubernetes "
+        "(overrides ~/.lightcone/config.yaml)"
+    ),
 )
 def build(force: bool, runtime: str | None) -> None:
     """Build container images declared in astra.yaml.
@@ -901,6 +1019,12 @@ def build(force: bool, runtime: str | None) -> None:
     image store. Pre-built registry images (``python:3.12-slim``,
     ``ghcr.io/foo/bar:tag``) are skipped — the runtime pulls them at
     ``lc run`` time.
+
+    On a deployment without a local OCI runtime (the ``kubernetes``
+    runtime on a lightcone JupyterHub), the same command builds through
+    the deployment's GCP Cloud Build service instead and pushes
+    ``<registry>/lc-<project>:<hash>`` — same content-addressed
+    identity, zero configuration.
     """
     from lightcone.engine.container import ContainerBuildError, load_runtime
 
@@ -923,21 +1047,27 @@ def build(force: bool, runtime: str | None) -> None:
     console.print("[green]Done.[/green]")
 
 
-def _ensure_images(project: Path, *, runtime: str, force: bool = False) -> None:
+def _ensure_images(project: Path, *, runtime: str, force: bool = False) -> list[str]:
     """Build/pull every container image referenced in astra.yaml.
 
-    No-op when *runtime* is ``"none"``. Idempotent: skips images already
-    present in the runtime's local image store. Used by ``lc build`` (with
-    ``--force`` exposed) and as a pre-flight by ``lc run`` so the first
-    invocation after editing a Containerfile doesn't fail mid-DAG with a
-    missing image.
+    Returns the distinct resolved images, in declaration order (local
+    tags or registry refs for Containerfile specs, prebuilt specs
+    as-is). No-op (and empty) when *runtime* is ``"none"``.
+
+    Idempotent: skips images already present (local image store, or the
+    deployment registry on the ``kubernetes`` runtime — where builds go
+    through Cloud Build instead of a local OCI CLI). Used by ``lc build``
+    (with ``--force`` exposed) and as a pre-flight by ``lc run`` so the
+    first invocation after editing a Containerfile doesn't fail mid-DAG
+    with a missing image.
     """
     if runtime == "none":
-        return
+        return []
 
     from astra.helpers import load_yaml, resolve_analysis_tree
 
     from lightcone.engine.container import (
+        KUBERNETES,
         ContainerBuildError,
         build_image,
         compute_image_tag,
@@ -950,6 +1080,7 @@ def _ensure_images(project: Path, *, runtime: str, force: bool = False) -> None:
     spec = resolve_analysis_tree(load_yaml(project / "astra.yaml"), project)
     project_name = (spec.get("name") or project.name).lower().replace(" ", "-")
 
+    images: list[str] = []
     seen: set[str] = set()
     for to in collect_tree_outputs(spec):
         recipe = to.output_def.get("recipe") or {}
@@ -962,8 +1093,13 @@ def _ensure_images(project: Path, *, runtime: str, force: bool = False) -> None:
             continue
         seen.add(spec_str)
         if not is_containerfile(spec_str, project):
-            # Registry image — pull so ``lc run`` can use ``--pull=never``
-            # without depending on the runtime's registry resolution.
+            images.append(spec_str)
+            if runtime == KUBERNETES:
+                # Nothing to materialize: worker pods pull registry
+                # images straight from their source.
+                continue
+            # Pull so ``lc run`` can use ``--pull=never`` without
+            # depending on the runtime's registry resolution.
             if image_exists_locally(spec_str, runtime=runtime) and not force:
                 continue
             console.print(f"[cyan]Pulling[/cyan] {spec_str} [dim](via {runtime})[/dim]")
@@ -973,8 +1109,13 @@ def _ensure_images(project: Path, *, runtime: str, force: bool = False) -> None:
                 raise click.ClickException(str(e))
             continue
 
+        if runtime == KUBERNETES:
+            images.append(_cloudbuild_image(project, spec_str, project_name, force))
+            continue
+
         containerfile = project / spec_str
         tag = compute_image_tag(project_name, containerfile, project)
+        images.append(tag)
         if image_exists_locally(tag, runtime=runtime) and not force:
             continue
         console.print(
@@ -984,6 +1125,51 @@ def _ensure_images(project: Path, *, runtime: str, force: bool = False) -> None:
             build_image(tag, containerfile, project, runtime=runtime)
         except ContainerBuildError as e:
             raise click.ClickException(str(e))
+    return images
+
+
+def _cloudbuild_image(
+    project: Path, spec_str: str, project_name: str, force: bool
+) -> str:
+    """Ensure one Containerfile's image via GCP Cloud Build; return its ref."""
+    from lightcone.engine.cloudbuild import (
+        CloudBuildError,
+        cloudbuild_available,
+        ensure_image,
+    )
+
+    if not cloudbuild_available():
+        raise click.ClickException(
+            "No image build backend on this host: the kubernetes runtime "
+            "has no local OCI CLI and this environment does not provide "
+            "the Cloud Build contract (LIGHTCONE_REGISTRY + "
+            "LIGHTCONE_BUILD_BUCKET). On a lightcone JupyterHub these are "
+            "injected into every user pod — ask the hub admin."
+        )
+
+    status = console.status(f"[cyan]Ensuring image for[/cyan] {spec_str} …")
+    status.start()
+
+    def on_progress(phase: str, detail: str) -> None:
+        note = f" [dim]{detail}[/dim]" if detail else ""
+        status.update(
+            f"[cyan]Ensuring image for[/cyan] {spec_str}: {phase}{note}"
+        )
+
+    try:
+        ref = ensure_image(
+            project,
+            spec_str,
+            project_name=project_name,
+            force=force,
+            on_progress=on_progress,
+        )
+    except CloudBuildError as e:
+        raise click.ClickException(str(e))
+    finally:
+        status.stop()
+    console.print(f"[green]✓[/green] Worker image: [cyan]{ref}[/cyan]")
+    return ref
 
 
 # =============================================================================

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -207,16 +207,15 @@ def init(
             "container: python:3.12-slim", "container: Containerfile", 1
         )
     )
-    # On a Dask Gateway deployment the project image doubles as the
-    # worker pod image, so the scaffold must be worker-capable: the
-    # dask/gateway/snakemake/lightcone stack at the versions the hub
-    # runs, and a uid-1000 user matching the mounted NFS home.
-    on_hub = site.get("backend") == "kubernetes"
-    (directory / "Containerfile").write_text(
-        _CONTAINERFILE_WORKER if on_hub else _CONTAINERFILE
-    )
+    # One scaffold everywhere — the Containerfile is agnostic to the
+    # execution environment. lightcone-cli in requirements.txt brings
+    # the whole execution stack (snakemake, dask, distributed,
+    # dask-gateway) so the same image can wrap recipes locally or run
+    # as a Dask Gateway worker pod on a hub; anything pod-specific
+    # (uid, mounts) is deployment configuration, not image content.
+    (directory / "Containerfile").write_text(_CONTAINERFILE)
     (directory / "requirements.txt").write_text(
-        _REQUIREMENTS + _worker_stack_pins() if on_hub else _REQUIREMENTS
+        _REQUIREMENTS + _lightcone_requirement()
     )
 
     # Append lightcone-specific entries to the .gitignore astra wrote.
@@ -333,16 +332,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY requirements.txt .
-
-# Install curl and certificates, then clean up to keep image size small
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
-RUN uv pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 """
@@ -354,45 +344,29 @@ pandas
 """
 
 
-_CONTAINERFILE_WORKER = """\
-FROM python:3.12-slim
+def _lightcone_requirement() -> str:
+    """Requirements lines pinning lightcone-cli into the project image.
 
-WORKDIR /app
-
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY . .
-
-# This image runs as a Dask Gateway worker pod with the user's NFS home
-# mounted at /home/jovyan. A uid-1000 passwd entry keeps outputs owned
-# by the user and getpass.getuser() (called by snakemake) working.
-RUN useradd --create-home --uid 1000 jovyan
-USER jovyan
-"""
-
-
-def _worker_stack_pins() -> str:
-    """Requirements lines for the Dask Gateway worker stack.
-
-    A Gateway worker must speak the deployment's dask protocol and run
-    the child snakemake that executes each rule, so the project image
-    carries dask/distributed/dask-gateway/snakemake/lightcone-cli. Pins
-    mirror the environment ``lc init`` is running in — the notebook pod
-    matches the hub's gateway version, so pinning to it keeps the
-    worker in lockstep. Unpinned fallback for anything not installed
-    here (or installed as a dev build).
+    The project image must be able to execute rules on any backend —
+    including as a Dask Gateway worker pod, where the dask worker and
+    the child snakemake run *inside* the image. lightcone-cli carries
+    that whole stack (snakemake, dask, distributed, dask-gateway) as
+    normal dependencies, so one line covers it. The pin mirrors the
+    version running ``lc init`` to keep driver and image in lockstep;
+    dev builds fall back to unpinned (their version isn't published).
     """
     from importlib.metadata import PackageNotFoundError, version
 
-    lines = ["", "# Dask Gateway worker stack (pinned to this hub's versions)"]
-    for dist in ("dask", "distributed", "dask-gateway", "snakemake", "lightcone-cli"):
-        try:
-            v = version(dist)
-        except PackageNotFoundError:
-            v = ""
-        lines.append(f"{dist}=={v}" if v and "dev" not in v else dist)
-    return "\n".join(lines) + "\n"
+    try:
+        v = version("lightcone-cli")
+    except PackageNotFoundError:
+        v = ""
+    pin = f"lightcone-cli=={v}" if v and "dev" not in v else "lightcone-cli"
+    return (
+        "\n# Execution stack — lets this image run rules on any backend,\n"
+        "# including as a Dask Gateway worker pod.\n"
+        f"{pin}\n"
+    )
 
 
 _GITIGNORE_APPEND = """
@@ -690,7 +664,6 @@ def run(
         targets=targets,
         force=force,
         has_outputs=bool(outputs),
-        gateway=gateway_branch_active(),
     )
 
     # Hold a project-level flock for the duration of the run. Acquiring
@@ -802,7 +775,6 @@ def _build_snakemake_cmd(
     targets: list[str],
     force: bool,
     has_outputs: bool,
-    gateway: bool = False,
 ) -> list[str]:
     """Build the snakemake argv list for ``lc run``.
 
@@ -810,18 +782,17 @@ def _build_snakemake_cmd(
     an explicit ``--`` separator it greedily consumes the first positional
     target path as an extra trigger value, causing an "invalid choice" error.
 
-    *gateway* adapts the invocation to Dask Gateway worker pods:
-
-    * ``--latency-wait 120`` — NFS home volumes sync slowly between
-      worker pods and the driver (measured up to ~60 s on the dev hub,
-      LCR-177); snakemake's default 5 s output-wait would fail
-      successful rules spuriously.
-    * ``--shared-fs-usage`` without ``software-deployment`` — with it
-      (the default) the child snakemake command embeds the *driver's*
-      ``sys.executable``, a path that doesn't exist inside the worker
-      image; without it, workers invoke plain ``python`` from their own
-      PATH. Everything else stays shared: the NFS home carries the
-      project, sources, and snakemake persistence.
+    ``--shared-fs-usage`` lists everything *except*
+    ``software-deployment``. With it included (snakemake's default),
+    spawned job commands embed the *driver's* ``sys.executable`` — a
+    path that doesn't exist inside a Dask Gateway worker image. Without
+    it, workers invoke plain ``python`` from their own environment,
+    which is equally correct on the other backends: LocalCluster
+    threads and srun-launched SLURM workers inherit the driver's
+    activated environment (and SLURM setups already require it — see
+    the ``dask``-on-PATH check in the cluster module). One invocation
+    shape for every backend; everything else stays shared via the
+    common filesystem (persistence, inputs/outputs, sources).
     """
     cmd: list[str] = [
         "snakemake",
@@ -835,20 +806,15 @@ def _build_snakemake_cmd(
         n,
         "--executor",
         "dask",
+        "--shared-fs-usage",
+        "persistence",
+        "input-output",
+        "sources",
+        "storage-local-copies",
+        "source-cache",
         "--rerun-triggers",
         *rerun_triggers.split(","),
     ]
-    if gateway:
-        cmd += [
-            "--latency-wait",
-            "120",
-            "--shared-fs-usage",
-            "persistence",
-            "input-output",
-            "sources",
-            "storage-local-copies",
-            "source-cache",
-        ]
     if force:
         # ``--force`` scopes to explicit targets; ``rule all`` itself
         # has no recipe, so force-all is the only useful sense when no

--- a/src/lightcone/engine/cloudbuild.py
+++ b/src/lightcone/engine/cloudbuild.py
@@ -1,0 +1,415 @@
+"""Remote image builds through GCP Cloud Build.
+
+The build backend for deployments where no OCI runtime exists on the
+host — a JupyterHub user pod on GKE. ``lc build`` tars the project's
+**staged build context** (the exact file set the content-addressed tag
+hashes), uploads it to a deployment-provided GCS bucket, and submits a
+Cloud Build job that pushes the image to the deployment's Artifact
+Registry. Auth is the pod's Workload Identity, spoken to the GCE
+metadata server — no stored credentials, no SDK dependency, no git
+remote required.
+
+Image identity is the same content-addressed scheme as everywhere else
+(:func:`lightcone.engine.container.image_identity`); the pushed ref is
+``$LIGHTCONE_REGISTRY/lc-<project>:<hash>`` and "is the image up to
+date" is a single registry HEAD on that ref — unchanged files never
+rebuild, never even upload.
+
+Deployment contract (env vars injected into user pods — see the
+hub-deploy ``lightcone`` hub config):
+
+- :data:`~lightcone.engine.container.REGISTRY_ENV` — Artifact Registry
+  prefix (``<region>-docker.pkg.dev/<project>/<repo>``); also names the
+  GCP project builds run in.
+- :data:`BUCKET_ENV` — GCS bucket for build sources and logs. Its
+  presence (with the registry) is what selects this backend.
+- :data:`SERVICE_ACCOUNT_ENV` (optional) — dedicated build service
+  account; the deployment grants it registry-writer rights only.
+
+The pod's identity needs ``cloudbuild.builds.editor``,
+``iam.serviceAccountUser`` on the build SA, object create/view on the
+bucket, and ``artifactregistry.reader`` for the freshness probe.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+
+from lightcone.engine.container import (
+    _populate_build_context,
+    deployment_registry,
+    image_identity,
+    registry_image_ref,
+)
+
+#: GCS bucket for build sources/logs. Presence selects this backend.
+BUCKET_ENV = "LIGHTCONE_BUILD_BUCKET"
+
+#: Optional dedicated Cloud Build service account (bare email or full
+#: ``projects/…/serviceAccounts/…`` resource name).
+SERVICE_ACCOUNT_ENV = "LIGHTCONE_BUILD_SERVICE_ACCOUNT"
+
+#: Hard ceiling on one build, seconds (also sent as the Cloud Build
+#: timeout). Project images are slim; single-digit minutes is typical.
+_BUILD_DEADLINE_S = 1800
+
+_POLL_INTERVAL_S = 5.0
+
+_METADATA_TOKEN_URL = (
+    "http://metadata.google.internal/computeMetadata/v1/"
+    "instance/service-accounts/default/token"
+)
+
+#: Progress callback ``(phase, detail)``; phases are ``cached``,
+#: ``staging``, then Cloud Build statuses lowercased (queued/working/…).
+ProgressFn = Callable[[str, str], None]
+
+
+class CloudBuildError(RuntimeError):
+    """An image could not be produced through Cloud Build."""
+
+
+def cloudbuild_available() -> bool:
+    """Is this environment configured for Cloud Build image builds?"""
+    return bool(os.environ.get(BUCKET_ENV)) and deployment_registry() is not None
+
+
+# ---------------------------------------------------------------------------
+# Auth + HTTP plumbing
+# ---------------------------------------------------------------------------
+
+
+def _metadata_access_token() -> str | None:
+    """OAuth2 access token from the GCE metadata server, or ``None``.
+
+    On GKE with Workload Identity this returns a token for the
+    Kubernetes service account's bound GCP identity. Off-GCP the
+    metadata host doesn't resolve and we return ``None`` quickly.
+    """
+    req = urllib.request.Request(
+        _METADATA_TOKEN_URL, headers={"Metadata-Flavor": "Google"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+    token = payload.get("access_token")
+    return token if isinstance(token, str) and token else None
+
+
+def _token() -> str:
+    token = _metadata_access_token()
+    if token is None:
+        raise CloudBuildError(
+            "No GCP credentials available from the metadata server. The "
+            "Cloud Build backend needs Workload Identity (or another "
+            "metadata-served identity) with cloudbuild.builds.editor."
+        )
+    return token
+
+
+def _request(
+    method: str,
+    url: str,
+    token: str,
+    *,
+    body: bytes | None = None,
+    content_type: str = "application/json",
+) -> tuple[int, bytes]:
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            **({"Content-Type": content_type} if body is not None else {}),
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+    except (urllib.error.URLError, OSError) as exc:
+        raise CloudBuildError(f"Could not reach {url.split('?')[0]} ({exc}).") from exc
+
+
+def _json_or_error(status: int, payload: bytes, what: str) -> dict[str, object]:
+    if not 200 <= status < 300:
+        detail = payload.decode("utf-8", errors="replace")[:500]
+        raise CloudBuildError(f"{what} failed: HTTP {status}\n{detail}")
+    try:
+        parsed = json.loads(payload.decode("utf-8") or "{}")
+    except ValueError as exc:
+        raise CloudBuildError(f"{what} returned unparseable JSON.") from exc
+    return parsed if isinstance(parsed, dict) else {}
+
+
+# ---------------------------------------------------------------------------
+# Registry freshness probe
+# ---------------------------------------------------------------------------
+
+
+def registry_image_exists(ref: str) -> bool | None:
+    """Does *ref* exist in its registry? ``None`` when unknowable.
+
+    Speaks the Docker Registry v2 API with the metadata-server token
+    (Artifact Registry accepts OAuth2 access tokens as Bearer). Returns
+    ``None`` — not ``False`` — when there are no credentials or the
+    registry can't be reached, so callers can distinguish "absent,
+    build it" from "can't tell".
+    """
+    host, _, path = ref.partition("/")
+    repo, _, tag = path.rpartition(":")
+    if not (host and repo and tag):
+        return None
+    token = _metadata_access_token()
+    if token is None:
+        return None
+    url = f"https://{host}/v2/{repo}/manifests/{urllib.parse.quote(tag, safe='')}"
+    req = urllib.request.Request(
+        url,
+        method="HEAD",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": (
+                "application/vnd.oci.image.index.v1+json, "
+                "application/vnd.oci.image.manifest.v1+json, "
+                "application/vnd.docker.distribution.manifest.v2+json, "
+                "application/vnd.docker.distribution.manifest.list.v2+json"
+            ),
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return bool(200 <= resp.status < 300)
+    except urllib.error.HTTPError as exc:
+        return None if exc.code in (401, 403) else False
+    except (urllib.error.URLError, OSError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Source staging + upload
+# ---------------------------------------------------------------------------
+
+
+def _staged_context_tarball(project: Path, containerfile: Path) -> bytes:
+    """gzip tarball of the staged build context (the hashed file set)."""
+    with tempfile.TemporaryDirectory(prefix="lc-cloudbuild-") as tmp:
+        staged = Path(tmp)
+        _populate_build_context(staged, containerfile, project)
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for entry in sorted(staged.rglob("*")):
+                tar.add(entry, arcname=str(entry.relative_to(staged)))
+        return buf.getvalue()
+
+
+def _upload_source(bucket: str, object_name: str, data: bytes, token: str) -> None:
+    url = (
+        "https://storage.googleapis.com/upload/storage/v1/b/"
+        f"{urllib.parse.quote(bucket, safe='')}/o?uploadType=media&name="
+        f"{urllib.parse.quote(object_name, safe='')}"
+    )
+    status, payload = _request(
+        "POST", url, token, body=data, content_type="application/gzip"
+    )
+    _json_or_error(status, payload, "Source upload to the build bucket")
+
+
+def _fetch_log_tail(bucket: str, build_id: str, token: str, lines: int = 30) -> str:
+    object_name = urllib.parse.quote(f"logs/log-{build_id}.txt", safe="")
+    url = (
+        "https://storage.googleapis.com/storage/v1/b/"
+        f"{urllib.parse.quote(bucket, safe='')}/o/{object_name}?alt=media"
+    )
+    try:
+        status, payload = _request("GET", url, token)
+    except CloudBuildError:
+        return ""
+    if not 200 <= status < 300:
+        return ""
+    text = payload.decode("utf-8", errors="replace")
+    return "\n".join(text.splitlines()[-lines:])
+
+
+# ---------------------------------------------------------------------------
+# Build submission + polling
+# ---------------------------------------------------------------------------
+
+
+def _gcp_project(registry: str) -> str:
+    """GCP project id out of an Artifact Registry prefix.
+
+    ``<region>-docker.pkg.dev/<project>/<repo>`` → ``<project>``.
+    """
+    parts = registry.split("/")
+    if len(parts) < 2 or not parts[0].endswith("-docker.pkg.dev"):
+        raise CloudBuildError(
+            f"{registry!r} is not an Artifact Registry prefix "
+            "(expected <region>-docker.pkg.dev/<project>/<repo>); the "
+            "Cloud Build backend only targets Artifact Registry."
+        )
+    return parts[1]
+
+
+def _submit_build(
+    *,
+    gcp_project: str,
+    bucket: str,
+    source_object: str,
+    containerfile_name: str,
+    image_ref: str,
+    token: str,
+) -> str:
+    """Create the build; return its id."""
+    build: dict[str, object] = {
+        "source": {"storageSource": {"bucket": bucket, "object": source_object}},
+        "steps": [
+            {
+                "name": "gcr.io/cloud-builders/docker",
+                "args": ["build", "-t", image_ref, "-f", containerfile_name, "."],
+            }
+        ],
+        "images": [image_ref],
+        "timeout": f"{_BUILD_DEADLINE_S}s",
+        # Logs into our own bucket: GCS_ONLY is required when running as
+        # a custom service account, and it is where the failure tail
+        # comes from.
+        "logsBucket": f"gs://{bucket}/logs",
+        "options": {"logging": "GCS_ONLY"},
+    }
+    build_sa = (os.environ.get(SERVICE_ACCOUNT_ENV) or "").strip()
+    if build_sa:
+        if "/" not in build_sa:
+            build_sa = f"projects/{gcp_project}/serviceAccounts/{build_sa}"
+        build["serviceAccount"] = build_sa
+
+    url = f"https://cloudbuild.googleapis.com/v1/projects/{gcp_project}/builds"
+    status, payload = _request("POST", url, token, body=json.dumps(build).encode())
+    op = _json_or_error(status, payload, "Cloud Build submission")
+    meta = op.get("metadata")
+    build_info = meta.get("build") if isinstance(meta, dict) else None
+    build_id = build_info.get("id") if isinstance(build_info, dict) else None
+    if not isinstance(build_id, str) or not build_id:
+        raise CloudBuildError(
+            f"Cloud Build submission returned no build id (response keys: {sorted(op)})."
+        )
+    return build_id
+
+
+def _wait_for_build(
+    gcp_project: str,
+    build_id: str,
+    token: str,
+    on_progress: ProgressFn | None,
+) -> str:
+    """Poll until a terminal status; return it."""
+    url = (
+        f"https://cloudbuild.googleapis.com/v1/projects/{gcp_project}"
+        f"/builds/{build_id}"
+    )
+    deadline = time.monotonic() + _BUILD_DEADLINE_S + 120
+    last_status = ""
+    while time.monotonic() < deadline:
+        status_code, payload = _request("GET", url, token)
+        build = _json_or_error(status_code, payload, "Cloud Build status poll")
+        status = str(build.get("status") or "")
+        if status != last_status:
+            last_status = status
+            if on_progress:
+                on_progress(status.lower(), "")
+        if status in (
+            "SUCCESS",
+            "FAILURE",
+            "INTERNAL_ERROR",
+            "TIMEOUT",
+            "CANCELLED",
+            "EXPIRED",
+        ):
+            return status
+        time.sleep(_POLL_INTERVAL_S)
+    raise CloudBuildError(f"Timed out waiting for Cloud Build {build_id} to finish.")
+
+
+# ---------------------------------------------------------------------------
+# High-level entry point
+# ---------------------------------------------------------------------------
+
+
+def ensure_image(
+    project: Path,
+    containerfile_spec: str,
+    *,
+    project_name: str,
+    force: bool = False,
+    on_progress: ProgressFn | None = None,
+) -> str:
+    """Make sure the project's image is in the registry; return its ref.
+
+    Content-addressed and git-free: the tag hashes the staged build
+    context, so an unchanged environment is a single registry HEAD (no
+    build, no upload), and any change builds from the working tree as
+    it is right now. *force* skips the freshness probe and rebuilds.
+    """
+    containerfile = project / containerfile_spec
+    if not containerfile.is_file():
+        raise CloudBuildError(
+            f"Declared container {containerfile_spec!r} not found in {project}."
+        )
+    registry = deployment_registry()
+    bucket = (os.environ.get(BUCKET_ENV) or "").strip().removeprefix("gs://").rstrip("/")
+    if registry is None or not bucket:
+        raise CloudBuildError(
+            "This environment is not configured for Cloud Build: both "
+            f"LIGHTCONE_REGISTRY and {BUCKET_ENV} must be set (they are "
+            "injected by the deployment)."
+        )
+    ref = registry_image_ref(project_name, containerfile, project, registry=registry)
+
+    if not force and registry_image_exists(ref) is True:
+        if on_progress:
+            on_progress("cached", f"{ref} already in the registry")
+        return ref
+
+    token = _token()
+    gcp_project = _gcp_project(registry)
+
+    if on_progress:
+        on_progress("staging", "uploading build context")
+    # Content-addressed object name: identical contexts collide into
+    # the same object, which is exactly right.
+    _, digest = image_identity(project_name, containerfile, project)
+    source_object = f"sources/lc-{project_name}-{digest}.tar.gz"
+    _upload_source(
+        bucket, source_object, _staged_context_tarball(project, containerfile), token
+    )
+
+    build_id = _submit_build(
+        gcp_project=gcp_project,
+        bucket=bucket,
+        source_object=source_object,
+        containerfile_name=containerfile.name,
+        image_ref=ref,
+        token=token,
+    )
+    status = _wait_for_build(gcp_project, build_id, token, on_progress)
+    if status != "SUCCESS":
+        tail = _fetch_log_tail(bucket, build_id, token)
+        raise CloudBuildError(
+            f"Cloud Build {build_id} ended with status {status}."
+            + (f" Last build output:\n{tail}" if tail else "")
+        )
+    return ref

--- a/src/lightcone/engine/container.py
+++ b/src/lightcone/engine/container.py
@@ -21,6 +21,13 @@ Supported runtimes:
     * ``podman-hpc`` — NERSC-style login nodes; ``build`` migrates the
       image so compute-node apptainer can read it. ``run`` still uses
       ``podman-hpc`` directly.
+    * ``kubernetes`` — the execution environment (a Dask Gateway worker
+      pod) already *is* the container: ``lc run`` starts the cluster
+      with the project's image, so ``wrap_recipe`` is a passthrough and
+      images resolve to registry refs (``<registry>/lc-<name>:<hash>``)
+      instead of local-store tags. Building goes through a remote
+      builder (:mod:`lightcone.engine.cloudbuild`), never a local OCI
+      CLI.
     * ``none`` — no container; recipe runs on the host. Useful for
       development and for projects that don't need isolation.
 """
@@ -29,6 +36,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import shlex
 import shutil
@@ -52,6 +60,19 @@ logger = logging.getLogger(__name__)
 #: (rootless, no daemon); docker last, gated behind a ``docker info``
 #: probe so a down daemon doesn't silently win over a healthy podman.
 RUNTIMES: tuple[str, ...] = ("podman-hpc", "podman", "docker")
+
+#: The non-OCI-CLI runtime: recipes run directly inside a worker pod
+#: that was started from the project's image. Never auto-detected from
+#: PATH — it is selected by site detection (a Dask Gateway deployment)
+#: or pinned explicitly in ``~/.lightcone/config.yaml``.
+KUBERNETES = "kubernetes"
+
+#: Registry prefix images are pushed to / pulled from on a deployment
+#: with a remote builder (e.g. ``europe-west1-docker.pkg.dev/<project>/
+#: <repo>`` on a lightcone JupyterHub). Injected into user pods by the
+#: deployment; its presence is half of the Cloud Build contract (see
+#: :mod:`lightcone.engine.cloudbuild`).
+REGISTRY_ENV = "LIGHTCONE_REGISTRY"
 
 #: Files whose contents contribute to the image tag hash.
 DEPENDENCY_FILES = (
@@ -155,7 +176,13 @@ def detect_runtime() -> str | None:
     → podman-hpc) are *hints* — missing-from-PATH falls through to the
     next candidate. Errors on missing-but-explicit user config are
     :func:`load_runtime`'s job.
+
+    A site that declares ``container_runtime: kubernetes`` (a Dask
+    Gateway deployment) short-circuits the PATH probing entirely —
+    there is no binary to find; the pod itself is the container.
     """
+    if _site_preferred_runtime() == KUBERNETES:
+        return KUBERNETES
     for runtime in _detection_order():
         if shutil.which(runtime) is None:
             continue
@@ -180,7 +207,7 @@ def _site_preferred_runtime() -> str | None:
     the declared value is not a known runtime — never raises.
     """
     preferred = detect_current_site().get("container_runtime")
-    return preferred if preferred in RUNTIMES else None
+    return preferred if preferred in (*RUNTIMES, KUBERNETES) else None
 
 
 def _docker_daemon_up() -> bool:
@@ -208,8 +235,11 @@ def load_runtime(*, project_path: Path | None = None) -> RuntimeChoice:
     consulted today). Values:
 
     * ``auto`` (default) — first available runtime in :data:`RUNTIMES`,
-      else falls back to ``"none"`` with ``explicit=False``.
+      else falls back to ``"none"`` with ``explicit=False``. On a site
+      that declares ``container_runtime: kubernetes``, auto resolves to
+      :data:`KUBERNETES` without any PATH probing.
     * ``docker | podman | podman-hpc`` — explicit; binary must exist.
+    * ``kubernetes`` — explicit; no binary involved.
     * ``none`` — explicit opt-out; recipes run on the host.
 
     Raises :class:`ContainerBuildError` if an explicit runtime is
@@ -228,12 +258,12 @@ def load_runtime(*, project_path: Path | None = None) -> RuntimeChoice:
 
     if requested == "auto":
         return RuntimeChoice(runtime=detect_runtime() or "none", explicit=False)
-    if requested == "none":
-        return RuntimeChoice(runtime="none", explicit=True)
+    if requested in ("none", KUBERNETES):
+        return RuntimeChoice(runtime=requested, explicit=True)
     if requested not in RUNTIMES:
         raise ContainerBuildError(
             f"Unknown container.runtime {requested!r} in {cfg_path}. "
-            f"Expected one of: auto, none, {', '.join(RUNTIMES)}."
+            f"Expected one of: auto, none, {KUBERNETES}, {', '.join(RUNTIMES)}."
         )
     if shutil.which(requested) is None:
         raise ContainerBuildError(
@@ -316,19 +346,23 @@ def _iter_build_context_entries(
                 yield "copy_dir", resolved
 
 
-def compute_image_tag(
+def image_identity(
     project_name: str,
     containerfile: Path,
     project_path: Path,
-) -> str:
-    """Compute a content-addressed image tag.
+) -> tuple[str, str]:
+    """Compute a content-addressed image identity ``(safe_name, digest)``.
 
-    The tag is ``lc-<project_name>-<12-char-sha256>``.  The hash covers
-    the Containerfile, every dependency file in :data:`DEPENDENCY_FILES`,
-    and the contents of every ``COPY``/``ADD`` source path referenced
-    from the Containerfile (files hashed directly, directories walked
-    recursively with stable ordering and :data:`_COPY_DIR_EXCLUDE`
-    subtrees skipped).
+    The digest (12-char sha256) covers the Containerfile, every
+    dependency file in :data:`DEPENDENCY_FILES`, and the contents of
+    every ``COPY``/``ADD`` source path referenced from the Containerfile
+    (files hashed directly, directories walked recursively with stable
+    ordering and :data:`_COPY_DIR_EXCLUDE` subtrees skipped).
+
+    The identity is spelled two ways downstream — ``lc-<name>-<digest>``
+    in a local image store (:func:`compute_image_tag`), ``…/lc-<name>:
+    <digest>`` in a registry (:func:`registry_image_ref`) — but it is
+    one identity: the same digest everywhere, on every backend.
     """
     h = hashlib.sha256()
     for kind, path in _iter_build_context_entries(containerfile, project_path):
@@ -349,9 +383,43 @@ def compute_image_tag(
                 _hash_dir_into(path, h)
             h.update(b"\0")
 
-    digest = h.hexdigest()[:12]
-    safe_name = project_name.lower().replace(" ", "-")
+    return project_name.lower().replace(" ", "-"), h.hexdigest()[:12]
+
+
+def compute_image_tag(
+    project_name: str,
+    containerfile: Path,
+    project_path: Path,
+) -> str:
+    """Content-addressed local-store tag: ``lc-<project_name>-<digest>``.
+
+    See :func:`image_identity` for what the digest covers.
+    """
+    safe_name, digest = image_identity(project_name, containerfile, project_path)
     return f"lc-{safe_name}-{digest}"
+
+
+def registry_image_ref(
+    project_name: str,
+    containerfile: Path,
+    project_path: Path,
+    *,
+    registry: str,
+) -> str:
+    """Content-addressed registry ref: ``<registry>/lc-<name>:<digest>``.
+
+    Same identity as :func:`compute_image_tag`, spelled for a registry:
+    the digest moves into the tag position so one repository per project
+    accumulates its image history.
+    """
+    safe_name, digest = image_identity(project_name, containerfile, project_path)
+    return f"{registry.rstrip('/')}/lc-{safe_name}:{digest}"
+
+
+def deployment_registry() -> str | None:
+    """The deployment-injected registry prefix, or ``None`` off-deployment."""
+    registry = (os.environ.get(REGISTRY_ENV) or "").strip()
+    return registry.rstrip("/") or None
 
 
 def _safe_relpath(path: Path, root: Path) -> str:
@@ -660,13 +728,16 @@ def resolve_image_for_run(
     *,
     project_path: Path,
     project_name: str,
+    registry: str | None = None,
 ) -> str | None:
     """Translate an astra.yaml ``container:`` value into the image tag
     that the runtime will execute.
 
     * ``None`` / empty → ``None`` (no container).
-    * Path to a Containerfile in the project → the content-addressed tag
-      that ``lc build`` would have produced (``lc-<name>-<hash>``).
+    * Path to a Containerfile in the project → the content-addressed
+      identity ``lc build`` produces: a local-store tag
+      (``lc-<name>-<hash>``), or with *registry* set (a deployment with
+      a remote builder) the registry ref (``<registry>/lc-<name>:<hash>``).
     * Anything else (registry image, e.g. ``python:3.12-slim``, or a
       pre-namespaced ``ghcr.io/foo/bar:tag``) → returned as-is for the
       runtime to pull.
@@ -674,13 +745,20 @@ def resolve_image_for_run(
     if not spec:
         return None
     if is_containerfile(spec, project_path):
-        return compute_image_tag(project_name, project_path / spec, project_path)
+        containerfile = project_path / spec
+        if registry is not None:
+            return registry_image_ref(
+                project_name, containerfile, project_path, registry=registry
+            )
+        return compute_image_tag(project_name, containerfile, project_path)
     return spec
 
 
 def make_image_tag_resolver(
     project_path: Path,
     project_name: str,
+    *,
+    registry: str | None = None,
 ) -> Callable[[str | None], str | None]:
     """Memoizing wrapper around :func:`resolve_image_for_run`.
 
@@ -695,7 +773,10 @@ def make_image_tag_resolver(
         if spec in cache:
             return cache[spec]
         tag = resolve_image_for_run(
-            spec, project_path=project_path, project_name=project_name
+            spec,
+            project_path=project_path,
+            project_name=project_name,
+            registry=registry,
         )
         cache[spec] = tag
         return tag
@@ -719,13 +800,18 @@ def wrap_recipe(
     No-op cases:
         * *image* is ``None`` → recipe returned unchanged
         * *runtime* is ``"none"`` → recipe returned unchanged
+        * *runtime* is :data:`KUBERNETES` → recipe returned unchanged:
+          the Dask worker pod executing it was started from *image*, so
+          wrapping would be containerizing twice. The image still flows
+          into ``code_version`` and the manifest — provenance records
+          the pod's image, which is what actually ran the recipe.
 
     The recipe is shell-quoted with :func:`shlex.quote` and passed as the
     argument to ``bash -c`` inside the container, which keeps single
     quotes, dollar signs, and other shell metacharacters intact across
     the host bash → runtime CLI → container bash boundaries.
     """
-    if image is None or runtime == "none":
+    if image is None or runtime in ("none", KUBERNETES):
         return recipe
     if runtime not in RUNTIMES:
         raise ContainerBuildError(
@@ -771,8 +857,24 @@ def get_container_status(
         return ContainerStatus(type="prebuilt", image=spec)
 
     containerfile = project_path / spec
+    if runtime == KUBERNETES and (registry := deployment_registry()) is not None:
+        from lightcone.engine.cloudbuild import registry_image_exists
+
+        ref = registry_image_ref(
+            project_name, containerfile, project_path, registry=registry
+        )
+        return ContainerStatus(
+            type="build",
+            image=ref,
+            exists=registry_image_exists(ref),
+            containerfile=spec,
+        )
     tag = compute_image_tag(project_name, containerfile, project_path)
-    exists = image_exists_locally(tag, runtime=runtime) if runtime != "none" else None
+    exists = (
+        image_exists_locally(tag, runtime=runtime)
+        if runtime not in ("none", KUBERNETES)
+        else None
+    )
     return ContainerStatus(
         type="build",
         image=tag,

--- a/src/lightcone/engine/container.py
+++ b/src/lightcone/engine/container.py
@@ -422,6 +422,19 @@ def deployment_registry() -> str | None:
     return registry.rstrip("/") or None
 
 
+def runtime_registry(runtime: str) -> str | None:
+    """Registry prefix image identities resolve against under *runtime*.
+
+    The single source of truth for "which spelling of the image identity
+    does this runtime use": the deployment registry on
+    :data:`KUBERNETES` (worker pods pull from a registry), ``None`` —
+    local-store tags — everywhere else. Shared by the Snakefile
+    generator and the status walker so their ``code_version``s can
+    never disagree about the image identity.
+    """
+    return deployment_registry() if runtime == KUBERNETES else None
+
+
 def _safe_relpath(path: Path, root: Path) -> str:
     try:
         return path.resolve().relative_to(root.resolve()).as_posix()

--- a/src/lightcone/engine/dask_cluster.py
+++ b/src/lightcone/engine/dask_cluster.py
@@ -195,15 +195,7 @@ def _gateway_cluster(
     vars carry the API address, the JupyterHub auth mode, and the proxy
     address, so ``Gateway()`` needs no arguments here.
     """
-    try:
-        from dask_gateway import Gateway
-    except ImportError as exc:
-        raise RuntimeError(
-            "A Dask Gateway environment was detected "
-            "(DASK_GATEWAY__ADDRESS is set) but the dask-gateway client "
-            "is not installed. Install it with "
-            "`pip install lightcone-cli[gateway]`."
-        ) from exc
+    from dask_gateway import Gateway
 
     gateway = Gateway()
     # The server-declared cluster options (merged with ambient config

--- a/src/lightcone/engine/dask_cluster.py
+++ b/src/lightcone/engine/dask_cluster.py
@@ -31,6 +31,7 @@ with the deployment's idle timeout as the backstop if lc dies uncleanly.
 
 from __future__ import annotations
 
+import getpass
 import logging
 import os
 import shutil
@@ -274,9 +275,13 @@ def _worker_environment(
     own environment) knows, keeping the deployment's options handler
     free of lightcone-specific injection:
 
-    * ``HOME``/``USER``/``LOGNAME`` — forwarded from the driver.
-      Passwd-less uid-1000 images crash ``getpass.getuser()`` (called
-      by snakemake at startup) without them, and home paths are
+    * ``HOME``/``USER``/``LOGNAME`` — always set. Project images are
+      environment-agnostic (no passwd entry for the pod uid), so
+      ``getpass.getuser()`` (called by snakemake at startup) crashes
+      in a worker unless the env vars are present — and the notebook
+      pod may not export ``USER``/``LOGNAME`` itself (its own passwd
+      entry covers it), so the name is *derived* on the driver via
+      ``getpass`` rather than merely forwarded. Home paths are
       identical on both sides by construction (same NFS mount).
     * ``DASK_DISTRIBUTED__WORKER__RESOURCES__*`` — the scheduling
       resource contract, mirrored from the deployment's declared
@@ -287,9 +292,19 @@ def _worker_environment(
       execution ground truth.
     """
     env: dict[str, str] = {}
-    for var in ("HOME", "USER", "LOGNAME"):
-        if val := os.environ.get(var):
-            env[var] = val
+    if home := os.environ.get("HOME"):
+        env["HOME"] = home
+    try:
+        # Checks USER/LOGNAME/... env vars first, then the driver's
+        # passwd — one of the two works in any sane notebook pod.
+        user = getpass.getuser()
+    except (KeyError, OSError):
+        # Driver can't determine a name either; any stable non-empty
+        # value keeps snakemake alive, and jovyan is the Jupyter
+        # convention for uid 1000.
+        user = "jovyan"
+    env["USER"] = user
+    env["LOGNAME"] = user
 
     cores = declared.get("worker_cores")
     if isinstance(cores, (int, float)) and cores > 0:

--- a/src/lightcone/engine/dask_cluster.py
+++ b/src/lightcone/engine/dask_cluster.py
@@ -1,19 +1,32 @@
 # mypy: disable-error-code="no-untyped-call"
 """Cluster lifecycle for ``lc run``.
 
-One context manager, three branches:
+One context manager, four branches:
 
 - ``DASK_SCHEDULER_ADDRESS`` is already set → yield it as-is. We don't own
   the cluster, so we don't tear it down.
+- ``DASK_GATEWAY__ADDRESS`` is set (a JupyterHub/Dask Gateway
+  deployment) → **create** a run-scoped Gateway cluster with the
+  project's image and shut it down when the run finishes. Create/cull
+  per run is what makes image updates seamless: a Gateway cluster's
+  image is fixed at creation, so picking up a freshly built project
+  image *requires* a fresh cluster. Gateway scheduler addresses use a
+  custom ``gateway://`` comm scheme a bare ``distributed.Client``
+  cannot dial, so this branch hands the executor the *cluster name*
+  (via :data:`GATEWAY_CLUSTER_ENV`) and the executor rejoins through
+  the authenticated Gateway API.
 - ``SLURM_JOB_ID`` is set → start an in-process scheduler via
   ``LocalCluster(n_workers=0)``, then ``srun`` one ``dask worker`` per node
   across the allocation. Workers advertise the node's full resources;
   per-rule ``threads`` / ``mem_mb`` / ``gpus`` map to per-task constraints.
-- Neither → ``LocalCluster()`` sized to the local machine.
+- None of the above → ``LocalCluster()`` sized to the local machine.
 
-The scheduler is always in-process (driven by ``lc run`` itself) so its
-lifetime equals the run's lifetime — no service to manage, no orphaned
-schedulers if the driver crashes.
+Outside the Gateway branch the scheduler is always in-process (driven
+by ``lc run`` itself) so its lifetime equals the run's lifetime — no
+service to manage, no orphaned schedulers if the driver crashes. On the
+Gateway branch the Gateway server owns scheduling, and the same
+lifetime contract is enforced there: the cluster is shut down on exit,
+with the deployment's idle timeout as the backstop if lc dies uncleanly.
 """
 
 from __future__ import annotations
@@ -33,6 +46,18 @@ from dataclasses import dataclass
 RESOURCE_CPUS = "cpus"
 RESOURCE_MEMORY = "memory"
 RESOURCE_GPUS = "gpus"
+
+#: Parent→child rendezvous for the Gateway branch: ``cluster_for_run``
+#: sets this to the name of the cluster it created so the executor
+#: plugin (running in the child snakemake process) can rejoin it via
+#: ``Gateway().connect(name)``. Internal contract, not a user knob.
+GATEWAY_CLUSTER_ENV = "LIGHTCONE_GATEWAY_CLUSTER"
+
+#: Bounds how long the Gateway branch waits for the first worker of a
+#: cluster it created (seconds; default 600 — a first-time image pull
+#: on a fresh node is minutes, not seconds). Without this bound an
+#: unpullable image leaves the run sitting at zero workers forever.
+GATEWAY_WORKER_TIMEOUT_ENV = "LIGHTCONE_GATEWAY_WORKER_TIMEOUT"
 
 
 @dataclass
@@ -84,37 +109,204 @@ def _resources_arg(shape: _NodeShape) -> str:
     return " ".join(f"{k}={int(v)}" for k, v in _resource_dict(shape).items())
 
 
+def gateway_branch_active() -> bool:
+    """Would :func:`cluster_for_run` take the Gateway branch right now?
+
+    Exposed so ``lc run`` can shape the snakemake invocation (e.g. NFS
+    latency tolerance) before entering the cluster context. Pure
+    function of the environment, in the same priority order as the
+    branches in :func:`cluster_for_run`.
+    """
+    if os.environ.get("DASK_SCHEDULER_ADDRESS"):
+        return False
+    return bool(os.environ.get("DASK_GATEWAY__ADDRESS"))
+
+
 @contextmanager
 def cluster_for_run(
     *,
     verbose: bool = False,
     local_directory: str | None = None,
-) -> Iterator[str]:
-    """Yield a Dask scheduler address valid for the duration of `lc run`.
+    worker_image: str | None = None,
+    max_workers: int | None = None,
+) -> Iterator[dict[str, str]]:
+    """Yield the env overlay the child snakemake needs to reach the cluster.
+
+    The parent (``lc run``) and the executor plugin live in different
+    processes, so connection info travels via environment variables.
+    Address-based branches yield ``{"DASK_SCHEDULER_ADDRESS": addr}``;
+    the Gateway branch yields ``{GATEWAY_CLUSTER_ENV: name}`` because
+    Gateway clusters are rejoined by name through the authenticated
+    Gateway API rather than dialled by address.
 
     *local_directory*, when given, is where dask workers stage their
     spilled task data and internal state files. ``lc run`` resolves it
     to a path under :mod:`lightcone.engine.scratch` so on NERSC the
     spill lands on Lustre instead of DVS-mounted home/CFS (where small-
     file I/O is slow and can pressure the gateway nodes).
+
+    *worker_image* is the registry ref the project's declared container
+    resolves to; the Gateway branch creates its cluster with exactly
+    this image (``None`` → the deployment's default). Ignored by the
+    other branches — they realize containers by wrapping recipes, not
+    via pod images.
+
+    *max_workers* bounds the adaptive scaling of a Gateway cluster
+    (``lc run`` passes its job bound — there is never a reason to hold
+    more workers than dispatchable rules). Ignored everywhere else.
     """
     if addr := os.environ.get("DASK_SCHEDULER_ADDRESS"):
         if verbose:
             print(f"→ Using existing Dask scheduler at {addr}")
-        yield addr
+        yield {"DASK_SCHEDULER_ADDRESS": addr}
+        return
+
+    if os.environ.get("DASK_GATEWAY__ADDRESS"):
+        with _gateway_cluster(
+            verbose=verbose, worker_image=worker_image, max_workers=max_workers
+        ) as name:
+            yield {GATEWAY_CLUSTER_ENV: name}
         return
 
     if "SLURM_JOB_ID" in os.environ:
         with _slurm_backed_cluster(
             verbose=verbose, local_directory=local_directory
         ) as addr:
-            yield addr
+            yield {"DASK_SCHEDULER_ADDRESS": addr}
         return
 
     with _local_cluster(
         verbose=verbose, local_directory=local_directory
     ) as addr:
-        yield addr
+        yield {"DASK_SCHEDULER_ADDRESS": addr}
+
+
+@contextmanager
+def _gateway_cluster(
+    *,
+    verbose: bool,
+    worker_image: str | None,
+    max_workers: int | None,
+) -> Iterator[str]:
+    """Create a run-scoped Dask Gateway cluster; yield its name.
+
+    The Gateway client is configured entirely by ambient dask config —
+    on a lightcone JupyterHub deployment the ``DASK_GATEWAY__*`` env
+    vars carry the API address, the JupyterHub auth mode, and the proxy
+    address, so ``Gateway()`` needs no arguments here.
+    """
+    try:
+        from dask_gateway import Gateway
+    except ImportError as exc:
+        raise RuntimeError(
+            "A Dask Gateway environment was detected "
+            "(DASK_GATEWAY__ADDRESS is set) but the dask-gateway client "
+            "is not installed. Install it with "
+            "`pip install lightcone-cli[gateway]`."
+        ) from exc
+
+    gateway = Gateway()
+    options: dict[str, object] = {}
+    if worker_image:
+        # ``image`` is a server-side cluster option declared by the
+        # deployment's options handler; a deployment that doesn't
+        # expose it rejects the request — surfaced below with guidance.
+        options["image"] = worker_image
+    try:
+        cluster = gateway.new_cluster(shutdown_on_close=True, **options)
+    except Exception as exc:
+        detail = (
+            f" (requested image={worker_image!r} — if the deployment does "
+            "not expose an `image` cluster option, ask the hub admin to "
+            "add it to the gateway's cluster-options handler)"
+            if worker_image
+            else ""
+        )
+        raise RuntimeError(
+            f"Could not create a Dask Gateway cluster ({exc}){detail}."
+        ) from exc
+
+    bound = max(1, max_workers or 1)
+    if verbose:
+        image_note = f" with image {worker_image}" if worker_image else ""
+        print(
+            f"→ Created Dask Gateway cluster {cluster.name}{image_note}; "
+            f"scaling adaptively up to {bound} worker(s) "
+            f"(dashboard: {cluster.dashboard_link})"
+        )
+    try:
+        cluster.adapt(minimum=1, maximum=bound)
+        client = cluster.get_client()
+        try:
+            _wait_first_worker(client, image=worker_image)
+            _assert_worker_resources(client)
+        finally:
+            client.close()
+        yield str(cluster.name)
+    finally:
+        # We created it, we cull it. shutdown() stops the cluster
+        # server-side; if lc dies before reaching this, shutdown_on_close
+        # and the deployment's idle timeout are the backstops.
+        try:
+            cluster.shutdown()
+        except Exception:
+            cluster.close()
+        if verbose:
+            print(f"→ Shut down Dask Gateway cluster {cluster.name}")
+
+
+def _wait_first_worker(client: object, *, image: str | None) -> None:
+    """Block until the created cluster has one live worker.
+
+    An unpullable image or an unschedulable pool otherwise leaves the
+    run sitting at zero workers with no error at all — the classic
+    silent-hang failure mode.
+    """
+    try:
+        timeout = int(os.environ.get(GATEWAY_WORKER_TIMEOUT_ENV) or 600)
+    except ValueError:
+        timeout = 600
+    try:
+        client.wait_for_workers(n_workers=1, timeout=timeout)  # type: ignore[attr-defined]
+    except Exception as exc:
+        image_hint = f"the worker image ({image or 'deployment default'}) cannot be pulled"
+        raise RuntimeError(
+            f"No Dask Gateway worker became ready within {timeout}s "
+            f"({exc}). Likely causes: {image_hint}, or the node pool "
+            "cannot schedule a worker (capacity/quota). Check the "
+            "JupyterLab Dask panel for the cluster's state, or raise "
+            f"{GATEWAY_WORKER_TIMEOUT_ENV}."
+        ) from exc
+
+
+def _assert_worker_resources(client: object) -> None:
+    """Fail fast when Gateway workers don't advertise the resource contract.
+
+    Dask schedules a task only on workers advertising *every* requested
+    resource key. The executor requests ``cpus`` for every rule and
+    ``memory`` for any rule with ``mem_mb``, so a deployment that forgot
+    to inject ``DASK_DISTRIBUTED__WORKER__RESOURCES__*`` into worker
+    pods makes every rule hang with no error — refuse loudly instead.
+    ``gpus`` is deliberately not required: a CPU-only deployment
+    legitimately omits it.
+    """
+    workers = client.scheduler_info().get("workers", {})  # type: ignore[attr-defined]
+    if not workers:
+        return
+    if any(
+        RESOURCE_CPUS in res and RESOURCE_MEMORY in res
+        for w in workers.values()
+        if (res := w.get("resources") or {}) is not None
+    ):
+        return
+    raise RuntimeError(
+        "Dask Gateway workers do not advertise the lightcone resource "
+        f"contract ({RESOURCE_CPUS}+{RESOURCE_MEMORY}, plus "
+        f"{RESOURCE_GPUS} on GPU pools); per-rule resource requests "
+        "would never schedule. Fix the deployment to inject "
+        "DASK_DISTRIBUTED__WORKER__RESOURCES__* into worker pods (see "
+        "the hub-deploy dask-gateway cluster-options handler)."
+    )
 
 
 @contextmanager

--- a/src/lightcone/engine/dask_cluster.py
+++ b/src/lightcone/engine/dask_cluster.py
@@ -206,12 +206,29 @@ def _gateway_cluster(
         ) from exc
 
     gateway = Gateway()
+    # The server-declared cluster options (merged with ambient config
+    # defaults) tell us what this deployment exposes and what the
+    # effective worker shape/image will be.
+    try:
+        declared = dict(gateway.cluster_options())
+    except Exception:
+        declared = {}
     options: dict[str, object] = {}
     if worker_image:
         # ``image`` is a server-side cluster option declared by the
         # deployment's options handler; a deployment that doesn't
         # expose it rejects the request — surfaced below with guidance.
         options["image"] = worker_image
+    if "environment" in declared:
+        # Self-provision everything our executor needs from a worker
+        # pod through the *standard* ``environment`` option, so the
+        # deployment's options handler can stay stock — no
+        # lightcone-specific injection required server-side.
+        base_env = dict(declared.get("environment") or {})
+        options["environment"] = {
+            **base_env,
+            **_worker_environment(declared, worker_image),
+        }
     try:
         cluster = gateway.new_cluster(shutdown_on_close=True, **options)
     except Exception as exc:
@@ -253,6 +270,52 @@ def _gateway_cluster(
             cluster.close()
         if verbose:
             print(f"→ Shut down Dask Gateway cluster {cluster.name}")
+
+
+def _worker_environment(
+    declared: dict[str, object], worker_image: str | None
+) -> dict[str, str]:
+    """Env vars lc provisions into scheduler/worker pods.
+
+    Passed through the deployment's standard ``environment`` cluster
+    option — everything worker pods need that only lc (or the driver's
+    own environment) knows, keeping the deployment's options handler
+    free of lightcone-specific injection:
+
+    * ``HOME``/``USER``/``LOGNAME`` — forwarded from the driver.
+      Passwd-less uid-1000 images crash ``getpass.getuser()`` (called
+      by snakemake at startup) without them, and home paths are
+      identical on both sides by construction (same NFS mount).
+    * ``DASK_DISTRIBUTED__WORKER__RESOURCES__*`` — the scheduling
+      resource contract, mirrored from the deployment's declared
+      ``worker_cores``/``worker_memory`` option values. Dask matches
+      resource keys by exact presence; without these every rule hangs.
+    * ``LIGHTCONE_WORKER_IMAGE`` — the image the cluster runs (ours,
+      or the deployment default), recorded by the manifest layer as
+      execution ground truth.
+    """
+    env: dict[str, str] = {}
+    for var in ("HOME", "USER", "LOGNAME"):
+        if val := os.environ.get(var):
+            env[var] = val
+
+    cores = declared.get("worker_cores")
+    if isinstance(cores, (int, float)) and cores > 0:
+        env["DASK_DISTRIBUTED__WORKER__RESOURCES__CPUS"] = str(int(cores))
+    memory = declared.get("worker_memory")
+    if isinstance(memory, (int, float)) and memory > 0:
+        # Deployments conventionally declare worker_memory in GB
+        # (float); anything implausibly large for GB is already bytes.
+        mem_bytes = int(memory * 1e9) if memory < 1e6 else int(memory)
+        env["DASK_DISTRIBUTED__WORKER__RESOURCES__MEMORY"] = str(mem_bytes)
+    env["DASK_DISTRIBUTED__WORKER__RESOURCES__GPUS"] = str(
+        int(declared.get("worker_gpus") or 0)  # type: ignore[call-overload]
+    )
+
+    image = worker_image or declared.get("image")
+    if isinstance(image, str) and image:
+        env["LIGHTCONE_WORKER_IMAGE"] = image
+    return env
 
 
 def _wait_first_worker(client: object, *, image: str | None) -> None:
@@ -303,9 +366,11 @@ def _assert_worker_resources(client: object) -> None:
         "Dask Gateway workers do not advertise the lightcone resource "
         f"contract ({RESOURCE_CPUS}+{RESOURCE_MEMORY}, plus "
         f"{RESOURCE_GPUS} on GPU pools); per-rule resource requests "
-        "would never schedule. Fix the deployment to inject "
-        "DASK_DISTRIBUTED__WORKER__RESOURCES__* into worker pods (see "
-        "the hub-deploy dask-gateway cluster-options handler)."
+        "would never schedule. lc provisions these via the gateway's "
+        "`environment` cluster option — this deployment likely doesn't "
+        "expose that option (or strips it); ask the hub admin to expose "
+        "the standard image/worker_cores/worker_memory/environment "
+        "options."
     )
 
 

--- a/src/lightcone/engine/manifest.py
+++ b/src/lightcone/engine/manifest.py
@@ -200,6 +200,12 @@ def write_manifest(
         "finished_at": time.time(),
         "host": socket.gethostname(),
         "slurm_job_id": os.environ.get("SLURM_JOB_ID"),
+        # On a Dask Gateway deployment the cluster-options handler
+        # injects the image every scheduler/worker pod was started with.
+        # ``container_image`` above is what the spec *declared*; this is
+        # the pod-reported ground truth of what actually executed.
+        # Optional/additive — None everywhere else.
+        "worker_image": os.environ.get("LIGHTCONE_WORKER_IMAGE"),
     }
 
     final_path = output_dir / MANIFEST_FILENAME

--- a/src/lightcone/engine/manifest.py
+++ b/src/lightcone/engine/manifest.py
@@ -200,8 +200,9 @@ def write_manifest(
         "finished_at": time.time(),
         "host": socket.gethostname(),
         "slurm_job_id": os.environ.get("SLURM_JOB_ID"),
-        # On a Dask Gateway deployment the cluster-options handler
-        # injects the image every scheduler/worker pod was started with.
+        # On a Dask Gateway deployment `lc run` provisions this into
+        # every scheduler/worker pod (via the `environment` cluster
+        # option) with the image the cluster was started with.
         # ``container_image`` above is what the spec *declared*; this is
         # the pod-reported ground truth of what actually executed.
         # Optional/additive — None everywhere else.

--- a/src/lightcone/engine/scratch.py
+++ b/src/lightcone/engine/scratch.py
@@ -1,7 +1,7 @@
 """Resolve and prepare lightcone's scratch root.
 
 A single concept: where lightcone keeps its operational state — snakemake
-metadata, dask worker spill, cross-node stdout locks. Resolved at the
+metadata, dask worker spill, the run-exclusion lock. Resolved at the
 start of every ``lc run``. Resolution precedence (first hit wins):
 
 1. ``LIGHTCONE_SCRATCH`` env var (escape hatch / CI override).
@@ -18,7 +18,7 @@ snakemake state is keyed by a hash of the project's absolute path.
 Why this matters on NERSC: ``$HOME`` and ``/global/cfs`` are mounted on
 compute nodes via DVS, which `does not support file locking
 <https://docs.nersc.gov/performance/io/dvs/>`_. Snakemake's workflow
-lock, our cross-node stdout lock, and any future coordination primitive
+lock, our run-exclusion lock, and any future coordination primitive
 silently fail there. ``$SCRATCH`` is Lustre, which works correctly.
 """
 from __future__ import annotations
@@ -47,7 +47,6 @@ class RunDirs:
     root: Path  # ``<scratch>/.lightcone``
     snakemake_state: Path  # ``<scratch>/.lightcone/snakemake/<project-hash>/.snakemake``
     dask_local: Path  # ``<scratch>/.lightcone/dask/<run-id>``
-    lock_path: Path  # ``<scratch>/.lightcone/locks/<run-id>.lock``
     # Project-level sentinel for the run-exclusion flock. Held for the
     # duration of one ``lc run`` to prevent concurrent invocations on
     # the same project from interleaving Snakemake state updates.
@@ -108,19 +107,16 @@ def prepare_run_dirs(project_path: Path, *, run_id: str | None = None) -> RunDir
     pkey = project_hash(project_path)
     snakemake_state = root / "snakemake" / pkey / ".snakemake"
     dask_local = root / "dask" / rid
-    lock_path = root / "locks" / f"{rid}.lock"
     run_lock_path = root / "locks" / f"{pkey}.run-lock"
-    for d in (root, snakemake_state.parent, dask_local, lock_path.parent):
+    for d in (root, snakemake_state.parent, dask_local, run_lock_path.parent):
         d.mkdir(parents=True, exist_ok=True)
-    # Touch lockfiles so workers can ``flock`` them without racing on
-    # ``O_CREAT``. Empty file is fine — flock is independent of contents.
-    lock_path.touch(exist_ok=True)
+    # Touch the lockfile so ``flock`` never races on ``O_CREAT``. Empty
+    # file is fine — flock is independent of contents.
     run_lock_path.touch(exist_ok=True)
     return RunDirs(
         root=root,
         snakemake_state=snakemake_state,
         dask_local=dask_local,
-        lock_path=lock_path,
         run_lock_path=run_lock_path,
     )
 

--- a/src/lightcone/engine/site_registry.py
+++ b/src/lightcone/engine/site_registry.py
@@ -81,9 +81,16 @@ SITE_DEFAULTS: dict[str, dict[str, Any]] = {
     # GKE). Unlike HPC sites, hostnames here are meaningless pod names —
     # detection is by the env vars the deployment injects into every
     # user pod. ``container_runtime: kubernetes`` routes recipe
-    # execution through worker pods running the project image, and
-    # scratch stays in ``$HOME`` because that's the NFS volume shared
-    # with the Dask worker pods (there is no site-local scratch).
+    # execution through worker pods running the project image.
+    #
+    # ``scratch_root`` must be declared even though "local" gets by
+    # without one: with no site scratch, resolution falls back to the
+    # tempdir — fine on a single machine, but a pod's ``/tmp`` is
+    # pod-local. The ``.snakemake`` state the driver symlinks into
+    # scratch has to live on the NFS home every worker pod mounts, or
+    # each worker would write its job metadata into its own ``/tmp``
+    # (invisible to the driver) and every subsequent run would consider
+    # all outputs stale. ``$HOME`` *is* the shared filesystem here.
     "jupyterhub": {
         "hostname_patterns": [],
         "env_markers": ["DASK_GATEWAY__ADDRESS"],

--- a/src/lightcone/engine/site_registry.py
+++ b/src/lightcone/engine/site_registry.py
@@ -14,6 +14,7 @@ place.
 """
 from __future__ import annotations
 
+import os
 import socket
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -76,6 +77,22 @@ SITE_DEFAULTS: dict[str, dict[str, Any]] = {
             "//global/cfs/cdirs/**",
         ],
     },
+    # A JupyterHub deployment with Dask Gateway (e.g. lightcone-hub on
+    # GKE). Unlike HPC sites, hostnames here are meaningless pod names —
+    # detection is by the env vars the deployment injects into every
+    # user pod. ``container_runtime: kubernetes`` routes recipe
+    # execution through worker pods running the project image, and
+    # scratch stays in ``$HOME`` because that's the NFS volume shared
+    # with the Dask worker pods (there is no site-local scratch).
+    "jupyterhub": {
+        "hostname_patterns": [],
+        "env_markers": ["DASK_GATEWAY__ADDRESS"],
+        "display_name": "JupyterHub (Dask Gateway)",
+        "backend": "kubernetes",
+        "connection": {},
+        "container_runtime": "kubernetes",
+        "scratch_root": "$HOME",
+    },
     "local": {
         "hostname_patterns": [],
         "display_name": "Local",
@@ -96,6 +113,19 @@ def detect_site(hostname_or_name: str) -> str | None:
         for pattern in site.get("hostname_patterns", []):
             if pattern in normalized:
                 return site_key
+    return None
+
+
+def detect_site_from_env() -> str | None:
+    """Detect a site whose declared ``env_markers`` are all present.
+
+    Deployment-style sites (JupyterHub pods) have arbitrary hostnames;
+    what identifies them is the environment the deployment injects.
+    """
+    for site_key, site in SITE_DEFAULTS.items():
+        markers = site.get("env_markers") or []
+        if markers and all(os.environ.get(m) for m in markers):
+            return site_key
     return None
 
 
@@ -157,11 +187,12 @@ def detect_current_site() -> HostSite:
 
     Single source of truth for "which site are we on?" — everything else
     in the codebase should call this rather than re-deriving it from
-    :func:`socket.gethostname` and :func:`detect_site`. Returns a falsy
-    :class:`HostSite` (``key is None``) when the hostname matches no
-    known site.
+    :func:`socket.gethostname` and :func:`detect_site`. Environment
+    markers win over hostname patterns (a pod's hostname is noise; the
+    injected env is the signal). Returns a falsy :class:`HostSite`
+    (``key is None``) when nothing matches.
     """
-    key = detect_site(socket.gethostname())
+    key = detect_site_from_env() or detect_site(socket.gethostname())
     if key is None:
         return _UNKNOWN_HOST_SITE
     return HostSite(key=key, defaults=get_site_defaults(key) or {})

--- a/src/lightcone/engine/snakefile.py
+++ b/src/lightcone/engine/snakefile.py
@@ -29,7 +29,12 @@ from typing import Any
 
 from astra.helpers import load_yaml, resolve_analysis_tree
 
-from lightcone.engine.container import make_image_tag_resolver, wrap_recipe
+from lightcone.engine.container import (
+    KUBERNETES,
+    deployment_registry,
+    make_image_tag_resolver,
+    wrap_recipe,
+)
 from lightcone.engine.manifest import code_version
 from lightcone.engine.tree import (
     TreeOutput,
@@ -332,10 +337,13 @@ def generate(
         project_path: Project root containing ``astra.yaml``.
         universes: Universe ids to expand rules over.
         runtime: Container runtime to wrap recipes with. One of
-            ``docker | podman | podman-hpc | none``. ``none`` runs
-            recipes on the host without isolation. Resolution is done
-            here once, not per-rule, so all rules use a consistent
-            runtime. See :func:`lightcone.engine.container.load_runtime`.
+            ``docker | podman | podman-hpc | kubernetes | none``.
+            ``none`` runs recipes on the host without isolation;
+            ``kubernetes`` leaves recipes unwrapped (the worker pod runs
+            the project image) and resolves Containerfile specs to
+            registry refs. Resolution is done here once, not per-rule,
+            so all rules use a consistent runtime. See
+            :func:`lightcone.engine.container.load_runtime`.
 
     Returns ``(snakefile_path, config_path)``.
     """
@@ -351,7 +359,10 @@ def generate(
     git_sha = _git_sha(project_path)
     git_remote = _git_remote(project_path)
     lc_version = _lc_version()
-    resolve_image = make_image_tag_resolver(project_path, project_name)
+    registry = deployment_registry() if runtime == KUBERNETES else None
+    resolve_image = make_image_tag_resolver(
+        project_path, project_name, registry=registry
+    )
 
     for to in tree_outputs:
         recipe = to.output_def.get("recipe")

--- a/src/lightcone/engine/snakefile.py
+++ b/src/lightcone/engine/snakefile.py
@@ -30,9 +30,8 @@ from typing import Any
 from astra.helpers import load_yaml, resolve_analysis_tree
 
 from lightcone.engine.container import (
-    KUBERNETES,
-    deployment_registry,
     make_image_tag_resolver,
+    runtime_registry,
     wrap_recipe,
 )
 from lightcone.engine.manifest import code_version
@@ -359,9 +358,8 @@ def generate(
     git_sha = _git_sha(project_path)
     git_remote = _git_remote(project_path)
     lc_version = _lc_version()
-    registry = deployment_registry() if runtime == KUBERNETES else None
     resolve_image = make_image_tag_resolver(
-        project_path, project_name, registry=registry
+        project_path, project_name, registry=runtime_registry(runtime)
     )
 
     for to in tree_outputs:

--- a/src/lightcone/engine/status.py
+++ b/src/lightcone/engine/status.py
@@ -16,7 +16,11 @@ from typing import Any, Literal
 
 from astra.helpers import load_yaml, resolve_analysis_tree
 
-from lightcone.engine.container import make_image_tag_resolver
+from lightcone.engine.container import (
+    load_runtime,
+    make_image_tag_resolver,
+    runtime_registry,
+)
 from lightcone.engine.manifest import code_version, read_manifest
 from lightcone.engine.tree import (
     TreeOutput,
@@ -95,7 +99,11 @@ def get_output_status(
     spec = resolve_analysis_tree(load_yaml(spec_path), project_path)
     universe_decisions = _load_universe_decisions(project_path, spec, universe_id)
     project_name = (spec.get("name") or project_path.name).lower().replace(" ", "-")
-    resolve_image = make_image_tag_resolver(project_path, project_name)
+    # Resolve image identities exactly as `lc run` would right now —
+    # on a kubernetes deployment that's the registry ref, not the local
+    # tag, or every freshly materialized output would read as stale.
+    registry = runtime_registry(load_runtime(project_path=project_path).runtime)
+    resolve_image = make_image_tag_resolver(project_path, project_name, registry=registry)
 
     for tree_out in collect_tree_outputs(spec):
         out_dir = resolve_output_path(project_path, tree_out, universe_id) / tree_out.output_id

--- a/src/snakemake_executor_plugin_dask/__init__.py
+++ b/src/snakemake_executor_plugin_dask/__init__.py
@@ -1,10 +1,14 @@
 """Snakemake executor plugin: dispatches each rule's shell command to a
 running ``dask.distributed`` cluster.
 
-The scheduler address is read from ``DASK_SCHEDULER_ADDRESS`` in the
-environment. ``lc run`` is responsible for setting that — typically by
-constructing a ``LocalCluster()`` for the duration of the run, optionally
-backed by ``srun``-launched workers when invoked inside an SLURM allocation.
+The cluster rendezvous is read from the environment: either a plain
+scheduler address in ``DASK_SCHEDULER_ADDRESS`` or a Dask Gateway
+cluster name in ``LIGHTCONE_GATEWAY_CLUSTER`` (rejoined through the
+Gateway API — ``gateway://`` schedulers cannot be dialled directly).
+``lc run`` is responsible for setting one of them — typically by
+constructing a ``LocalCluster()`` for the duration of the run, backed by
+``srun``-launched workers inside a SLURM allocation, or by creating a
+run-scoped Gateway cluster on a JupyterHub deployment.
 
 The plugin is intentionally minimal: each Snakemake job becomes a
 ``client.submit(_run_shell, cmd, resources={...})`` call. Workers run the

--- a/src/snakemake_executor_plugin_dask/executor.py
+++ b/src/snakemake_executor_plugin_dask/executor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 import sys
 from collections.abc import AsyncGenerator
@@ -148,6 +149,16 @@ class DaskExecutor(RemoteExecutor):  # type: ignore[misc]
                 "(`pip install distributed`)."
             ) from exc
         self._client, self._close_client = _connect_client()
+
+    def get_job_exec_prefix(self, job: JobExecutorInterface) -> str:
+        # Spawned job commands carry no --directory: snakemake expects
+        # remote executors to cd into the workdir themselves (the
+        # official kubernetes executor does the same). Local and SLURM
+        # workers happen to inherit the driver's cwd, but a Dask
+        # Gateway worker pod starts in its image's WORKDIR (e.g. /app),
+        # where the child snakemake would resolve every relative path
+        # — and die on a read-only ``.snakemake``.
+        return f"cd {shlex.quote(self.workflow.workdir_init)}"
 
     def run_job(self, job: JobExecutorInterface) -> None:
         cmd = self.format_job_exec(job)

--- a/src/snakemake_executor_plugin_dask/executor.py
+++ b/src/snakemake_executor_plugin_dask/executor.py
@@ -1,7 +1,6 @@
 # mypy: disable-error-code="no-untyped-call"
 from __future__ import annotations
 
-import fcntl
 import os
 import subprocess
 import sys
@@ -19,60 +18,65 @@ from snakemake_interface_executor_plugins.jobs import (  # type: ignore[import-u
 )
 
 from lightcone.engine.dask_cluster import (
+    GATEWAY_CLUSTER_ENV,
     RESOURCE_CPUS,
     RESOURCE_GPUS,
     RESOURCE_MEMORY,
 )
 from lightcone.engine.runner import SENTINEL
 
+#: On a failure with no sentinel-framed output at all — the child
+#: snakemake died before reaching the rule body (import error, missing
+#: package in the worker image, broken snakefile) — forward this many
+#: raw trailing lines so the failure is debuggable from the driver.
+_RAW_TAIL_LINES = 60
 
-def _run_shell(cmd: str) -> int:
-    """Worker-side: run the child snakemake command, forward its lightcone
-    output, and return its exit code.
+
+def _run_shell(cmd: str) -> tuple[int, str]:
+    """Worker-side: run the child snakemake command; return
+    ``(exit_code, output_block)``.
 
     The command is a child snakemake invocation that loads the generated
     Snakefile and executes one rule's ``run:`` block. That block calls
     :func:`lightcone.engine.runner.run_rule`, which streams structured
     output prefixed with :data:`lightcone.engine.runner.SENTINEL`.
 
-    We capture both stdout and stderr from the child snakemake; anything
-    not prefixed (snakemake's bootstrap, dask noise, stray prints) is
-    dropped. Lightcone-prefixed lines are forwarded to *our* stdout —
-    inherited from ``lc run``'s terminal across local LocalCluster
-    workers and srun-launched remote workers alike — as one atomic block
-    per rule, serialised across workers and nodes by an ``flock`` on the
-    path pointed to by ``LIGHTCONE_OUT_LOCK``.
-
-    The lockfile must live on a filesystem that supports advisory locks.
-    On NERSC, ``$HOME`` and ``/global/cfs`` are mounted on compute nodes
-    via DVS, which silently swallows ``flock``; lc run resolves the path
-    onto Lustre via :mod:`lightcone.engine.scratch`.
+    The block travels back to the driver as part of the task result —
+    the only channel that works uniformly across LocalCluster threads,
+    srun-launched SLURM workers, and Dask Gateway worker pods (whose
+    stdout goes to pod logs, not the user's terminal). Sentinel-prefixed
+    lines are kept verbatim (prefix included: ``lc run`` filters on it);
+    everything else (snakemake bootstrap, dask noise, stray prints) is
+    dropped — unless the child failed without producing a single
+    sentinel line, in which case a bounded raw tail is forwarded so
+    bootstrap failures don't vanish into worker logs.
     """
     p = subprocess.run(
         cmd, shell=True, capture_output=True, text=True, check=False
     )
 
-    forwarded: list[str] = []
-    for stream in (p.stdout, p.stderr):
-        for line in stream.splitlines():
-            if line.startswith(SENTINEL):
-                forwarded.append(line[len(SENTINEL):])
-    if forwarded:
-        block = "\n".join(forwarded) + "\n"
-        lock_path = os.environ.get("LIGHTCONE_OUT_LOCK")
-        if lock_path:
-            with open(lock_path, "w") as lf:
-                fcntl.flock(lf, fcntl.LOCK_EX)
-                try:
-                    sys.stdout.write(block)
-                    sys.stdout.flush()
-                finally:
-                    fcntl.flock(lf, fcntl.LOCK_UN)
-        else:
-            sys.stdout.write(block)
-            sys.stdout.flush()
+    lines = [
+        line
+        for stream in (p.stdout, p.stderr)
+        for line in stream.splitlines()
+        if line.startswith(SENTINEL)
+    ]
+    if p.returncode != 0 and not lines:
+        raw = (p.stdout + p.stderr).splitlines()[-_RAW_TAIL_LINES:]
+        lines = [f"{SENTINEL}  {line}" for line in raw]
 
-    return p.returncode
+    block = "\n".join(lines) + "\n" if lines else ""
+    return p.returncode, block
+
+
+def _unpack_result(result: object) -> tuple[int, str]:
+    """Accept both the current ``(exit_code, block)`` result and the
+    bare ``int`` a worker running an older lightcone-cli release returns
+    (dask resolves ``_run_shell`` by module path on the worker, so
+    driver and worker versions can skew on image-based deployments)."""
+    if isinstance(result, tuple) and len(result) == 2:
+        return int(result[0]), str(result[1])
+    return int(result), ""  # type: ignore[call-overload]
 
 
 def _build_resources(job: JobExecutorInterface) -> dict[str, float]:
@@ -90,25 +94,60 @@ def _build_resources(job: JobExecutorInterface) -> dict[str, float]:
     return res
 
 
+def _connect_client():  # type: ignore[no-untyped-def]
+    """Connect to the run's cluster.
+
+    Two rendezvous modes, both set up by ``lc run``:
+
+    - :data:`GATEWAY_CLUSTER_ENV` names a Dask Gateway cluster the
+      parent created. Gateway schedulers speak a ``gateway://`` comm
+      scheme with per-cluster TLS credentials held by the Gateway API —
+      a bare ``Client`` cannot dial them, so we rejoin through
+      ``Gateway().connect(name)``.
+    - Otherwise ``DASK_SCHEDULER_ADDRESS`` is a plain scheduler address.
+
+    Returns ``(client, closer)`` where *closer* releases everything the
+    rendezvous opened.
+    """
+    from dask.distributed import Client
+
+    if name := os.environ.get(GATEWAY_CLUSTER_ENV):
+        from dask_gateway import Gateway
+
+        # shutdown_on_close=False: the parent lc run owns the cluster
+        # lifecycle; the executor is a guest.
+        cluster = Gateway().connect(name, shutdown_on_close=False)
+        client = cluster.get_client()
+
+        def closer() -> None:
+            client.close()
+            cluster.close()
+
+        return client, closer
+
+    addr = os.environ.get("DASK_SCHEDULER_ADDRESS")
+    if not addr:
+        raise WorkflowError(
+            "Neither DASK_SCHEDULER_ADDRESS nor "
+            f"{GATEWAY_CLUSTER_ENV} is set. `lc run` should set one "
+            "before invoking snakemake; if you're calling snakemake "
+            "directly, point it at a running dask scheduler."
+        )
+    client = Client(addr)
+    return client, client.close
+
+
 class DaskExecutor(RemoteExecutor):  # type: ignore[misc]
     def __init__(self, workflow, logger):  # type: ignore[no-untyped-def]
         super().__init__(workflow, logger)
         try:
-            from dask.distributed import Client
+            import dask.distributed  # noqa: F401
         except ImportError as exc:
             raise WorkflowError(
                 "dask.distributed is required for the dask executor "
                 "(`pip install distributed`)."
             ) from exc
-
-        addr = os.environ.get("DASK_SCHEDULER_ADDRESS")
-        if not addr:
-            raise WorkflowError(
-                "DASK_SCHEDULER_ADDRESS is not set. `lc run` should set this "
-                "before invoking snakemake; if you're calling snakemake "
-                "directly, point it at a running dask scheduler."
-            )
-        self._client = Client(addr)
+        self._client, self._close_client = _connect_client()
 
     def run_job(self, job: JobExecutorInterface) -> None:
         cmd = self.format_job_exec(job)
@@ -143,7 +182,13 @@ class DaskExecutor(RemoteExecutor):  # type: ignore[misc]
                 )
                 continue
 
-            exit_code = future.result()
+            exit_code, block = _unpack_result(future.result())
+            if block:
+                # One atomic write per finished rule. We run inside the
+                # parent snakemake process, so this is naturally
+                # serialised — no cross-process locking needed.
+                sys.stdout.write(block)
+                sys.stdout.flush()
             if exit_code != 0:
                 self.report_job_error(
                     j, msg=f"Dask task '{j.external_jobid}' exited {exit_code}."
@@ -168,6 +213,6 @@ class DaskExecutor(RemoteExecutor):  # type: ignore[misc]
 
     def shutdown(self) -> None:
         try:
-            self._client.close()
+            self._close_client()
         finally:
             super().shutdown()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,11 +237,12 @@ def test_run_cmd_multiple_triggers_all_before_separator() -> None:
 # ---- JupyterHub deployment paths ------------------------------------------
 
 
-def test_run_cmd_gateway_adaptations() -> None:
-    """The gateway invocation tolerates NFS latency and must NOT embed
-    the driver's sys.executable (worker images have their own python) —
-    dropping software-deployment from --shared-fs-usage is what makes
-    snakemake spawn plain `python` on the workers."""
+def test_run_cmd_uniform_across_backends() -> None:
+    """One invocation shape for every backend: --shared-fs-usage drops
+    software-deployment so spawned jobs run plain `python` from the
+    worker's own environment (the worker image on a gateway, the
+    driver's activated env locally / on SLURM) instead of embedding the
+    driver's sys.executable. No gateway-specific flags exist."""
     from lightcone.cli.commands import _build_snakemake_cmd
 
     cmd = _build_snakemake_cmd(
@@ -252,69 +253,54 @@ def test_run_cmd_gateway_adaptations() -> None:
         targets=["results/u/foo/.lightcone-manifest.json"],
         force=False,
         has_outputs=True,
-        gateway=True,
     )
-    i = cmd.index("--latency-wait")
-    assert cmd[i + 1] == "120"
     j = cmd.index("--shared-fs-usage")
-    values = cmd[j + 1 : cmd.index("--")]
+    values = cmd[j + 1 : cmd.index("--rerun-triggers")]
     assert "software-deployment" not in values
     assert "persistence" in values and "input-output" in values
+    assert "--latency-wait" not in cmd
     # nargs=+ flags must never swallow the positional targets.
     assert cmd.index("--") < cmd.index("results/u/foo/.lightcone-manifest.json")
 
-    cmd = _build_snakemake_cmd(
-        snakefile_path=Path("/p/.lightcone/Snakefile"),
-        project=Path("/p"),
-        n="4",
-        rerun_triggers="mtime",
-        targets=[],
-        force=False,
-        has_outputs=False,
-    )
-    assert "--latency-wait" not in cmd
-    assert "--shared-fs-usage" not in cmd
 
-
-def test_init_on_hub_scaffolds_worker_capable_image(
+def test_init_scaffold_is_environment_agnostic(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """On a Dask Gateway deployment the project image doubles as the
-    worker pod image, so the scaffold must carry the worker stack and a
-    uid-1000 user matching the mounted NFS home."""
+    """The scaffold is identical on and off a hub: the Containerfile
+    carries no environment-specific content (pod identity is deployment
+    config, not image content), and lightcone-cli in requirements.txt
+    brings the whole execution stack — including dask-gateway — as
+    normal dependencies."""
     monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
-    project = tmp_path / "proj"
-    result = runner.invoke(main, ["init", str(project), "--no-git", "--no-venv"])
+    hub_project = tmp_path / "hub"
+    result = runner.invoke(main, ["init", str(hub_project), "--no-git", "--no-venv"])
     assert result.exit_code == 0, result.output
 
-    containerfile = (project / "Containerfile").read_text()
-    assert "useradd" in containerfile and "1000" in containerfile
-    requirements = (project / "requirements.txt").read_text()
-    for dist in ("dask", "distributed", "dask-gateway", "snakemake", "lightcone-cli"):
-        assert dist in requirements
-
-
-def test_init_off_hub_keeps_slim_scaffold(
-    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.delenv("DASK_GATEWAY__ADDRESS", raising=False)
-    project = tmp_path / "proj"
-    result = runner.invoke(main, ["init", str(project), "--no-git", "--no-venv"])
+    monkeypatch.delenv("DASK_GATEWAY__ADDRESS")
+    local_project = tmp_path / "local"
+    result = runner.invoke(main, ["init", str(local_project), "--no-git", "--no-venv"])
     assert result.exit_code == 0, result.output
-    assert "dask-gateway" not in (project / "requirements.txt").read_text()
+
+    containerfile = (hub_project / "Containerfile").read_text()
+    requirements = (hub_project / "requirements.txt").read_text()
+    assert containerfile == (local_project / "Containerfile").read_text()
+    assert requirements == (local_project / "requirements.txt").read_text()
+    assert "useradd" not in containerfile and "USER" not in containerfile
+    assert "lightcone-cli" in requirements
 
 
-def test_worker_stack_pins_ambient_versions() -> None:
-    from lightcone.cli.commands import _worker_stack_pins
+def test_lightcone_requirement_pins_running_version() -> None:
+    from importlib.metadata import version
 
-    pins = _worker_stack_pins()
-    # dask and snakemake are installed in the dev env → pinned; the pin
-    # must mirror the running environment.
-    import dask
+    from lightcone.cli.commands import _lightcone_requirement
 
-    assert f"dask=={dask.__version__}" in pins
-    # dask-gateway is not a dev dependency → unpinned fallback line.
-    assert "dask-gateway" in pins
+    req = _lightcone_requirement()
+    v = version("lightcone-cli")
+    if "dev" in v:
+        # Dev builds aren't published — unpinned fallback.
+        assert req.strip().splitlines()[-1] == "lightcone-cli"
+    else:
+        assert f"lightcone-cli=={v}" in req
 
 
 def test_ensure_images_none_runtime_returns_empty(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,3 +232,92 @@ def test_run_cmd_multiple_triggers_all_before_separator() -> None:
     for trigger in ("code", "input", "mtime", "params"):
         assert trigger in cmd, f"trigger '{trigger}' missing from cmd"
         assert cmd.index(trigger) < sep_idx, f"trigger '{trigger}' must come before '--'"
+
+
+# ---- JupyterHub deployment paths ------------------------------------------
+
+
+def test_run_cmd_gateway_adaptations() -> None:
+    """The gateway invocation tolerates NFS latency and must NOT embed
+    the driver's sys.executable (worker images have their own python) —
+    dropping software-deployment from --shared-fs-usage is what makes
+    snakemake spawn plain `python` on the workers."""
+    from lightcone.cli.commands import _build_snakemake_cmd
+
+    cmd = _build_snakemake_cmd(
+        snakefile_path=Path("/p/.lightcone/Snakefile"),
+        project=Path("/p"),
+        n="4",
+        rerun_triggers="mtime",
+        targets=["results/u/foo/.lightcone-manifest.json"],
+        force=False,
+        has_outputs=True,
+        gateway=True,
+    )
+    i = cmd.index("--latency-wait")
+    assert cmd[i + 1] == "120"
+    j = cmd.index("--shared-fs-usage")
+    values = cmd[j + 1 : cmd.index("--")]
+    assert "software-deployment" not in values
+    assert "persistence" in values and "input-output" in values
+    # nargs=+ flags must never swallow the positional targets.
+    assert cmd.index("--") < cmd.index("results/u/foo/.lightcone-manifest.json")
+
+    cmd = _build_snakemake_cmd(
+        snakefile_path=Path("/p/.lightcone/Snakefile"),
+        project=Path("/p"),
+        n="4",
+        rerun_triggers="mtime",
+        targets=[],
+        force=False,
+        has_outputs=False,
+    )
+    assert "--latency-wait" not in cmd
+    assert "--shared-fs-usage" not in cmd
+
+
+def test_init_on_hub_scaffolds_worker_capable_image(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On a Dask Gateway deployment the project image doubles as the
+    worker pod image, so the scaffold must carry the worker stack and a
+    uid-1000 user matching the mounted NFS home."""
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    project = tmp_path / "proj"
+    result = runner.invoke(main, ["init", str(project), "--no-git", "--no-venv"])
+    assert result.exit_code == 0, result.output
+
+    containerfile = (project / "Containerfile").read_text()
+    assert "useradd" in containerfile and "1000" in containerfile
+    requirements = (project / "requirements.txt").read_text()
+    for dist in ("dask", "distributed", "dask-gateway", "snakemake", "lightcone-cli"):
+        assert dist in requirements
+
+
+def test_init_off_hub_keeps_slim_scaffold(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("DASK_GATEWAY__ADDRESS", raising=False)
+    project = tmp_path / "proj"
+    result = runner.invoke(main, ["init", str(project), "--no-git", "--no-venv"])
+    assert result.exit_code == 0, result.output
+    assert "dask-gateway" not in (project / "requirements.txt").read_text()
+
+
+def test_worker_stack_pins_ambient_versions() -> None:
+    from lightcone.cli.commands import _worker_stack_pins
+
+    pins = _worker_stack_pins()
+    # dask and snakemake are installed in the dev env → pinned; the pin
+    # must mirror the running environment.
+    import dask
+
+    assert f"dask=={dask.__version__}" in pins
+    # dask-gateway is not a dev dependency → unpinned fallback line.
+    assert "dask-gateway" in pins
+
+
+def test_ensure_images_none_runtime_returns_empty(tmp_path: Path) -> None:
+    from lightcone.cli.commands import _ensure_images
+
+    assert _ensure_images(tmp_path, runtime="none") == []

--- a/tests/test_cloudbuild.py
+++ b/tests/test_cloudbuild.py
@@ -1,0 +1,275 @@
+"""Unit tests for the GCP Cloud Build backend.
+
+All GCP surfaces (metadata server, GCS, Cloud Build API, registry) are
+mocked at the module's HTTP seams — ``_metadata_access_token`` and
+``_request`` — so the tests exercise the real control flow: freshness
+probe, staging, submission, polling, failure-tail reporting.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lightcone.engine import cloudbuild
+from lightcone.engine.cloudbuild import (
+    BUCKET_ENV,
+    SERVICE_ACCOUNT_ENV,
+    CloudBuildError,
+    cloudbuild_available,
+    ensure_image,
+)
+from lightcone.engine.container import REGISTRY_ENV, registry_image_ref
+
+REGISTRY = "europe-west1-docker.pkg.dev/lightconehub/lightcone-images"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (REGISTRY_ENV, BUCKET_ENV, SERVICE_ACCOUNT_ENV):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def deployment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(REGISTRY_ENV, REGISTRY)
+    monkeypatch.setenv(BUCKET_ENV, "lightconehub-lightcone-lc-build")
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    (tmp_path / "Containerfile").write_text("FROM python:3.12-slim\n")
+    (tmp_path / "requirements.txt").write_text("numpy\n")
+    return tmp_path
+
+
+# ---- backend selection ----------------------------------------------------
+
+
+def test_unavailable_without_env() -> None:
+    assert cloudbuild_available() is False
+
+
+def test_available_with_full_contract(deployment: None) -> None:
+    assert cloudbuild_available() is True
+
+
+def test_unavailable_with_bucket_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(BUCKET_ENV, "some-bucket")
+    assert cloudbuild_available() is False
+
+
+# ---- registry ref / project parsing ---------------------------------------
+
+
+def test_registry_ref_shape(project: Path) -> None:
+    ref = registry_image_ref("My Proj", project / "Containerfile", project,
+                             registry=REGISTRY + "/")
+    repo, _, tag = ref.rpartition(":")
+    assert repo == f"{REGISTRY}/lc-my-proj"
+    assert len(tag) == 12
+
+
+def test_gcp_project_from_registry() -> None:
+    assert cloudbuild._gcp_project(REGISTRY) == "lightconehub"
+
+
+def test_gcp_project_rejects_non_artifact_registry() -> None:
+    with pytest.raises(CloudBuildError, match="Artifact Registry"):
+        cloudbuild._gcp_project("ghcr.io/someorg")
+
+
+# ---- ensure_image control flow --------------------------------------------
+
+
+def _fresh_probe(monkeypatch: pytest.MonkeyPatch, exists: bool | None) -> None:
+    monkeypatch.setattr(cloudbuild, "registry_image_exists", lambda ref: exists)
+
+
+def test_ensure_image_cached_is_probe_only(
+    deployment: None, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fresh_probe(monkeypatch, True)
+    monkeypatch.setattr(
+        cloudbuild, "_request", lambda *a, **k: pytest.fail("no HTTP beyond probe")
+    )
+    phases: list[str] = []
+    ref = ensure_image(
+        project, "Containerfile", project_name="proj",
+        on_progress=lambda p, _d: phases.append(p),
+    )
+    assert ref.startswith(f"{REGISTRY}/lc-proj:")
+    assert phases == ["cached"]
+
+
+def test_ensure_image_builds_when_absent(
+    deployment: None, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fresh_probe(monkeypatch, False)
+    monkeypatch.setattr(cloudbuild, "_metadata_access_token", lambda: "tok")
+    monkeypatch.setenv(SERVICE_ACCOUNT_ENV, "builder@lightconehub.iam.gserviceaccount.com")
+
+    calls: list[tuple[str, str]] = []
+    poll_status = iter(["WORKING", "SUCCESS"])
+
+    def fake_request(method: str, url: str, token: str, *, body=None, content_type=""):
+        calls.append((method, url))
+        if "storage.googleapis.com/upload" in url:
+            return 200, b"{}"
+        if url.endswith("/builds") and method == "POST":
+            payload = json.loads(body.decode())
+            assert payload["images"][0].startswith(f"{REGISTRY}/lc-proj:")
+            assert payload["serviceAccount"] == (
+                "projects/lightconehub/serviceAccounts/"
+                "builder@lightconehub.iam.gserviceaccount.com"
+            )
+            assert payload["source"]["storageSource"]["bucket"] == (
+                "lightconehub-lightcone-lc-build"
+            )
+            return 200, json.dumps(
+                {"metadata": {"build": {"id": "build-123"}}}
+            ).encode()
+        if "/builds/build-123" in url:
+            return 200, json.dumps({"status": next(poll_status)}).encode()
+        raise AssertionError(f"unexpected request {method} {url}")
+
+    monkeypatch.setattr(cloudbuild, "_request", fake_request)
+    monkeypatch.setattr(cloudbuild.time, "sleep", lambda _s: None)
+
+    phases: list[str] = []
+    ref = ensure_image(
+        project, "Containerfile", project_name="proj",
+        on_progress=lambda p, _d: phases.append(p),
+    )
+    assert ref.startswith(f"{REGISTRY}/lc-proj:")
+    assert phases[0] == "staging"
+    assert "working" in phases and "success" in phases
+    # Upload happened before submission.
+    assert "upload" in calls[0][1]
+
+
+def test_ensure_image_failure_surfaces_log_tail(
+    deployment: None, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fresh_probe(monkeypatch, False)
+    monkeypatch.setattr(cloudbuild, "_metadata_access_token", lambda: "tok")
+
+    def fake_request(method: str, url: str, token: str, *, body=None, content_type=""):
+        if "storage.googleapis.com/upload" in url:
+            return 200, b"{}"
+        if url.endswith("/builds") and method == "POST":
+            return 200, json.dumps(
+                {"metadata": {"build": {"id": "build-9"}}}
+            ).encode()
+        if "/builds/build-9" in url:
+            return 200, json.dumps({"status": "FAILURE"}).encode()
+        if "alt=media" in url:
+            return 200, b"step1 ok\nERROR: pip failed\n"
+        raise AssertionError(f"unexpected request {method} {url}")
+
+    monkeypatch.setattr(cloudbuild, "_request", fake_request)
+    monkeypatch.setattr(cloudbuild.time, "sleep", lambda _s: None)
+
+    with pytest.raises(CloudBuildError, match="ERROR: pip failed"):
+        ensure_image(project, "Containerfile", project_name="proj")
+
+
+def test_ensure_image_force_skips_probe(
+    deployment: None, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        cloudbuild,
+        "registry_image_exists",
+        lambda ref: pytest.fail("force must skip the freshness probe"),
+    )
+    monkeypatch.setattr(cloudbuild, "_metadata_access_token", lambda: "tok")
+
+    def fake_request(method: str, url: str, token: str, *, body=None, content_type=""):
+        if "storage.googleapis.com/upload" in url:
+            return 200, b"{}"
+        if url.endswith("/builds") and method == "POST":
+            return 200, json.dumps(
+                {"metadata": {"build": {"id": "b"}}}
+            ).encode()
+        return 200, json.dumps({"status": "SUCCESS"}).encode()
+
+    monkeypatch.setattr(cloudbuild, "_request", fake_request)
+    ensure_image(project, "Containerfile", project_name="proj", force=True)
+
+
+def test_ensure_image_requires_credentials(
+    deployment: None, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fresh_probe(monkeypatch, None)
+    monkeypatch.setattr(cloudbuild, "_metadata_access_token", lambda: None)
+    with pytest.raises(CloudBuildError, match="Workload Identity"):
+        ensure_image(project, "Containerfile", project_name="proj")
+
+
+def test_ensure_image_missing_containerfile(
+    deployment: None, tmp_path: Path
+) -> None:
+    with pytest.raises(CloudBuildError, match="not found"):
+        ensure_image(tmp_path, "Containerfile", project_name="proj")
+
+
+def test_ensure_image_off_deployment(project: Path) -> None:
+    with pytest.raises(CloudBuildError, match="not configured for Cloud Build"):
+        ensure_image(project, "Containerfile", project_name="proj")
+
+
+# ---- staged tarball --------------------------------------------------------
+
+
+def test_staged_tarball_matches_hashed_context(project: Path) -> None:
+    """The tarball must contain exactly the staged (= hashed) file set."""
+    import io
+    import tarfile
+
+    (project / "results").mkdir()
+    (project / "results" / "big.bin").write_text("x" * 10)
+    data = cloudbuild._staged_context_tarball(project, project / "Containerfile")
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        names = set(tar.getnames())
+    assert "Containerfile" in names
+    assert "requirements.txt" in names
+    assert not any("results" in n for n in names)
+
+
+# ---- registry probe --------------------------------------------------------
+
+
+def test_registry_image_exists_parses_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cloudbuild, "_metadata_access_token", lambda: "tok")
+    seen: dict[str, str] = {}
+
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            pass
+
+    def fake_urlopen(req, timeout: int = 0):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        return _Resp()
+
+    monkeypatch.setattr(cloudbuild.urllib.request, "urlopen", fake_urlopen)
+    assert cloudbuild.registry_image_exists(f"{REGISTRY}/lc-proj:abc123") is True
+    assert seen["method"] == "HEAD"
+    assert seen["url"] == (
+        "https://europe-west1-docker.pkg.dev/v2/"
+        "lightconehub/lightcone-images/lc-proj/manifests/abc123"
+    )
+
+
+def test_registry_image_exists_none_without_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cloudbuild, "_metadata_access_token", lambda: None)
+    assert cloudbuild.registry_image_exists(f"{REGISTRY}/lc-proj:abc") is None

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -708,3 +708,75 @@ class TestIsContainerfile:
 
     def test_missing_file(self, project: Path) -> None:
         assert is_containerfile("python:3.12-slim", project) is False
+
+
+# ---- kubernetes runtime ---------------------------------------------------
+
+
+class TestKubernetesRuntime:
+    def test_wrap_recipe_is_passthrough(self) -> None:
+        """The worker pod already runs the image — wrapping would
+        containerize twice."""
+        from lightcone.engine.container import KUBERNETES
+
+        wrapped = wrap_recipe(
+            "python run.py", image="reg/lc-p:abc", runtime=KUBERNETES
+        )
+        assert wrapped == "python run.py"
+
+    def test_registry_ref_shares_identity_with_local_tag(
+        self, project: Path
+    ) -> None:
+        from lightcone.engine.container import registry_image_ref
+
+        tag = compute_image_tag("proj", project / "Containerfile", project)
+        ref = registry_image_ref(
+            "proj", project / "Containerfile", project, registry="reg.io/ns/repo"
+        )
+        digest = tag.rsplit("-", 1)[1]
+        assert ref == f"reg.io/ns/repo/lc-proj:{digest}"
+
+    def test_resolve_image_uses_registry_when_given(self, project: Path) -> None:
+        ref = resolve_image_for_run(
+            "Containerfile",
+            project_path=project,
+            project_name="proj",
+            registry="reg.io/ns/repo",
+        )
+        assert ref is not None and ref.startswith("reg.io/ns/repo/lc-proj:")
+
+    def test_resolve_prebuilt_ignores_registry(self, project: Path) -> None:
+        assert (
+            resolve_image_for_run(
+                "python:3.12-slim",
+                project_path=project,
+                project_name="proj",
+                registry="reg.io/ns/repo",
+            )
+            == "python:3.12-slim"
+        )
+
+    def test_detect_runtime_site_kubernetes_skips_path_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A gateway deployment has no OCI binary to find — the site
+        preference short-circuits detection entirely."""
+        monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dg")
+        monkeypatch.setattr(
+            "lightcone.engine.container.shutil.which",
+            lambda _: pytest.fail("no PATH probing on kubernetes sites"),
+        )
+        assert detect_runtime() == "kubernetes"
+
+    def test_load_runtime_explicit_kubernetes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        cfg_dir = tmp_path / ".lightcone"
+        cfg_dir.mkdir()
+        (cfg_dir / "config.yaml").write_text(
+            yaml.safe_dump({"container": {"runtime": "kubernetes"}})
+        )
+        choice = load_runtime()
+        assert choice.runtime == "kubernetes"
+        assert choice.explicit is True

--- a/tests/test_dask_cluster.py
+++ b/tests/test_dask_cluster.py
@@ -535,6 +535,35 @@ def test_gateway_self_provisions_worker_environment(
     assert env["EXTRA"] == "kept", "ambient environment defaults must survive"
 
 
+def test_gateway_provisions_identity_without_user_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """USER/LOGNAME must be *derived*, not merely forwarded: notebook
+    pods often don't export them (their own passwd entry covers
+    getpass), while the environment-agnostic worker image has NO passwd
+    entry for the pod uid — so the child snakemake crashes at
+    ``getpass.getuser()`` unless lc always provisions the vars.
+    Regression: live run failed with ``getpwuid(): uid not found``."""
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("LOGNAME", raising=False)
+    record: dict[str, object] = {}
+    _install_fake_gateway(
+        monkeypatch,
+        record,
+        declared_options={"image": "notebook:latest", "environment": {}},
+    )
+
+    with cluster_for_run(worker_image="reg/lc-p:abc"):
+        pass
+
+    import getpass
+
+    env = record["options"]["environment"]  # type: ignore[index]
+    assert env["USER"] == getpass.getuser()
+    assert env["LOGNAME"] == env["USER"]
+
+
 def test_gateway_worker_image_env_falls_back_to_declared_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_dask_cluster.py
+++ b/tests/test_dask_cluster.py
@@ -28,6 +28,8 @@ from lightcone.engine.dask_cluster import (
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for var in (
         "DASK_SCHEDULER_ADDRESS",
+        "DASK_GATEWAY__ADDRESS",
+        "LIGHTCONE_GATEWAY_WORKER_TIMEOUT",
         "SLURM_JOB_ID",
         "SLURM_NNODES",
         "SLURM_CPUS_ON_NODE",
@@ -69,8 +71,8 @@ def test_existing_scheduler_address_yields_unchanged(
 ) -> None:
     monkeypatch.setenv("DASK_SCHEDULER_ADDRESS", "tcp://example:8786")
 
-    with cluster_for_run() as addr:
-        assert addr == "tcp://example:8786"
+    with cluster_for_run() as env:
+        assert env == {"DASK_SCHEDULER_ADDRESS": "tcp://example:8786"}
 
 
 def test_no_env_uses_local_cluster() -> None:
@@ -83,8 +85,8 @@ def test_no_env_uses_local_cluster() -> None:
         yield "tcp://stub:9999"
 
     with patch("lightcone.engine.dask_cluster._local_cluster", _fake_local):
-        with cluster_for_run() as addr:
-            assert addr == "tcp://stub:9999"
+        with cluster_for_run() as env:
+            assert env == {"DASK_SCHEDULER_ADDRESS": "tcp://stub:9999"}
             assert sentinel["called"] == "local"
 
 
@@ -98,8 +100,8 @@ def test_slurm_env_takes_slurm_path(monkeypatch: pytest.MonkeyPatch) -> None:
         yield "tcp://stub:9999"
 
     with patch("lightcone.engine.dask_cluster._slurm_backed_cluster", _fake_slurm):
-        with cluster_for_run() as addr:
-            assert addr == "tcp://stub:9999"
+        with cluster_for_run() as env:
+            assert env == {"DASK_SCHEDULER_ADDRESS": "tcp://stub:9999"}
             assert sentinel["called"] == "slurm"
 
 
@@ -116,8 +118,8 @@ def test_existing_scheduler_address_wins_over_slurm(
         yield  # pragma: no cover
 
     with patch("lightcone.engine.dask_cluster._slurm_backed_cluster", _should_not_run):
-        with cluster_for_run() as addr:
-            assert addr == "tcp://existing:8786"
+        with cluster_for_run() as env:
+            assert env == {"DASK_SCHEDULER_ADDRESS": "tcp://existing:8786"}
 
 
 def test_slurm_backed_cluster_binds_to_routable_host(
@@ -289,3 +291,179 @@ def test_local_cluster_smoke() -> None:
             assert client.submit(lambda x: x + 1, 41).result() == 42
         finally:
             client.close()
+
+# ---------------------------------------------------------------------------
+# Dask Gateway branch
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+    record: dict[str, object],
+    *,
+    worker_resources: dict[str, float] | None = None,
+    wait_raises: bool = False,
+):
+    """Register a fake ``dask_gateway`` module and return it."""
+    import sys
+    from types import SimpleNamespace
+
+    resources = (
+        worker_resources
+        if worker_resources is not None
+        else {"cpus": 2.0, "memory": 4e9}
+    )
+
+    class _FakeClient:
+        def wait_for_workers(self, n_workers: int, timeout: int) -> None:
+            record["waited"] = (n_workers, timeout)
+            if wait_raises:
+                raise TimeoutError("no workers")
+
+        def scheduler_info(self) -> dict[str, object]:
+            return {"workers": {"w0": {"resources": resources}}}
+
+        def close(self) -> None:
+            record["client_closed"] = True
+
+    class _FakeCluster:
+        name = "hub.abc123"
+        dashboard_link = "http://dash"
+
+        def adapt(self, minimum: int, maximum: int) -> None:
+            record["adapt"] = (minimum, maximum)
+
+        def get_client(self) -> _FakeClient:
+            return _FakeClient()
+
+        def shutdown(self) -> None:
+            record["shutdown"] = True
+
+        def close(self) -> None:
+            record["closed"] = True
+
+    class _FakeGateway:
+        def new_cluster(self, shutdown_on_close: bool = True, **options: object):
+            record["shutdown_on_close"] = shutdown_on_close
+            record["options"] = options
+            return _FakeCluster()
+
+    module = SimpleNamespace(Gateway=_FakeGateway)
+    monkeypatch.setitem(sys.modules, "dask_gateway", module)
+    return module
+
+
+def test_gateway_env_takes_gateway_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    from lightcone.engine.dask_cluster import GATEWAY_CLUSTER_ENV
+
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    record: dict[str, object] = {}
+    _install_fake_gateway(monkeypatch, record)
+
+    with cluster_for_run(worker_image="reg/lc-p:abc", max_workers=4) as env:
+        assert env == {GATEWAY_CLUSTER_ENV: "hub.abc123"}
+        assert record["options"] == {"image": "reg/lc-p:abc"}
+        assert record["adapt"] == (1, 4)
+        assert "shutdown" not in record
+
+    assert record["shutdown"] is True, "run-scoped cluster must be culled on exit"
+
+
+def test_gateway_without_image_uses_deployment_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    record: dict[str, object] = {}
+    _install_fake_gateway(monkeypatch, record)
+
+    with cluster_for_run() as _env:
+        pass
+
+    assert record["options"] == {}, "no image option → deployment default"
+
+
+def test_explicit_scheduler_address_wins_over_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DASK_SCHEDULER_ADDRESS", "tcp://existing:8786")
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+
+    with cluster_for_run() as env:
+        assert env == {"DASK_SCHEDULER_ADDRESS": "tcp://existing:8786"}
+
+
+def test_gateway_culled_when_body_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cluster must be shut down even when the run fails."""
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    record: dict[str, object] = {}
+    _install_fake_gateway(monkeypatch, record)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with cluster_for_run():
+            raise RuntimeError("boom")
+
+    assert record["shutdown"] is True
+
+
+def test_gateway_zero_workers_fails_loudly_and_culls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    monkeypatch.setenv("LIGHTCONE_GATEWAY_WORKER_TIMEOUT", "7")
+    record: dict[str, object] = {}
+    _install_fake_gateway(monkeypatch, record, wait_raises=True)
+
+    with pytest.raises(RuntimeError, match="within 7s"):
+        with cluster_for_run(worker_image="reg/lc-p:abc"):
+            pass  # pragma: no cover
+
+    assert record["waited"] == (1, 7)
+    assert record["shutdown"] is True
+
+
+def test_gateway_missing_resource_contract_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    record: dict[str, object] = {}
+    _install_fake_gateway(monkeypatch, record, worker_resources={})
+
+    with pytest.raises(RuntimeError, match="resource contract"):
+        with cluster_for_run():
+            pass  # pragma: no cover
+
+    assert record["shutdown"] is True
+
+
+def test_gateway_missing_client_package_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import builtins
+    import sys
+
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    monkeypatch.delitem(sys.modules, "dask_gateway", raising=False)
+    real_import = builtins.__import__
+
+    def _no_gateway(name: str, *args: object, **kwargs: object):
+        if name == "dask_gateway":
+            raise ImportError("nope")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", _no_gateway)
+
+    with pytest.raises(RuntimeError, match=r"lightcone-cli\[gateway\]"):
+        with cluster_for_run():
+            pass  # pragma: no cover
+
+
+def test_gateway_branch_active_matches_routing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lightcone.engine.dask_cluster import gateway_branch_active
+
+    assert gateway_branch_active() is False
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    assert gateway_branch_active() is True
+    monkeypatch.setenv("DASK_SCHEDULER_ADDRESS", "tcp://existing:8786")
+    assert gateway_branch_active() is False

--- a/tests/test_dask_cluster.py
+++ b/tests/test_dask_cluster.py
@@ -450,28 +450,6 @@ def test_gateway_missing_resource_contract_refused(
     assert record["shutdown"] is True
 
 
-def test_gateway_missing_client_package_hint(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    import builtins
-    import sys
-
-    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
-    monkeypatch.delitem(sys.modules, "dask_gateway", raising=False)
-    real_import = builtins.__import__
-
-    def _no_gateway(name: str, *args: object, **kwargs: object):
-        if name == "dask_gateway":
-            raise ImportError("nope")
-        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
-
-    monkeypatch.setattr(builtins, "__import__", _no_gateway)
-
-    with pytest.raises(RuntimeError, match=r"lightcone-cli\[gateway\]"):
-        with cluster_for_run():
-            pass  # pragma: no cover
-
-
 def test_gateway_branch_active_matches_routing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_dask_cluster.py
+++ b/tests/test_dask_cluster.py
@@ -303,6 +303,7 @@ def _install_fake_gateway(
     *,
     worker_resources: dict[str, float] | None = None,
     wait_raises: bool = False,
+    declared_options: dict[str, object] | None = None,
 ):
     """Register a fake ``dask_gateway`` module and return it."""
     import sys
@@ -312,6 +313,16 @@ def _install_fake_gateway(
         worker_resources
         if worker_resources is not None
         else {"cpus": 2.0, "memory": 4e9}
+    )
+    declared = (
+        declared_options
+        if declared_options is not None
+        else {
+            "image": "notebook:latest",
+            "worker_cores": 2,
+            "worker_memory": 4.0,
+            "environment": {},
+        }
     )
 
     class _FakeClient:
@@ -343,6 +354,9 @@ def _install_fake_gateway(
             record["closed"] = True
 
     class _FakeGateway:
+        def cluster_options(self) -> dict[str, object]:
+            return dict(declared)
+
         def new_cluster(self, shutdown_on_close: bool = True, **options: object):
             record["shutdown_on_close"] = shutdown_on_close
             record["options"] = options
@@ -362,7 +376,8 @@ def test_gateway_env_takes_gateway_branch(monkeypatch: pytest.MonkeyPatch) -> No
 
     with cluster_for_run(worker_image="reg/lc-p:abc", max_workers=4) as env:
         assert env == {GATEWAY_CLUSTER_ENV: "hub.abc123"}
-        assert record["options"] == {"image": "reg/lc-p:abc"}
+        opts = record["options"]
+        assert opts["image"] == "reg/lc-p:abc"  # type: ignore[index]
         assert record["adapt"] == (1, 4)
         assert "shutdown" not in record
 
@@ -379,7 +394,7 @@ def test_gateway_without_image_uses_deployment_default(
     with cluster_for_run() as _env:
         pass
 
-    assert record["options"] == {}, "no image option → deployment default"
+    assert "image" not in record["options"], "no image option → deployment default"  # type: ignore[operator]
 
 
 def test_explicit_scheduler_address_wins_over_gateway(
@@ -502,3 +517,81 @@ def test_gateway_explicit_image_beats_ambient_default() -> None:
                 assert captured["cluster_options"] == {"image": "notebook:latest"}
         finally:
             gateway.close()
+
+
+def test_gateway_self_provisions_worker_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """lc passes everything worker pods need through the STANDARD
+    `environment` cluster option — resource contract mirrored from the
+    deployment's declared worker shape, driver identity forwarded,
+    image ground truth — so the deployment's options handler needs no
+    lightcone-specific injection."""
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    monkeypatch.setenv("HOME", "/home/jovyan")
+    monkeypatch.setenv("USER", "jovyan")
+    monkeypatch.setenv("LOGNAME", "jovyan")
+    record: dict[str, object] = {}
+    _install_fake_gateway(
+        monkeypatch,
+        record,
+        declared_options={
+            "image": "notebook:latest",
+            "worker_cores": 2,
+            "worker_memory": 4.0,
+            "environment": {"EXTRA": "kept"},
+        },
+    )
+
+    with cluster_for_run(worker_image="reg/lc-p:abc"):
+        pass
+
+    env = record["options"]["environment"]  # type: ignore[index]
+    assert env["DASK_DISTRIBUTED__WORKER__RESOURCES__CPUS"] == "2"
+    assert env["DASK_DISTRIBUTED__WORKER__RESOURCES__MEMORY"] == str(int(4.0 * 1e9))
+    assert env["DASK_DISTRIBUTED__WORKER__RESOURCES__GPUS"] == "0"
+    assert env["HOME"] == "/home/jovyan"
+    assert env["USER"] == "jovyan"
+    assert env["LOGNAME"] == "jovyan"
+    assert env["LIGHTCONE_WORKER_IMAGE"] == "reg/lc-p:abc"
+    assert env["EXTRA"] == "kept", "ambient environment defaults must survive"
+
+
+def test_gateway_worker_image_env_falls_back_to_declared_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    record: dict[str, object] = {}
+    _install_fake_gateway(monkeypatch, record)
+
+    with cluster_for_run():  # no project image → deployment default
+        pass
+
+    env = record["options"]["environment"]  # type: ignore[index]
+    assert env["LIGHTCONE_WORKER_IMAGE"] == "notebook:latest"
+
+
+def test_gateway_no_environment_option_no_injection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deployment that doesn't expose `environment` gets no surprise
+    kwarg (the server would reject it)."""
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    record: dict[str, object] = {}
+    _install_fake_gateway(
+        monkeypatch, record, declared_options={"image": "notebook:latest"}
+    )
+
+    with cluster_for_run(worker_image="reg/lc-p:abc"):
+        pass
+
+    assert "environment" not in record["options"]  # type: ignore[operator]
+
+
+def test_worker_environment_memory_bytes_heuristic() -> None:
+    from lightcone.engine.dask_cluster import _worker_environment
+
+    env = _worker_environment({"worker_memory": 4294967296}, None)
+    assert env["DASK_DISTRIBUTED__WORKER__RESOURCES__MEMORY"] == "4294967296"
+    env = _worker_environment({"worker_memory": 4.0}, None)
+    assert env["DASK_DISTRIBUTED__WORKER__RESOURCES__MEMORY"] == str(int(4e9))

--- a/tests/test_dask_cluster.py
+++ b/tests/test_dask_cluster.py
@@ -467,3 +467,38 @@ def test_gateway_branch_active_matches_routing(
     assert gateway_branch_active() is True
     monkeypatch.setenv("DASK_SCHEDULER_ADDRESS", "tcp://existing:8786")
     assert gateway_branch_active() is False
+
+
+def test_gateway_explicit_image_beats_ambient_default() -> None:
+    """The deployment injects DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE
+    (= the notebook image) as the client's ambient default. lc run's
+    explicit ``image`` kwarg MUST override it — otherwise every cluster
+    would run the notebook image instead of the one `lc build` just
+    produced. Pinned against the real dask-gateway client merge logic.
+    """
+    pytest.importorskip("dask_gateway")
+    import dask
+    from dask_gateway import Gateway
+
+    captured: dict[str, object] = {}
+
+    async def fake_request(self, method, url, json=None, **kwargs):  # type: ignore[no-untyped-def]
+        captured["cluster_options"] = (json or {}).get("cluster_options")
+
+        class _Resp:
+            async def json(self) -> dict[str, str]:
+                return {"name": "hub.fake"}
+
+        return _Resp()
+
+    with dask.config.set({"gateway.cluster.options": {"image": "notebook:latest"}}):
+        gateway = Gateway(address="http://gateway.invalid", auth="basic")
+        try:
+            with patch.object(Gateway, "_request", fake_request):
+                gateway.submit(image="reg/lc-proj:abc123")
+                assert captured["cluster_options"] == {"image": "reg/lc-proj:abc123"}
+
+                gateway.submit()
+                assert captured["cluster_options"] == {"image": "notebook:latest"}
+        finally:
+            gateway.close()

--- a/tests/test_dask_plugin.py
+++ b/tests/test_dask_plugin.py
@@ -202,3 +202,19 @@ def test_connect_client_gateway_rendezvous_by_name(
     closer()
     assert record.get("client_closed") is True
     assert record.get("cluster_closed") is True
+
+
+def test_job_exec_prefix_cds_into_workdir() -> None:
+    """Gateway worker pods start in the image's WORKDIR, not the
+    project — every spawned job must cd into the workflow's workdir
+    first (spawned commands carry no --directory)."""
+    from types import SimpleNamespace
+
+    from snakemake_executor_plugin_dask.executor import DaskExecutor
+
+    executor = DaskExecutor.__new__(DaskExecutor)
+    executor.workflow = SimpleNamespace(  # type: ignore[attr-defined]
+        workdir_init="/home/jovyan/my project"
+    )
+    prefix = executor.get_job_exec_prefix(SimpleNamespace())  # type: ignore[arg-type]
+    assert prefix == "cd '/home/jovyan/my project'"

--- a/tests/test_dask_plugin.py
+++ b/tests/test_dask_plugin.py
@@ -21,13 +21,13 @@ def _job(threads: int = 1, **resources: float) -> SimpleNamespace:
 
 
 def test_run_shell_propagates_exit_code() -> None:
-    assert _run_shell("true") == 0
-    assert _run_shell("false") != 0
+    assert _run_shell("true")[0] == 0
+    assert _run_shell("false")[0] != 0
 
 
 def test_run_shell_runs_under_shell() -> None:
     """We rely on shell=True so recipes can use pipes and env expansion."""
-    assert _run_shell("echo hi | grep hi >/dev/null") == 0
+    assert _run_shell("echo hi | grep hi >/dev/null")[0] == 0
 
 
 def test_build_resources_default_uses_threads() -> None:
@@ -105,3 +105,100 @@ def test_cancel_jobs_does_not_close_client() -> None:
 
     assert future.cancelled is True
     assert closed["count"] == 0, "cancel_jobs must not close the dask client"
+
+
+def test_run_shell_returns_sentinel_block() -> None:
+    """Sentinel-prefixed lines come back (prefix intact) as the block;
+    everything else is dropped."""
+    from lightcone.engine.runner import SENTINEL
+
+    rc, block = _run_shell(
+        f"echo '{SENTINEL}hello'; echo noise; echo '{SENTINEL}world' >&2"
+    )
+    assert rc == 0
+    assert block == f"{SENTINEL}hello\n{SENTINEL}world\n"
+
+
+def test_run_shell_failure_without_sentinel_forwards_raw_tail() -> None:
+    """A child snakemake that dies before the rule body (import error,
+    missing package in the worker image) must not vanish into worker
+    logs — its raw output comes back sentinel-framed."""
+    from lightcone.engine.runner import SENTINEL
+
+    rc, block = _run_shell("echo bootstrap-crash >&2; exit 3")
+    assert rc == 3
+    assert block.startswith(SENTINEL)
+    assert "bootstrap-crash" in block
+
+
+def test_run_shell_success_drops_noise() -> None:
+    rc, block = _run_shell("echo just-noise")
+    assert rc == 0
+    assert block == ""
+
+
+def test_unpack_result_accepts_legacy_int() -> None:
+    """Workers running an older lightcone-cli release return a bare int."""
+    from snakemake_executor_plugin_dask.executor import _unpack_result
+
+    assert _unpack_result(1) == (1, "")
+    assert _unpack_result((0, "block\n")) == (0, "block\n")
+
+
+def test_connect_client_requires_rendezvous(
+    monkeypatch: object,
+) -> None:
+    import pytest
+    from snakemake_interface_common.exceptions import WorkflowError
+
+    from snakemake_executor_plugin_dask.executor import _connect_client
+
+    monkeypatch.delenv("DASK_SCHEDULER_ADDRESS", raising=False)  # type: ignore[attr-defined]
+    monkeypatch.delenv("LIGHTCONE_GATEWAY_CLUSTER", raising=False)  # type: ignore[attr-defined]
+    with pytest.raises(WorkflowError, match="LIGHTCONE_GATEWAY_CLUSTER"):
+        _connect_client()
+
+
+def test_connect_client_gateway_rendezvous_by_name(
+    monkeypatch: object,
+) -> None:
+    """With LIGHTCONE_GATEWAY_CLUSTER set, the executor rejoins the run's
+    cluster through the Gateway API — never dials gateway:// directly."""
+    import sys
+    from types import SimpleNamespace
+
+    from snakemake_executor_plugin_dask.executor import _connect_client
+
+    record: dict[str, object] = {}
+
+    class _FakeClient:
+        def close(self) -> None:
+            record["client_closed"] = True
+
+    class _FakeCluster:
+        def get_client(self) -> _FakeClient:
+            return _FakeClient()
+
+        def close(self) -> None:
+            record["cluster_closed"] = True
+
+    class _FakeGateway:
+        def connect(self, name: str, shutdown_on_close: bool = True):
+            record["connected"] = name
+            record["shutdown_on_close"] = shutdown_on_close
+            return _FakeCluster()
+
+    monkeypatch.setitem(  # type: ignore[attr-defined]
+        sys.modules, "dask_gateway", SimpleNamespace(Gateway=_FakeGateway)
+    )
+    monkeypatch.setenv("LIGHTCONE_GATEWAY_CLUSTER", "hub.abc")  # type: ignore[attr-defined]
+    monkeypatch.delenv("DASK_SCHEDULER_ADDRESS", raising=False)  # type: ignore[attr-defined]
+
+    client, closer = _connect_client()
+    assert record["connected"] == "hub.abc"
+    assert record["shutdown_on_close"] is False, (
+        "the executor is a guest — closing it must not cull the run's cluster"
+    )
+    closer()
+    assert record.get("client_closed") is True
+    assert record.get("cluster_closed") is True

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -361,3 +361,30 @@ def test_read_manifest_propagates_oserror(tmp_path: Path) -> None:
             read_manifest(out)
     finally:
         manifest_path.chmod(0o644)
+
+
+def test_manifest_records_worker_image_from_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On a Gateway deployment the pod env carries the image it was
+    started with — the manifest records it as ground truth."""
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "data.txt").write_text("x")
+    cfg = {
+        "output_id": "o",
+        "universe_id": "u",
+        "recipe": "echo",
+        "container_image": "Containerfile",
+        "decisions": {},
+        "code_version": "sha256:x",
+        "git_sha": None,
+        "lc_version": "0",
+    }
+    monkeypatch.delenv("LIGHTCONE_WORKER_IMAGE", raising=False)
+    write_manifest(output_dir=out, inputs={}, cfg=cfg)
+    assert read_manifest(out)["worker_image"] is None
+
+    monkeypatch.setenv("LIGHTCONE_WORKER_IMAGE", "reg/lc-p:abc")
+    write_manifest(output_dir=out, inputs={}, cfg=cfg)
+    assert read_manifest(out)["worker_image"] == "reg/lc-p:abc"

--- a/tests/test_scratch.py
+++ b/tests/test_scratch.py
@@ -123,12 +123,11 @@ def test_prepare_run_dirs_creates_layout(
     rd = prepare_run_dirs(project, run_id="42")
     assert rd.root == tmp_path / "scratch" / ".lightcone"
     assert rd.dask_local == rd.root / "dask" / "42"
-    assert rd.lock_path == rd.root / "locks" / "42.lock"
     assert rd.snakemake_state.parent.parent == rd.root / "snakemake"
     # Every path that callers rely on must exist on return.
     assert rd.root.is_dir()
     assert rd.dask_local.is_dir()
-    assert rd.lock_path.is_file()
+    assert rd.run_lock_path.is_file()
     assert rd.snakemake_state.parent.is_dir()
 
 

--- a/tests/test_site_registry.py
+++ b/tests/test_site_registry.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 
@@ -95,3 +96,60 @@ class TestDetectCurrentSite:
         # returning an empty HostSite rather than None.
         fake_hostname("generic-laptop")
         assert detect_current_site().get("scratch_root", "/tmp") == "/tmp"
+
+
+# ---- env-marker detection (JupyterHub deployments) ------------------------
+
+
+def test_detect_site_from_env_matches_jupyterhub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lightcone.engine.site_registry import detect_site_from_env
+
+    monkeypatch.delenv("DASK_GATEWAY__ADDRESS", raising=False)
+    assert detect_site_from_env() is None
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    assert detect_site_from_env() == "jupyterhub"
+
+
+def test_env_markers_win_over_hostname(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pod's hostname is noise; the injected env is the signal."""
+    from lightcone.engine.site_registry import detect_current_site
+
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    monkeypatch.setattr(
+        "lightcone.engine.site_registry.socket.gethostname",
+        lambda: "login29.chn.perlmutter.nersc.gov",
+    )
+    site = detect_current_site()
+    assert site.key == "jupyterhub"
+    assert site.get("container_runtime") == "kubernetes"
+    assert site.get("scratch_root") == "$HOME"
+
+
+def test_no_markers_falls_back_to_hostname(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lightcone.engine.site_registry import detect_current_site
+
+    monkeypatch.delenv("DASK_GATEWAY__ADDRESS", raising=False)
+    monkeypatch.setattr(
+        "lightcone.engine.site_registry.socket.gethostname",
+        lambda: "login29.chn.perlmutter.nersc.gov",
+    )
+    assert detect_current_site().key == "perlmutter"
+
+
+def test_hub_scratch_resolves_to_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No separate scratch space on the hub — home IS the shared volume."""
+    import os
+
+    from lightcone.engine.scratch import resolve_scratch_root
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    monkeypatch.delenv("LIGHTCONE_SCRATCH", raising=False)
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    assert resolve_scratch_root(project) == Path(os.environ["HOME"])

--- a/tests/test_snakefile.py
+++ b/tests/test_snakefile.py
@@ -561,3 +561,39 @@ class TestGitRemote:
 
     def test_returns_none_when_empty_url(self, git_remote) -> None:
         assert git_remote("\n") is None
+
+
+def test_generate_kubernetes_runtime_unwrapped_with_registry_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On the kubernetes runtime the worker pod runs the project image:
+    recipes stay unwrapped, and the image identity that flows into
+    code_version is the registry ref, so a Containerfile edit (new ref)
+    still triggers reruns."""
+    (tmp_path / "Containerfile").write_text("FROM python:3.12-slim\n")
+    _spec(
+        tmp_path,
+        {
+            "name": "proj",
+            "container": "Containerfile",
+            "outputs": [{"id": "foo", "recipe": {"command": "echo foo"}}],
+        },
+    )
+    monkeypatch.setenv(
+        "LIGHTCONE_REGISTRY", "europe-west1-docker.pkg.dev/hub/images"
+    )
+    _, cfg_path = generate(tmp_path, universes=["u1"], runtime="kubernetes")
+    entry = json.loads(cfg_path.read_text())["foo"]["u1"]
+
+    assert "docker run" not in entry["shell_command"]
+    assert "podman" not in entry["shell_command"]
+    assert "echo foo" in entry["shell_command"]
+    # The declared spec is what the manifest records — unchanged.
+    assert entry["container_image"] == "Containerfile"
+
+    # Same spec, docker runtime (local tag, no registry): different
+    # image identity → different code_version.
+    monkeypatch.delenv("LIGHTCONE_REGISTRY")
+    _, cfg_path2 = generate(tmp_path, universes=["u1"], runtime="docker")
+    entry2 = json.loads(cfg_path2.read_text())["foo"]["u1"]
+    assert entry["code_version"] != entry2["code_version"]

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 from lightcone.engine.manifest import code_version, write_manifest
@@ -163,3 +164,40 @@ def test_status_universe_specific(tmp_path: Path) -> None:
     _materialize(tmp_path, "foo", "u1", recipe="echo foo")
     statuses = list(get_output_status(tmp_path, universe_id="u2"))
     assert statuses[0].status == "missing"
+
+
+def test_status_ok_on_kubernetes_deployment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On a hub, `lc run` hashes the registry ref into code_version;
+    status must resolve the image identity the same way or every
+    freshly materialized output reads as stale (live-hub regression)."""
+    from lightcone.engine.container import registry_image_ref
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setenv("DASK_GATEWAY__ADDRESS", "http://proxy/services/dask-gateway")
+    monkeypatch.setenv(
+        "LIGHTCONE_REGISTRY", "europe-west1-docker.pkg.dev/hub/images"
+    )
+
+    _write_spec(
+        tmp_path,
+        {
+            "name": "proj",
+            "container": "Containerfile",
+            "outputs": [{"id": "foo", "recipe": {"command": "echo foo"}}],
+        },
+    )
+    (tmp_path / "Containerfile").write_text("FROM python:3.12-slim\n")
+    ref = registry_image_ref(
+        "proj",
+        tmp_path / "Containerfile",
+        tmp_path,
+        registry="europe-west1-docker.pkg.dev/hub/images",
+    )
+    _materialize(
+        tmp_path, "foo", "baseline", recipe="echo foo", container_image=ref
+    )
+
+    statuses = list(get_output_status(tmp_path, universe_id="baseline"))
+    assert [s.status for s in statuses] == ["ok"]

--- a/zensical.toml
+++ b/zensical.toml
@@ -37,6 +37,7 @@ nav = [
       {"engine/manifest" = "api/manifest.md"},
       {"engine/snakefile" = "api/snakefile.md"},
       {"engine/container" = "api/container.md"},
+      {"engine/cloudbuild" = "api/cloudbuild.md"},
       {"engine/status" = "api/status.md"},
       {"engine/verify" = "api/verify.md"},
       {"engine/tree" = "api/tree.md"},


### PR DESCRIPTION
## Summary

Implements the [Kubernetes/JupyterHub-on-GCP PRD](https://linear.app/lightcone-research/document/prd-integration-with-kubernetes-and-jupyterhub-on-gcp-29f86d16fcbb) (LCR-174) against the **hub-deploy `dask-cloudbuild` deployment**: on a lightcone hub, `lc run` makes sure the project image is up to date (building through **GCP Cloud Build** when needed), **creates a run-scoped Dask Gateway cluster with that image, runs the pipeline in worker pods, and culls the cluster when the run finishes** — the exact same zero-configuration UX as on a laptop or a SLURM allocation. Everything keys off the env contract the deployment injects into user pods (`DASK_GATEWAY__*`, `LIGHTCONE_REGISTRY`, `LIGHTCONE_BUILD_BUCKET`, `LIGHTCONE_BUILD_SERVICE_ACCOUNT`); nothing is configured by the user.

## Design

**One new runtime, not a new subsystem.** The spec already routes everything through two seams — the container runtime (`wrap_recipe`, image resolution) and the cluster context (`cluster_for_run`) — so the k8s integration is a value flowing through existing seams:

- **`kubernetes` runtime** (`engine/container.py`): the worker pod *is* the container. `wrap_recipe` is a passthrough (no nested containers), and Containerfile specs resolve to registry refs. One content-addressed identity everywhere: `image_identity()` yields the digest that spells `lc-<project>-<hash>` in a local store and `$LIGHTCONE_REGISTRY/lc-<project>:<hash>` in the registry — so `code_version`, staleness, and reruns work identically on every backend.
- **Build backend** (`engine/cloudbuild.py`, ~400 lines): selected when the deployment contract is present. Freshness is a single registry HEAD on the content-addressed ref — unchanged files never rebuild, never even upload. A build tars the **staged build context** (the exact file set the tag hashes), uploads it to the deployment's GCS bucket, and submits a Cloud Build job that runs as the deployment's least-privilege build SA. Auth is the pod's Workload Identity via the metadata server — pure `urllib`, no SDK dependency, no git remote, no stored credentials. Failures surface the build-log tail.
- **Gateway branch of `cluster_for_run`** (`engine/dask_cluster.py`): create a cluster with the project image as the `image` cluster option, scale adaptively `1..--jobs`, wait (bounded, default 600 s) for the first worker so an unpullable image fails loudly instead of hanging at zero workers, and **shut the cluster down on exit — success or failure**. Create/cull per run is PRD decision #1 and is also what makes image updates seamless: a Gateway cluster's image is fixed at creation. A startup assertion refuses clusters whose workers don't advertise the `cpus`/`memory` resource contract (the other silent-hang mode).
- **Self-provisioned worker environment — the deployment stays near-stock**: lc reads the gateway's declared cluster options and passes everything workers need through the *standard* `environment` option — the `DASK_DISTRIBUTED__WORKER__RESOURCES__*` scheduling contract mirrored from the declared `worker_cores`/`worker_memory`, the driver's `HOME`/`USER`/`LOGNAME` (passwd-less uid-1000 images crash `getpass.getuser()` without them), and `LIGHTCONE_WORKER_IMAGE` (covering the deployment-default-image case too), preserving any deployment-declared environment defaults underneath. The hub's options handler reduces to the stock 2i2c daskhub shape (cores/memory/image/environment) plus the per-user home mount — zero lightcone-specific injection server-side (hub-deploy `e10088c`).
- **Executor rendezvous by name**: `gateway://` schedulers can't be dialled by a bare `Client`, so `lc run` hands the executor the cluster name (`LIGHTCONE_GATEWAY_CLUSTER`) and it rejoins through the authenticated Gateway API as a guest (`shutdown_on_close=False`).
- **Output through the future result**: worker pods' stdout goes to pod logs, so `_run_shell` now returns `(exit_code, sentinel_block)` and the driver prints each finished rule's block — the one channel that works uniformly across LocalCluster threads, srun workers, and Gateway pods. This **retires the cross-node stdout `flock`** entirely (one less NFS/DVS concern), and a child snakemake that dies before the rule body (missing package in the worker image) forwards a bounded raw tail instead of vanishing (PRD architecture bullet / LCR-175 semantics). Legacy bare-`int` results from older workers are still accepted (version skew on image-based deployments). The executor also prefixes every spawned job with `cd <workdir>` — spawned snakemake commands carry no `--directory`, and Gateway worker pods start in the image's `WORKDIR`, not the project (local/SLURM workers only worked by inheriting the driver's cwd).
- **Site detection by env markers** (`engine/site_registry.py`): a pod's hostname is noise; `DASK_GATEWAY__ADDRESS` is the signal. The `jupyterhub` site declares `container_runtime: kubernetes` and `scratch_root: $HOME` — **no separate scratch space on the hub**; home is the NFS volume shared with every worker pod, so driver and workers see one consistent snakemake state.
- **One snakemake invocation on every backend**: `--shared-fs-usage` minus `software-deployment` is unconditional, so spawned jobs always run plain `python` from the worker's own environment (the worker image on the gateway; the driver's activated env locally/SLURM) instead of embedding the driver's `sys.executable`. No gateway-specific flags remain (`--latency-wait` dropped — the NFS latency was not reproducible in recent tests).
- **Environment-agnostic scaffold** — `lc init` writes the same Containerfile everywhere; `requirements.txt` pins `lightcone-cli`, which carries the whole execution stack (snakemake, dask, distributed, dask-gateway — now a normal dependency, no `[gateway]` extra). No uid/USER is baked into the image: cluster pods run as the notebook uid via the deployment's `securityContext` (hub-deploy `c8dc6cd`), and `getpass.getuser()` works through the lc-provisioned `USER`/`LOGNAME`/`HOME` (LCR-176 Part A).
- **Provenance**: the manifest keeps recording the declared spec, `code_version` hashes the registry ref (Containerfile edit → new ref → rerun), and a new additive `worker_image` field records `LIGHTCONE_WORKER_IMAGE` — provisioned into every pod by lc itself — as ground truth of what actually executed.

A spec declaring several distinct containers is rejected on this backend with guidance (the worker pod image is fixed per run — LCR-176 note); a project with no containers runs on the deployment's default image.

## Out of scope (per PRD)

- Cluster lifecycle beyond one run (clusters never survive between `lc run` calls).
- Non-GCP build backends; general k8s support beyond the lightcone hub contract.

## Relation to #162

Same PRD, different mechanism: #162 built through the BinderHub service (git-ref-based, requires committed/pushed state and a GitHub connect flow). This PR targets the newer Cloud-Build-based deployment (hub-deploy `dask-cloudbuild`), where builds are git-free tarball submissions — which removes the GitHub coupling and most of the surface area (~1.1k src lines vs ~4k).

## Testing

- `just lint` clean (ruff + strict mypy), **388 tests pass** (+55 new: Cloud Build control flow against mocked HTTP seams incl. failure-tail and force-rebuild, gateway create/cull lifecycle incl. failure-path culling and zero-worker timeout, self-provisioned worker environment, an image-override regression test against the real dask-gateway client (lc's explicit image must beat the ambient `DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE` default), executor rendezvous-by-name / workdir-prefix / legacy-result unpacking, sentinel-block forwarding, env-marker site detection, hub scratch resolution, runtime-aware status resolution, kubernetes-runtime Snakefile generation, environment-agnostic `lc init` scaffold).
- **Live end-to-end validated on the deployed lightcone hub** (project `union2.1_lcdm_fit`, user pod → Cloud Build cached-image check → run-scoped Gateway cluster with the project image → all four rules executed in worker pods with per-rule output on the driver terminal → `lc verify` green, manifests recording `worker_image` ground truth → cluster culled on exit). The live test surfaced and fixed three integration bugs: gateway pods must use the modern `dask scheduler`/`dask worker` subcommands (deployment-side, hub-deploy `bfec4ab`), the executor must `cd` into the workdir for spawned jobs (`c7b18e3`), and the status walker must resolve image identities runtime-aware (`50508b9`). A second live validation (forced full re-run) was done after the near-stock streamlining (`3533b25` + hub-deploy `e10088c`): all rules on workers, `lc status`/`lc verify` green, manifests carrying the lc-provisioned `worker_image`, cluster culled — and the run automatically picked up a changed build context (new content hash → Cloud Build → fresh cluster on the new image).

Refs: LCR-174 (PRD), LCR-176 (Part A + build path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wg3CVQ5oYWJBCfq58Z8d2


