### PR TITLE
Docs: add early-alpha warning to landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,13 @@
 It serves as the machinery that ties an analysis `astra.yaml` specification to a tree
 of materialized outputs.
 
+!!! warning "Alpha development"
+    lightcone-cli is in **early alpha**. The CLI, skills, and execution layer are all
+    still moving — expect breaking changes between minor versions. Bug reports, design
+    challenges, and use cases the tooling doesn't yet cover are exactly what we want to
+    hear at this stage; please open an issue on the
+    [GitHub repo](https://github.com/LightconeResearch/lightcone-cli/issues).
+
 ## Choose your path to the documentation
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
Adds an early-alpha admonition to the docs landing page, mirroring the one on the ASTRA spec site: breaking changes expected between minor versions, and a pointer to the issue tracker for bug reports and design feedback.

The docs have already been redeployed from this branch via workflow_dispatch (no release/version change); merging keeps the warning in place for future release-triggered deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RdnNAzntq6EYuJw9rGNQf