### PR TITLE
Use the ASTRA article theme for generated MyST reports

### DIFF
--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -406,7 +406,7 @@ project:
   toc:
     - file: index.md
 site:
-  template: book-theme
+  template: https://github.com/LightconeResearch/astra-article-theme.git
 """
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,6 +82,7 @@ def test_init_creates_report_template(runner: CliRunner, tmp_path: Path) -> None
 
     myst_yml = (project / "myst.yml").read_text()
     assert "mystra.mjs" in myst_yml
+    assert "https://github.com/LightconeResearch/astra-article-theme.git" in myst_yml
     assert "index.md" in myst_yml
 
     index_md = (project / "index.md").read_text()


### PR DESCRIPTION
## Summary

- Replace the default MyST `book-theme` with the latest organization-owned ASTRA article theme.
- Keep the existing MySTRA `releases/latest` configuration unchanged.
- Verify generated projects point at `LightconeResearch/astra-article-theme`.

## Testing

- `uv run pytest -q` — 389 passed
- `uv run ruff check src tests`
- `uv run mypy src`

## Dependency

This draft depends on [astra-theme #5](https://github.com/LightconeResearch/astra-theme/pull/5) and the public `LightconeResearch/astra-article-theme` repository being transferred or created. Do not merge until that URL serves the published theme bundle; the end-to-end MyST fetch cannot pass before then.
