### PR TITLE
Bump gh-action-pypi-publish to v1.14.2 for metadata 2.5 support

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -72,6 +72,6 @@ jobs:
 
       # https://github.com/pypa/gh-action-pypi-publish
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           verbose: true


### PR DESCRIPTION
## Summary

The v0.4.1 release's PyPI publish failed before upload with:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Ecosystem skew, not a problem with the release: the build step uses latest hatchling, which now emits `Metadata-Version: 2.5`, while `gh-action-pypi-publish@v1.14.0` (April) bundles a Twine that predates it. Per the v1.14.1 release notes, the action's internal Twine was updated to v7, which accepts metadata 2.5. This bumps the pin to v1.14.2 (latest).

## After merging

The v0.4.1 tag points at the pre-fix commit, so re-running the failed workflow run would fail identically (release workflows execute the workflow file at the tag's ref). Since nothing reached PyPI, either:
- delete the v0.4.1 release + tag and recreate them on the new main HEAD, or
- cut v0.4.2 directly from the fixed main.

## Test plan

- [x] Failure reproduced from the run logs; fix matches the upstream release notes for v1.14.1 ("upload … wheels containing core packaging metadata v2.5")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EL5bESx3CqfMNZNPA1KHJ