### PR TITLE
Layer 3: the launcher, and the environment the engine actually runs in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ speculatively.
 |---|-------|-------|
 | 1 | **Project scaffolding** — `lc init` | ✅ **done** |
 | 2 | **Environment layer** — `env_version`, lock scan, manifest schema | ✅ **done** |
-| 3 | The `lc` entrypoint — launcher: discover → mode-detect → scrub `UV_*` → converge → delegate | ⬜ |
+| 3 | **The `lc` entrypoint** — launcher: scrub `UV_*` → converge → delegate | ✅ **done** |
 | 4 | **Fabric** — `lc materialize`, worker sequence, mid-run relock gate | ✅ **done** |
 | 5 | **Sandbox layer** — Landlock / Seatbelt, exec-shim, denial UX, `lc run` | ✅ **done** |
 | 6 | Container hatch — `[tool.lightcone.image]`, generated Containerfile, `lc build` | ⬜ |
@@ -149,8 +149,9 @@ Any new `lightcone-*` package must:
 src/lightcone/              # namespace — NO __init__.py
 ├── _sandbox_exec.py        # the Landlock shim — stdlib only, zero lightcone imports
 ├── cli/                    # the CLI only: flags, rendering, exit codes
-│   ├── __init__.py         # exposes main(); the launcher hooks in here (layer 3)
-│   └── commands.py         # lc init, lc run, lc materialize
+│   ├── __init__.py         # exposes main(); delegation happens here, before click
+│   ├── launcher.py         # converge, then exec the project's own engine
+│   └── commands.py         # lc init, lc run, lc materialize, lc status
 └── engine/
     ├── __init__.py         # docstring only
     ├── project.py          # what a project is: convergence + discovery
@@ -1046,6 +1047,109 @@ larger than a laptop land behind it without the driver noticing.
   not argv, and `bash` is in the exec allowlist — so it is granted by the
   same rule that grants everything else a recipe may run.
 
+## Key Invariants (layer 3)
+
+**`lc` and the engine are two different programs, and the launcher is
+where they meet.** `lc` is installed once as a uv tool; the engine that
+executes a project lives inside that project's own lock, because `lc init`
+pins `lightcone-cli` into its dependencies so the engine that produced a
+result stays recoverable from the commit that recorded it. Before click
+sees an argument, `cli/launcher.py` converges the project's environment and
+`exec`s the `lc` inside it.
+
+What this fixed was not hypothetical: `cluster_for_run()` builds a
+`LocalCluster(processes=False)`, so the driver, the graph, `astra.resolve`,
+the classifier and `worker.materialize` all ran in the *invoking* process,
+while `_lc_version()` resolved `importlib.metadata` against that same
+process. A project whose lock pinned engine A could be materialized by
+engine B, with the manifest recording both and reconciling neither.
+
+**The delegation interface is argv plus one variable, and that is
+deliberate.** `LC_DELEGATED=1` is the whole of what crosses. A launcher of
+any version has to be able to hand over to a project engine of any age, so
+anything richer is something the two would have to agree about — and the
+older half cannot be changed.
+
+**The launcher decides four things and writes no errors of its own.**
+
+| Question | Answer |
+|---|---|
+| Already delegated? | Return. The engine we exec runs this same code on the way in. |
+| A verb at all, and not `init`? | `init` is what *makes* the environment a delegation would hand over to. Everything else delegates — including `status`. |
+| Is the current directory a uv project? | If not, **decline silently**: `current_project()` already says why, and a second copy of that message here could only disagree with it. |
+| Are we already the project's engine? | `uv run lc …` arrives inside the project's environment; delegating would re-exec this program to reach itself and re-converge what uv just converged. |
+
+**`lc status` delegates, against spec §4.** It and `materialize --check` run
+the same classification walk, and `definition_version` hashes what
+`astra.resolve.render_command` produced — so two astra versions can render
+one recipe differently. Leaving status in the tool env is the one way to
+make two verbs that must differ only in exit code disagree on the answer.
+The price, stated where the promise is written: status converges before it
+answers. Its "reads only" promise is about the analysis and the repository,
+never about not touching `.venv`.
+
+**A converged `.venv` with no `lc` in it is a refusal**, naming
+`uv add lightcone-cli`. Never a fall-through to the tool env — that
+fall-through *is* the silent skew the layer removes.
+
+**There is no discovery step**, where spec §4 walks up looking for
+`astra.yaml`. The current directory is the project, as everywhere else.
+
+**A parity test is the only thing binding the launcher to the CLI.** The
+launcher never imports `commands.py`, so `TOOL_ENV_VERBS` and the click
+group could drift apart in silence — a verb added without a routing
+decision would delegate by default, into an engine that may be too old to
+know it, failing far from its cause.
+`tests/test_launcher.py::test_every_verb_has_a_routing_decision` asserts
+the two partitions agree.
+
+**Startup stays cheap, and the launcher is on every invocation.** Stdlib
+only — no click, no rich, no astra — and the engine import happens *after*
+the decision to delegate, so a verbless `lc --help` pays for none of it.
+Measured through the installed console script: 91 ms, no converge, no exec.
+
+### The `UV_*` scrub
+
+**It lives in `project.child_env()`, not in the launcher.** That is the one
+seam every external tool goes through, so one edit covers convergence, a
+run's sync, the recipe's `uv run` hop *and* the delegation exec; a
+launcher-only scrub would cover the last of those alone.
+
+**The list is closed and audited, exactly like `identity._INSTALL_SETTINGS`
+— and for the same reason.** A set that grew by guesswork would strip a
+variable someone legitimately relies on. Every entry was verified read by
+uv 0.12.5, by giving it an unparseable value and watching uv reject it.
+Three families, and nothing else qualifies:
+
+- **where the environment goes, and which interpreter builds it** —
+  measured, `UV_PROJECT_ENVIRONMENT` relocates the venv outright and
+  `UV_PYTHON` changes the interpreter, while every flag lc passes stays the
+  same. `--project` is no defence against either.
+- **which artifacts a sync materializes from an unchanged lock** — the
+  environment spellings of the audited install settings, plus the family
+  that actually spells `default-groups` on a command line
+  (`UV_NO_DEFAULT_GROUPS`, `UV_NO_DEV`, `UV_DEV`) and the install-shape
+  flags. These are the dangerous ones: `env_version` hashes those settings
+  *from the project's files*, so an ambient one changes what is installed
+  **without moving the hash**, and the identity model says something
+  untrue.
+- **what lc's own flags mean** — `UV_FROZEN` would defeat the `--locked`
+  that makes a drifted lock an error rather than a silent relock.
+
+**What is deliberately kept.** `UV_CACHE_DIR` and `UV_LINK_MODE` decide
+where bytes are cached and how they are linked, never what is installed —
+and they are exactly what a site registry supplies on a machine whose cache
+cannot live in `$HOME`. Credentials and TLS settings stay too: without them
+a private index cannot be fetched from at all. `UV_PROJECT` needs no scrub
+— measured, the explicit `--project` every invocation carries already beats
+it.
+
+**The scrub and the identity model are held together by a test**, not by
+memory: `test_every_audited_install_setting_is_scrubbed` derives each
+setting's environment spelling and asserts it is scrubbed, so adding a
+setting to the hash without adding it to the scrub fails rather than
+quietly reopening the hole.
+
 ## Key Invariants (layer 5)
 
 **The seam is a pure argv rewrite.** Every mechanism is a
@@ -1375,7 +1479,7 @@ only checks that the guard is present. Verified empirically, not assumed.
 | Change how the spec becomes a graph | `src/lightcone/engine/plan.py` + `tests/test_plan.py` | Ask `astra.resolve`; if the answer is missing, the fix is a PR to astra-tools. Anything ambiguous is a `ProjectError`, never a guess |
 | Change how a recipe runs | `src/lightcone/engine/worker.py` + `tests/test_worker.py` | Never raises, never writes git; mutation-check every denial test |
 | Change what a run commits | `src/lightcone/engine/materialize.py` + `tests/test_materialize.py` | The driver owns git alone; the tree ends as clean as it started |
-| Add a CLI verb | `src/lightcone/cli/commands.py` | `@main.command()`; keep logic in the engine, raise `ProjectError`, render here |
+| Add a CLI verb | `src/lightcone/cli/commands.py` + `cli/launcher.py` | `@main.command()`; keep logic in the engine, raise `ProjectError`, render here. Decide whether it delegates — the parity test fails until you do |
 | Add a sandbox mechanism | `src/lightcone/engine/sandbox/` | One module with a `Backend` (`wrap` pure, `attest` honest) + one line in `detect()`. Nothing above the seam changes |
 | Change what a sandboxed command may touch | `sandbox/policy.py` + `tests/test_sandbox_policy.py` | Path sets only — no mechanism ever leaks in here |
 | Change a denial message | `sandbox/denial.py` + `tests/test_sandbox_denial.py` | Remedies must be copy-pasteable and real *today*; the trailer stays unconditional |
@@ -1421,6 +1525,15 @@ only checks that the guard is present. Verified empirically, not assumed.
 - `tests/test_cli.py` — the CLI surface only: flags reaching the engine,
   rendering, exit codes, error translation. Rich wraps output at terminal
   width, so assert on short unwrappable fragments.
+- `tests/test_launcher.py` — routing, the frozen interface, and what the
+  scrub lets through. `os.execve` is faked by *raising* `SystemExit`, since
+  a fake that returned would let a test run on through code the real caller
+  can never reach. One test runs a genuine `os.execve` in a subprocess
+  against a shell-script stand-in for the project's engine: everything else
+  fakes the exec, and so cannot catch an argv that is well-formed and
+  unrunnable. `test_cli.py` is untouched by all of this — it drives
+  `cli.commands.main` through `CliRunner`, while delegation hooks into
+  `cli/__init__.py`, which the suite never calls.
 - `tests/test_templates.py` — template loading (guards the packaging of
   package data), strict substitution, and the `.gitignore` /
   `.gitattributes` entry/repair logic. Content assertions live here; `test_project.py` asserts only that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1076,8 +1076,27 @@ older half cannot be changed.
 |---|---|
 | Already delegated? | Return. The engine we exec runs this same code on the way in. |
 | A verb at all, and not `init`? | `init` is what *makes* the environment a delegation would hand over to. Everything else delegates — including `status`. |
-| Is the current directory a uv project? | If not, **decline silently**: `current_project()` already says why, and a second copy of that message here could only disagree with it. |
-| Are we already the project's engine? | `uv run lc …` arrives inside the project's environment; delegating would re-exec this program to reach itself and re-converge what uv just converged. |
+| Does `.venv/bin/lc` already exist? | One stat, and it answers both questions worth asking: this is a built project, and it carries an engine of its own. If not, **decline silently** — `current_project()` already says why, and a second copy of that message here could only disagree with it. |
+| Are we already inside that environment? | `uv run lc …` arrives there; delegating would re-exec this program to reach itself. |
+
+**The engine check comes *before* the converge, and that ordering is the
+whole of it.** `uv sync --exact` *uninstalls* whatever the lock does not
+name, so converging first would let `lc status`, typed in an unrelated uv
+checkout, rewrite someone else's environment on its way to reporting that
+lc is not installed there. Gating on an engine that is already present
+means a project that is not ours is never written to — and it is also why
+there is no "run `uv add lightcone-cli`" refusal: a project without an
+engine of its own is simply the tool env's to run, and convergence already
+warns about the missing dependency.
+
+**"Am I already in that environment" is asked of `sys.prefix`, never
+`sys.executable`.** `.venv/bin/python` is a symlink out to the base
+interpreter, so `Path(sys.executable).resolve().parent` names the
+interpreter's own directory and is *never* the venv's `bin` — a guard
+written that way is dead, and a test that monkeypatches `sys.executable`
+to a path the fixture never created will pass over it. `sys.prefix` is the
+venv root, symlink-free, and is the question itself rather than a proxy
+for it.
 
 **`lc status` delegates, against spec §4.** It and `materialize --check` run
 the same classification walk, and `definition_version` hashes what
@@ -1087,10 +1106,6 @@ make two verbs that must differ only in exit code disagree on the answer.
 The price, stated where the promise is written: status converges before it
 answers. Its "reads only" promise is about the analysis and the repository,
 never about not touching `.venv`.
-
-**A converged `.venv` with no `lc` in it is a refusal**, naming
-`uv add lightcone-cli`. Never a fall-through to the tool env — that
-fall-through *is* the silent skew the layer removes.
 
 **There is no discovery step**, where spec §4 walks up looking for
 `astra.yaml`. The current directory is the project, as everywhere else.
@@ -1105,8 +1120,26 @@ the two partitions agree.
 
 **Startup stays cheap, and the launcher is on every invocation.** Stdlib
 only — no click, no rich, no astra — and the engine import happens *after*
-the decision to delegate, so a verbless `lc --help` pays for none of it.
-Measured through the installed console script: 91 ms, no converge, no exec.
+the decision to delegate, so a verbless `lc --help` pays for none of it:
+not the 18 ms of `engine.project`, and not a single `stat`, since nothing
+touches the filesystem before the verb is known. Measured through the
+installed console script: 91 ms, no converge, no exec.
+
+**The converge verifies before it writes** (`project.converge_environment`).
+A full `uv sync --locked --exact --compile-bytecode` costs ~100 ms against
+an environment that needs nothing, where uv's own read-only probe costs
+~15 ms — and the launcher runs on every delegating verb, ahead of the sync
+`materialize` does for its own reasons. The split from `sync()` is
+deliberate and not an optimization to propagate: the probe is *set-level*,
+so a hand-installed extra survives it where `--exact` would prune one. That
+is the right trade for a caller that needs the environment to **be** the
+lock's, and the wrong one for a run that needs it to be **nothing but** the
+lock's — which is why `materialize` still syncs unconditionally.
+
+**`require_uv()` lives inside `sync()`**, not at each call site. It was
+added there after the launcher — a fourth caller — forgot it, and the
+failure was a raw `FileNotFoundError` out of `Popen` in the one code path
+that runs before click can render anything.
 
 ### The `UV_*` scrub
 
@@ -1119,7 +1152,7 @@ launcher-only scrub would cover the last of those alone.
 — and for the same reason.** A set that grew by guesswork would strip a
 variable someone legitimately relies on. Every entry was verified read by
 uv 0.12.5, by giving it an unparseable value and watching uv reject it.
-Three families, and nothing else qualifies:
+Four families, and nothing else qualifies:
 
 - **where the environment goes, and which interpreter builds it** —
   measured, `UV_PROJECT_ENVIRONMENT` relocates the venv outright and
@@ -1135,6 +1168,14 @@ Three families, and nothing else qualifies:
   untrue.
 - **what lc's own flags mean** — `UV_FROZEN` would defeat the `--locked`
   that makes a drifted lock an error rather than a silent relock.
+- **which settings apply at all** — `UV_NO_CONFIG` makes uv ignore
+  `[tool.uv]` and `uv.toml`, the very files `identity` hashes, and
+  `UV_CONFIG_FILE` substitutes another for them. Neither is a setting, so
+  the derived correspondence test cannot reach them; both belong to the
+  family above by consequence. Distinguish these from the *user-level*
+  `~/.config/uv/uv.toml` that `identity` deliberately tolerates as machine
+  state — these two change whether the project's own configuration is read
+  at all.
 
 **What is deliberately kept.** `UV_CACHE_DIR` and `UV_LINK_MODE` decide
 where bytes are cached and how they are linked, never what is installed —

--- a/src/lightcone/cli/__init__.py
+++ b/src/lightcone/cli/__init__.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+import sys
+
 
 def main() -> None:
     """Run the CLI.
 
-    The console-script entry point. Imports the command module lazily, so
-    the cost of click and the engine is paid only once a command runs.
+    The console-script entry point. Delegation comes first and click
+    second: the engine that runs a project is the one inside its lock, and
+    deciding that has to happen before any of this environment's modules
+    are imported and used. Both imports are lazy, so ``lc --help`` and
+    shell completion pay for neither.
     """
+    from lightcone.cli.launcher import maybe_delegate
+
+    maybe_delegate(sys.argv[1:])
+
     from lightcone.cli.commands import main as _main
 
     _main()

--- a/src/lightcone/cli/launcher.py
+++ b/src/lightcone/cli/launcher.py
@@ -24,9 +24,11 @@ Three things it does not do:
 - **It does not report that a directory is not a project.** It simply
   declines to delegate, and the engine's own message says why — one
   error, written once.
-- **It does not fall back.** A converged environment with no ``lc`` in it
-  is a loud failure, because continuing in the tool env is exactly the
-  silent version skew this module exists to remove.
+- **It does not touch a project that has no engine of its own.** The gate
+  is a ``.venv/bin/lc`` that is already there, checked *before* anything
+  is converged. Any other order would let ``lc status`` in an unrelated
+  uv checkout run ``uv sync --exact`` against it and uninstall someone
+  else's packages on the way to reporting that lc is not installed there.
 
 Kept to the standard library: it runs on every invocation, ahead of click,
 rich and the astra stack.
@@ -39,8 +41,9 @@ import sys
 from pathlib import Path
 
 #: Set on delegation, and the whole of what the launcher tells the engine.
-#: Its presence is also what stops a second hand-over: the engine we exec
-#: runs this same code on the way in.
+#: Its presence is also what stops a second hand-over — belt to the
+#: :func:`maybe_delegate` braces, since the engine we exec lives in the
+#: environment whose own check would already have returned.
 DELEGATED_ENV = "LC_DELEGATED"
 
 #: Verbs that never delegate, because they are what *produces* the
@@ -49,11 +52,6 @@ DELEGATED_ENV = "LC_DELEGATED"
 #: classification walk with ``materialize --check`` and would otherwise be
 #: the one way to make those two verbs answer differently.
 TOOL_ENV_VERBS = frozenset({"init"})
-
-#: What has to be there before delegating is even a question. Not
-#: ``.venv``: converging is this module's job, so a project that has never
-#: been synced is one to build, not one to refuse.
-_PROJECT_FILES = ("pyproject.toml", "uv.lock")
 
 
 def maybe_delegate(argv: list[str]) -> None:
@@ -72,20 +70,26 @@ def maybe_delegate(argv: list[str]) -> None:
     if verb is None or verb in TOOL_ENV_VERBS:
         return
 
+    # One stat, and it answers both questions worth asking here: a
+    # directory holding this file is a built project, and it is one that
+    # carries an engine of its own. Nothing before this point touches the
+    # filesystem, so `lc --help` and shell completion pay for none of it.
     root = Path.cwd()
-    if not all((root / name).is_file() for name in _PROJECT_FILES):
-        return
     engine = root / ".venv" / "bin" / "lc"
-    if Path(sys.executable).resolve().parent == engine.parent.resolve():
-        # Already the project's engine — `uv run lc …`, or a direct call
-        # to the binary in its `.venv`. Delegating would re-exec this same
-        # program to reach itself, and re-converge what uv just converged.
+    if not engine.is_file():
+        return
+    if Path(sys.prefix).resolve() == (root / ".venv").resolve():
+        # Already inside that environment — `uv run lc …`, or a direct
+        # call to the binary. Delegating would re-exec this same program
+        # to reach itself. `sys.prefix` rather than `sys.executable`:
+        # `.venv/bin/python` is a symlink out to the base interpreter, so
+        # resolving it names the interpreter's home, never the venv.
         return
 
-    from lightcone.engine.project import ProjectError, child_env, sync
+    from lightcone.engine.project import ProjectError, child_env, converge_environment
 
     try:
-        warnings = sync(root)
+        warnings = converge_environment(root)
     except ProjectError as e:
         # Raised before click is imported, so `_EngineErrorGroup` cannot
         # render it and this has to say it plainly itself.
@@ -94,9 +98,12 @@ def maybe_delegate(argv: list[str]) -> None:
         print(f"uv: {warning}", file=sys.stderr)
 
     if not engine.is_file():
-        raise SystemExit(
-            f"Error: {engine} does not exist after a successful sync — the "
-            "engine lives inside the experiment's lock, so the project has "
-            "to depend on it: `uv add lightcone-cli`."
-        )
-    os.execve(str(engine), ["lc", *argv], {**child_env(), DELEGATED_ENV: "1"})
+        # Converging removed it: the lock no longer carries
+        # `lightcone-cli`, and `--exact` prunes what the lock does not
+        # name. There is no project engine to hand over to, so this is the
+        # tool env's command after all — convergence already warns about
+        # the missing dependency.
+        return
+    env = child_env()
+    env[DELEGATED_ENV] = "1"
+    os.execve(str(engine), ["lc", *argv], env)

--- a/src/lightcone/cli/launcher.py
+++ b/src/lightcone/cli/launcher.py
@@ -1,0 +1,102 @@
+"""Converge the project's environment, then hand the command over to it.
+
+``lc`` is installed once, as a uv tool, while the *engine* that executes a
+project lives inside that project's own lock — ``lc init`` pins
+``lightcone-cli`` into its dependencies precisely so the engine that
+produced a result stays recoverable from the commit that recorded it.
+Those are two different programs, and until now nothing made them meet:
+the driver, the graph, ``astra.resolve`` and every classification ran from
+whichever ``lc`` happened to be on ``PATH``, while each manifest recorded
+the lock's environment beside them. A project pinning one version could be
+materialized by another, and nothing said so.
+
+So before click sees an argument, this module converges the project's
+environment and ``exec``s the ``lc`` inside it. What crosses that boundary
+is deliberately minimal — the argv verbatim, plus ``LC_DELEGATED=1`` —
+because a launcher of any version has to be able to hand over to a project
+engine of any age, and anything richer is something the two would have to
+agree about.
+
+Three things it does not do:
+
+- **It does not discover the project.** The directory you invoke from is
+  the project, or nothing is delegated. There is no walk-up.
+- **It does not report that a directory is not a project.** It simply
+  declines to delegate, and the engine's own message says why — one
+  error, written once.
+- **It does not fall back.** A converged environment with no ``lc`` in it
+  is a loud failure, because continuing in the tool env is exactly the
+  silent version skew this module exists to remove.
+
+Kept to the standard library: it runs on every invocation, ahead of click,
+rich and the astra stack.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+#: Set on delegation, and the whole of what the launcher tells the engine.
+#: Its presence is also what stops a second hand-over: the engine we exec
+#: runs this same code on the way in.
+DELEGATED_ENV = "LC_DELEGATED"
+
+#: Verbs that never delegate, because they are what *produces* the
+#: environment a delegation would hand over to. Everything else runs from
+#: the project's own engine — including ``status``, which shares its
+#: classification walk with ``materialize --check`` and would otherwise be
+#: the one way to make those two verbs answer differently.
+TOOL_ENV_VERBS = frozenset({"init"})
+
+#: What has to be there before delegating is even a question. Not
+#: ``.venv``: converging is this module's job, so a project that has never
+#: been synced is one to build, not one to refuse.
+_PROJECT_FILES = ("pyproject.toml", "uv.lock")
+
+
+def maybe_delegate(argv: list[str]) -> None:
+    """Hand *argv* to the project's own engine, or return and let click run.
+
+    Args:
+        argv: The command line, without the program name.
+
+    Returns:
+        Nothing — and only when the caller should carry on in this
+        environment. Otherwise the process is replaced.
+    """
+    if os.environ.get(DELEGATED_ENV):
+        return
+    verb = next((arg for arg in argv if not arg.startswith("-")), None)
+    if verb is None or verb in TOOL_ENV_VERBS:
+        return
+
+    root = Path.cwd()
+    if not all((root / name).is_file() for name in _PROJECT_FILES):
+        return
+    engine = root / ".venv" / "bin" / "lc"
+    if Path(sys.executable).resolve().parent == engine.parent.resolve():
+        # Already the project's engine — `uv run lc …`, or a direct call
+        # to the binary in its `.venv`. Delegating would re-exec this same
+        # program to reach itself, and re-converge what uv just converged.
+        return
+
+    from lightcone.engine.project import ProjectError, child_env, sync
+
+    try:
+        warnings = sync(root)
+    except ProjectError as e:
+        # Raised before click is imported, so `_EngineErrorGroup` cannot
+        # render it and this has to say it plainly itself.
+        raise SystemExit(f"Error: {e}") from e
+    for warning in warnings:
+        print(f"uv: {warning}", file=sys.stderr)
+
+    if not engine.is_file():
+        raise SystemExit(
+            f"Error: {engine} does not exist after a successful sync — the "
+            "engine lives inside the experiment's lock, so the project has "
+            "to depend on it: `uv add lightcone-cli`."
+        )
+    os.execve(str(engine), ["lc", *argv], {**child_env(), DELEGATED_ENV: "1"})

--- a/src/lightcone/engine/project.py
+++ b/src/lightcone/engine/project.py
@@ -529,7 +529,7 @@ def current_project(directory: Path | None = None) -> Path:
     declared = (directory / "pyproject.toml").exists() or (directory / SPEC_FILENAME).exists()
     if not declared:
         raise ProjectError(
-            f"{directory} is not a Lightcone project — `lc run` uses the "
+            f"{directory} is not a Lightcone project — lc uses the "
             "directory it is invoked from, and there is no project here. "
             "cd to the root of one and try again."
         )

--- a/src/lightcone/engine/project.py
+++ b/src/lightcone/engine/project.py
@@ -556,18 +556,69 @@ def _run(argv: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+#: Ambient variables that would make ``env_version`` describe an
+#: environment other than the one uv builds. Closed and audited, exactly
+#: like ``identity._INSTALL_SETTINGS`` — and for the same reason: a set
+#: that grew by guesswork would strip a variable someone legitimately
+#: relies on. Verified read by uv 0.12.5, by giving each an unparseable
+#: value and watching uv reject it.
+#:
+#: Three families, and nothing else qualifies:
+#:
+#: - **where the environment goes, and which interpreter builds it.**
+#:   ``--project`` is no defence against these: measured,
+#:   ``UV_PROJECT_ENVIRONMENT`` relocates the venv and ``UV_PYTHON``
+#:   changes the interpreter while every flag lc passes stays the same.
+#: - **which artifacts a sync materializes from an unchanged lock** —
+#:   the env-var spellings of the audited install settings, plus the
+#:   family that actually spells `default-groups` on a command line.
+#:   These are the dangerous ones: `env_version` hashes those settings
+#:   *from the project's files*, so an ambient one changes what is
+#:   installed without moving the hash, and the identity model says
+#:   something untrue.
+#: - **what lc's own flags mean.** ``UV_FROZEN`` would defeat the
+#:   ``--locked`` that makes a drifted lock an error rather than a
+#:   silent relock.
+#:
+#: Deliberately *not* scrubbed: ``UV_CACHE_DIR`` and ``UV_LINK_MODE``
+#: decide where bytes are cached and how they are linked, never what is
+#: installed — and they are what a site registry legitimately supplies.
+#: Nor credentials or TLS settings, without which a private index simply
+#: cannot be fetched from. ``UV_PROJECT`` needs no scrub either:
+#: measured, the explicit ``--project`` every invocation carries already
+#: beats it.
+_UV_SCRUB = (
+    "UV_PROJECT_ENVIRONMENT", "UV_PYTHON", "UV_WORKING_DIR",
+    "UV_NO_BINARY", "UV_NO_BINARY_PACKAGE",
+    "UV_NO_BUILD", "UV_NO_BUILD_PACKAGE",
+    "UV_NO_BUILD_ISOLATION", "UV_NO_BUILD_ISOLATION_PACKAGE",
+    "UV_CONFIG_SETTINGS", "UV_DEFAULT_GROUPS",
+    "UV_NO_DEFAULT_GROUPS", "UV_NO_DEV", "UV_DEV",
+    "UV_NO_INSTALL_PROJECT", "UV_NO_INSTALL_LOCAL", "UV_NO_EDITABLE",
+    "UV_NO_SOURCES",
+    "UV_FROZEN", "UV_LOCKED", "UV_NO_SYNC",
+)  # fmt: skip
+
+
 def child_env() -> dict[str, str]:
     """Build the environment external tools run in.
 
-    Ours, minus ``VIRTUAL_ENV``. Every uv invocation names its project
-    explicitly, so an activated environment elsewhere is never what we
-    mean — and uv warns once per invocation when it ignores one, which
-    would otherwise land in the report and in ``--json``.
+    Ours, minus ``VIRTUAL_ENV`` and minus the ambient uv steering in
+    :data:`_UV_SCRUB`. Every uv invocation names its project explicitly,
+    so an activated environment elsewhere is never what we mean — and uv
+    warns once per invocation when it ignores one, which would otherwise
+    land in the report and in ``--json``.
+
+    The scrub lives here rather than in the launcher because this is the
+    one seam every external tool goes through: convergence, a run's sync,
+    the recipe's ``uv run`` hop and the delegation exec all read it, and
+    a launcher-only scrub would cover the last of those alone.
 
     Returns:
-        The current environment without ``VIRTUAL_ENV``.
+        The current environment, scrubbed.
     """
-    return {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    dropped = {"VIRTUAL_ENV", *_UV_SCRUB}
+    return {k: v for k, v in os.environ.items() if k not in dropped}
 
 
 def _check_call(argv: list[str], *, cwd: Path) -> list[str]:

--- a/src/lightcone/engine/project.py
+++ b/src/lightcone/engine/project.py
@@ -332,9 +332,46 @@ def sync(directory: Path) -> list[str]:
         Whatever uv warned about.
 
     Raises:
-        ProjectError: If uv fails.
+        ProjectError: If uv is absent, or fails.
     """
+    # Guarded here rather than at each call site: this is the only place
+    # that promises "uv failing is a ProjectError", and a caller that
+    # forgets gets `FileNotFoundError` out of `Popen` instead of the
+    # message written for exactly that case.
+    require_uv()
     return _check_call(["uv", *_SYNC_ARGS, "--project", str(directory)], cwd=directory)
+
+
+def converge_environment(directory: Path) -> list[str]:
+    """Make ``.venv`` agree with ``uv.lock``, verifying before writing.
+
+    The same decide-then-maybe-write shape convergence uses for derived
+    artifacts: ask uv's own read-only probe first, and sync only when the
+    answer is no. Against a converged environment the probe costs ~15 ms
+    where the sync costs ~100 ms (measured, uv 0.12.5, this project),
+    because ``--compile-bytecode`` re-stamps every file whether or not
+    anything moved — and the launcher runs this on every delegating verb.
+
+    Unlike :func:`sync`, this is not enough to guarantee an environment
+    holding *only* what the lock names: the probe is set-level, so a
+    hand-installed extra survives it where ``--exact`` would prune one.
+    That is the right trade for a caller that needs the environment to be
+    the lock's, and the wrong one for a run that needs it to be *nothing
+    but* the lock's — which is why :func:`sync` stays unconditional there.
+
+    Args:
+        directory: The project root.
+
+    Returns:
+        Whatever uv warned about; empty when nothing needed doing.
+
+    Raises:
+        ProjectError: If uv is absent, or fails.
+    """
+    require_uv()
+    if (directory / ".venv").is_dir() and _env_is_current(directory):
+        return []
+    return sync(directory)
 
 
 def _converge_uv_project(c: _Converger, directory: Path) -> None:
@@ -563,7 +600,7 @@ def _run(argv: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
 #: relies on. Verified read by uv 0.12.5, by giving each an unparseable
 #: value and watching uv reject it.
 #:
-#: Three families, and nothing else qualifies:
+#: Four families, and nothing else qualifies:
 #:
 #: - **where the environment goes, and which interpreter builds it.**
 #:   ``--project`` is no defence against these: measured,
@@ -579,6 +616,15 @@ def _run(argv: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
 #: - **what lc's own flags mean.** ``UV_FROZEN`` would defeat the
 #:   ``--locked`` that makes a drifted lock an error rather than a
 #:   silent relock.
+#: - **which settings apply at all.** ``UV_NO_CONFIG`` makes uv ignore
+#:   ``[tool.uv]`` and ``uv.toml`` — the very files ``identity`` hashes —
+#:   and ``UV_CONFIG_FILE`` substitutes another for them. Either changes
+#:   what a sync installs while ``env_version`` reports the settings it
+#:   read from the project, so they belong to family two by consequence
+#:   even though neither is a setting itself. (This is *not* the
+#:   user-level ``~/.config/uv/uv.toml`` that ``identity`` deliberately
+#:   tolerates as machine state: these two change whether the project's
+#:   own configuration is read.)
 #:
 #: Deliberately *not* scrubbed: ``UV_CACHE_DIR`` and ``UV_LINK_MODE``
 #: decide where bytes are cached and how they are linked, never what is
@@ -587,7 +633,7 @@ def _run(argv: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
 #: cannot be fetched from. ``UV_PROJECT`` needs no scrub either:
 #: measured, the explicit ``--project`` every invocation carries already
 #: beats it.
-_UV_SCRUB = (
+_UV_SCRUB = frozenset({
     "UV_PROJECT_ENVIRONMENT", "UV_PYTHON", "UV_WORKING_DIR",
     "UV_NO_BINARY", "UV_NO_BINARY_PACKAGE",
     "UV_NO_BUILD", "UV_NO_BUILD_PACKAGE",
@@ -597,7 +643,13 @@ _UV_SCRUB = (
     "UV_NO_INSTALL_PROJECT", "UV_NO_INSTALL_LOCAL", "UV_NO_EDITABLE",
     "UV_NO_SOURCES",
     "UV_FROZEN", "UV_LOCKED", "UV_NO_SYNC",
-)  # fmt: skip
+    "UV_NO_CONFIG", "UV_CONFIG_FILE",
+})  # fmt: skip
+
+#: Everything :func:`child_env` drops, built once. `VIRTUAL_ENV` joins the
+#: scrub for a different reason — every uv invocation names its project, so
+#: an environment activated elsewhere is never what we mean.
+_DROPPED = _UV_SCRUB | {"VIRTUAL_ENV"}
 
 
 def child_env() -> dict[str, str]:
@@ -617,8 +669,7 @@ def child_env() -> dict[str, str]:
     Returns:
         The current environment, scrubbed.
     """
-    dropped = {"VIRTUAL_ENV", *_UV_SCRUB}
-    return {k: v for k, v in os.environ.items() if k not in dropped}
+    return {k: v for k, v in os.environ.items() if k not in _DROPPED}
 
 
 def _check_call(argv: list[str], *, cwd: Path) -> list[str]:

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -6,11 +6,16 @@ import os
 import subprocess
 import sys
 import textwrap
+from collections.abc import Callable
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from lightcone.cli.launcher import DELEGATED_ENV, TOOL_ENV_VERBS, maybe_delegate
+
+#: What the `execs` fixture records: the exec'd path, its argv, its env.
+Execs = list[tuple[str, list[str], dict[str, str]]]
 
 #: Every verb that is not in :data:`TOOL_ENV_VERBS`. Spelled out rather
 #: than derived, so that adding a command to the CLI fails
@@ -21,7 +26,7 @@ DELEGATING_VERBS = {"run", "materialize", "status"}
 
 @pytest.fixture
 def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """A directory the launcher will recognise, and stand in for its engine.
+    """A built project, standing in for its engine.
 
     The engine binary is written by hand rather than installed: what is
     under test is the hand-over, and a real ``lc`` in a real ``.venv``
@@ -37,13 +42,13 @@ def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 @pytest.fixture
-def execs(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, list[str], dict[str, str]]]:
+def execs(monkeypatch: pytest.MonkeyPatch) -> Execs:
     """Capture ``os.execve``, emulating the process hand-over by raising.
 
     A real exec never returns, so a fake that did would let the test run
     on through code the caller can never reach.
     """
-    calls: list[tuple[str, list[str], dict[str, str]]] = []
+    calls: Execs = []
 
     def fake_execve(path: str, argv: list[str], env: dict[str, str]) -> None:
         calls.append((path, argv, env))
@@ -53,14 +58,36 @@ def execs(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, list[str], dict[st
     return calls
 
 
+@pytest.fixture
+def uv_says(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Make every external tool answer with one canned result.
+
+    ``MagicMock`` rather than a hand-rolled stand-in, as everywhere else in
+    the suite: the moment the code under test reads a field a bespoke fake
+    did not think to define, it fails on the fake instead of on the code.
+    """
+
+    def answer(returncode: int = 0, stderr: str = "") -> None:
+        from lightcone.engine import project as project_module
+
+        def fake(argv: list[str], *, cwd: Path) -> MagicMock:
+            # The read-only probe always reports drift, so the sync under
+            # test actually runs; the canned result is the sync's.
+            if "--check" in argv:
+                return MagicMock(returncode=1, stdout="", stderr="")
+            return MagicMock(returncode=returncode, stdout="", stderr=stderr)
+
+        monkeypatch.setattr(project_module, "_run", fake)
+
+    return answer
+
+
 # =============================================================================
 # Routing — who is handed over, and who is not
 # =============================================================================
 
 
-def test_a_verb_in_a_project_is_handed_to_its_own_engine(
-    project: Path, execs: list[tuple[str, list[str], dict[str, str]]]
-) -> None:
+def test_a_verb_in_a_project_is_handed_to_its_own_engine(project: Path, execs: Execs) -> None:
     with pytest.raises(SystemExit):
         maybe_delegate(["materialize", "--check"])
 
@@ -72,7 +99,7 @@ def test_a_verb_in_a_project_is_handed_to_its_own_engine(
 
 
 def test_the_environment_is_converged_before_the_hand_over(
-    project: Path, execs: list[tuple[str, list[str], dict[str, str]]], tools: list[list[str]]
+    project: Path, execs: Execs, tools: list[list[str]]
 ) -> None:
     """The engine that is about to run is the one the lock describes.
 
@@ -82,9 +109,21 @@ def test_the_environment_is_converged_before_the_hand_over(
     with pytest.raises(SystemExit):
         maybe_delegate(["status"])
 
-    synced = [c for c in tools if c[:2] == ["uv", "sync"]]
-    assert synced, tools
-    assert "--locked" in synced[0] and "--project" in synced[0]
+    assert [c for c in tools if c[0] == "uv"], tools
+
+
+def test_a_converged_environment_is_verified_not_re_synced(
+    project: Path, execs: Execs, tools: list[list[str]]
+) -> None:
+    """Against a converged environment the probe costs ~15 ms where the
+    sync costs ~100 ms, because `--compile-bytecode` re-stamps every file
+    whether or not anything moved. The launcher runs on every delegating
+    verb, so it asks before it writes."""
+    with pytest.raises(SystemExit):
+        maybe_delegate(["status"])
+
+    uv = [c for c in tools if c[0] == "uv"]
+    assert uv and all("--check" in c for c in uv), f"converged should only probe: {uv}"
 
 
 @pytest.mark.parametrize(
@@ -97,15 +136,27 @@ def test_the_environment_is_converged_before_the_hand_over(
         (["init", "--check"], "flags do not change which verb it is"),
     ],
 )
-def test_what_never_delegates(
-    argv: list[str], why: str, project: Path, execs: list[tuple[str, ...]]
-) -> None:
+def test_what_never_delegates(argv: list[str], why: str, project: Path, execs: Execs) -> None:
     maybe_delegate(argv)
     assert execs == [], why
 
 
+def test_nothing_is_stat_ed_before_a_verb_is_found(
+    project: Path, execs: Execs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`lc --help` and shell completion are the hot path, and they run
+    wherever the user happens to be standing."""
+
+    def forbidden() -> Path:
+        raise AssertionError("the working directory was read before the verb check")
+
+    monkeypatch.setattr(Path, "cwd", staticmethod(forbidden))
+    maybe_delegate(["--help"])
+    assert execs == []
+
+
 def test_a_second_hand_over_never_happens(
-    project: Path, execs: list[tuple[str, ...]], monkeypatch: pytest.MonkeyPatch
+    project: Path, execs: Execs, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The engine we exec runs this same code on the way in."""
     monkeypatch.setenv(DELEGATED_ENV, "1")
@@ -114,7 +165,7 @@ def test_a_second_hand_over_never_happens(
 
 
 def test_a_directory_that_is_not_a_project_is_left_to_the_engine(
-    tmp_path: Path, execs: list[tuple[str, ...]], monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, execs: Execs, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Declining is the whole response — the refusal is written once, in
     `current_project`, and a second copy here could only disagree with it."""
@@ -123,19 +174,42 @@ def test_a_directory_that_is_not_a_project_is_left_to_the_engine(
     assert execs == []
 
 
+def test_a_uv_project_that_is_not_ours_is_never_converged(
+    tmp_path: Path, execs: Execs, tools: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A uv project without an lc of its own must not be written to.
+
+    `uv sync --exact` *uninstalls* whatever the lock does not name, so
+    converging before checking for an engine would have `lc status`, typed
+    in the wrong checkout, rewrite someone else's environment on its way
+    to reporting that lc is not installed there.
+    """
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "theirs"\n')
+    (tmp_path / "uv.lock").write_text("version = 1\n")
+    (tmp_path / ".venv" / "bin").mkdir(parents=True)  # a venv, but no `lc` in it
+    monkeypatch.chdir(tmp_path)
+
+    maybe_delegate(["status"])
+
+    assert execs == []
+    assert [c for c in tools if c[0] == "uv"] == [], "their environment was left alone"
+
+
 def test_the_project_engine_does_not_hand_over_to_itself(
-    project: Path, execs: list[tuple[str, ...]], tools: list[list[str]], monkeypatch
+    project: Path, execs: Execs, tools: list[list[str]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """`uv run lc …` already arrives in the project's environment.
 
-    Delegating would re-exec this same program to reach itself, and
-    re-converge what uv converged a moment ago.
+    Asked of `sys.prefix`, which *is* the venv root. `sys.executable`
+    cannot answer it: `.venv/bin/python` is a symlink out to the base
+    interpreter, so resolving it names the interpreter's own directory and
+    the comparison is false for the one case it was written for.
     """
-    monkeypatch.setattr(sys, "executable", str(project / ".venv" / "bin" / "python"))
+    monkeypatch.setattr(sys, "prefix", str(project / ".venv"))
     maybe_delegate(["materialize"])
 
     assert execs == []
-    assert [c for c in tools if c[:2] == ["uv", "sync"]] == []
+    assert [c for c in tools if c[0] == "uv"] == [], "nothing was converged either"
 
 
 def test_every_verb_has_a_routing_decision() -> None:
@@ -148,37 +222,33 @@ def test_every_verb_has_a_routing_decision() -> None:
     assert set(main.commands) == TOOL_ENV_VERBS | DELEGATING_VERBS
 
 
+def test_the_group_takes_no_option_with_a_value() -> None:
+    """Verb detection is "the first argument that is not a flag".
+
+    That holds only while every group-level option is a flag. Add one that
+    takes a value and routing breaks both ways at once:
+    `lc --log-level debug init` would read `debug` as the verb and
+    delegate `init`, while `lc --log-level init materialize` would read
+    `init` and refuse to delegate `materialize`.
+    """
+    from lightcone.cli.commands import main
+
+    valued = [p.name for p in main.params if not getattr(p, "is_flag", False)]
+    assert valued == [], f"group options taking a value break verb detection: {valued}"
+
+
 # =============================================================================
 # Failing loudly
 # =============================================================================
 
 
-def test_an_environment_without_the_engine_is_a_refusal(
-    project: Path, execs: list[tuple[str, ...]]
-) -> None:
-    """Never a fall-through to the tool env: continuing there is exactly
-    the silent version skew the launcher exists to remove."""
-    (project / ".venv" / "bin" / "lc").unlink()
-
-    with pytest.raises(SystemExit) as raised:
-        maybe_delegate(["materialize"])
-
-    assert "uv add lightcone-cli" in str(raised.value)
-    assert execs == []
-
-
 def test_a_failed_converge_is_reported_here(
-    project: Path, execs: list[tuple[str, ...]], monkeypatch: pytest.MonkeyPatch
+    project: Path, execs: Execs, uv_says: Callable[..., None]
 ) -> None:
     """Click has not been imported yet, so `_EngineErrorGroup` cannot
     render this one and the launcher has to say it itself."""
-    from lightcone.engine import project as project_module
+    uv_says(returncode=1, stderr="the lock is stale")
 
-    monkeypatch.setattr(
-        project_module,
-        "_run",
-        lambda argv, *, cwd: type("P", (), {"returncode": 1, "stderr": "the lock is stale"})(),
-    )
     with pytest.raises(SystemExit) as raised:
         maybe_delegate(["materialize"])
 
@@ -188,28 +258,42 @@ def test_a_failed_converge_is_reported_here(
 
 def test_a_uv_warning_reaches_the_user(
     project: Path,
-    execs: list[tuple[str, ...]],
-    monkeypatch: pytest.MonkeyPatch,
+    execs: Execs,
+    uv_says: Callable[..., None],
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """The cache-on-another-filesystem warning is the one that must not be
     swallowed — nothing else would tell anyone their packages are being
     copied rather than linked."""
-    from lightcone.engine import project as project_module
-
-    monkeypatch.setattr(
-        project_module,
-        "_run",
-        lambda argv, *, cwd: type(
-            "P", (), {"returncode": 0, "stderr": "warning: Failed to hardlink files"}
-        )(),
-    )
-    (project / ".venv" / "bin" / "lc").write_text("#!/bin/sh\n")
+    uv_says(returncode=0, stderr="warning: Failed to hardlink files")
 
     with pytest.raises(SystemExit):
         maybe_delegate(["status"])
 
     assert "Failed to hardlink files" in capsys.readouterr().err
+    assert execs, "and the hand-over still happened"
+
+
+def test_an_engine_pruned_by_the_converge_is_not_exec_d(
+    project: Path, execs: Execs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--exact` uninstalls what the lock does not name.
+
+    A project that dropped `lightcone-cli` from its dependencies has no
+    engine to hand over to once the environment agrees with its lock — and
+    `execve` on the file that used to be there is a traceback, not an
+    error message.
+    """
+    from lightcone.engine import project as project_module
+
+    def prune(argv: list[str], *, cwd: Path) -> MagicMock:
+        (project / ".venv" / "bin" / "lc").unlink(missing_ok=True)
+        return MagicMock(returncode=1 if "--check" in argv else 0, stdout="", stderr="")
+
+    monkeypatch.setattr(project_module, "_run", prune)
+
+    maybe_delegate(["materialize"])
+    assert execs == []
 
 
 # =============================================================================
@@ -218,26 +302,20 @@ def test_a_uv_warning_reaches_the_user(
 
 
 def test_ambient_uv_steering_does_not_cross(
-    project: Path,
-    execs: list[tuple[str, list[str], dict[str, str]]],
-    monkeypatch: pytest.MonkeyPatch,
+    project: Path, execs: Execs, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Measured against uv 0.12.5: `UV_PROJECT_ENVIRONMENT` relocates the
-    venv outright, so an engine handed one would converge and describe two
-    different environments."""
     monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/tmp/elsewhere")
     monkeypatch.setenv("UV_NO_BUILD_ISOLATION", "1")
+    monkeypatch.setenv("UV_NO_CONFIG", "1")
     monkeypatch.setenv("UV_CACHE_DIR", "/scratch/uv")
 
     with pytest.raises(SystemExit):
         maybe_delegate(["materialize"])
 
     _, _, env = execs[0]
-    assert "UV_PROJECT_ENVIRONMENT" not in env
-    assert "UV_NO_BUILD_ISOLATION" not in env
-    # Kept: where bytes are cached is placement, never content — and it is
-    # what a site registry legitimately supplies.
-    assert env["UV_CACHE_DIR"] == "/scratch/uv"
+    for name in ("UV_PROJECT_ENVIRONMENT", "UV_NO_BUILD_ISOLATION", "UV_NO_CONFIG"):
+        assert name not in env
+    assert env["UV_CACHE_DIR"] == "/scratch/uv", "placement is kept"
 
 
 def test_the_hand_over_really_execs(project: Path) -> None:
@@ -254,9 +332,8 @@ def test_the_hand_over_really_execs(project: Path) -> None:
 
     driver = textwrap.dedent(
         """
-        import sys
         from lightcone.engine import project
-        project.sync = lambda root: []          # no uv in a subprocess
+        project.converge_environment = lambda root: []   # no uv in a subprocess
         from lightcone.cli.launcher import maybe_delegate
         maybe_delegate(["materialize", "--refresh"])
         print("NOT REACHED")

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,276 @@
+"""The launcher: what delegates, what does not, and what crosses over."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from lightcone.cli.launcher import DELEGATED_ENV, TOOL_ENV_VERBS, maybe_delegate
+
+#: Every verb that is not in :data:`TOOL_ENV_VERBS`. Spelled out rather
+#: than derived, so that adding a command to the CLI fails
+#: :func:`test_every_verb_has_a_routing_decision` until someone decides
+#: which side of the boundary it belongs on.
+DELEGATING_VERBS = {"run", "materialize", "status"}
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A directory the launcher will recognise, and stand in for its engine.
+
+    The engine binary is written by hand rather than installed: what is
+    under test is the hand-over, and a real ``lc`` in a real ``.venv``
+    would cost a full resolve to assert exactly the same argv.
+    """
+    root = tmp_path / "proj"
+    (root / ".venv" / "bin").mkdir(parents=True)
+    (root / "pyproject.toml").write_text('[project]\nname = "proj"\n')
+    (root / "uv.lock").write_text("version = 1\n")
+    (root / ".venv" / "bin" / "lc").write_text("#!/bin/sh\n")
+    monkeypatch.chdir(root)
+    return root
+
+
+@pytest.fixture
+def execs(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, list[str], dict[str, str]]]:
+    """Capture ``os.execve``, emulating the process hand-over by raising.
+
+    A real exec never returns, so a fake that did would let the test run
+    on through code the caller can never reach.
+    """
+    calls: list[tuple[str, list[str], dict[str, str]]] = []
+
+    def fake_execve(path: str, argv: list[str], env: dict[str, str]) -> None:
+        calls.append((path, argv, env))
+        raise SystemExit(0)
+
+    monkeypatch.setattr(os, "execve", fake_execve)
+    return calls
+
+
+# =============================================================================
+# Routing — who is handed over, and who is not
+# =============================================================================
+
+
+def test_a_verb_in_a_project_is_handed_to_its_own_engine(
+    project: Path, execs: list[tuple[str, list[str], dict[str, str]]]
+) -> None:
+    with pytest.raises(SystemExit):
+        maybe_delegate(["materialize", "--check"])
+
+    path, argv, env = execs[0]
+    assert path == str(project / ".venv" / "bin" / "lc")
+    # The frozen interface: the argv verbatim, and one variable.
+    assert argv == ["lc", "materialize", "--check"]
+    assert env[DELEGATED_ENV] == "1"
+
+
+def test_the_environment_is_converged_before_the_hand_over(
+    project: Path, execs: list[tuple[str, list[str], dict[str, str]]], tools: list[list[str]]
+) -> None:
+    """The engine that is about to run is the one the lock describes.
+
+    Syncing after the exec would be too late — the process making that
+    decision would already be gone.
+    """
+    with pytest.raises(SystemExit):
+        maybe_delegate(["status"])
+
+    synced = [c for c in tools if c[:2] == ["uv", "sync"]]
+    assert synced, tools
+    assert "--locked" in synced[0] and "--project" in synced[0]
+
+
+@pytest.mark.parametrize(
+    ("argv", "why"),
+    [
+        ([], "no verb at all"),
+        (["--help"], "a flag is not a verb"),
+        (["--version"], "a flag is not a verb"),
+        (["init"], "init is what *makes* the environment"),
+        (["init", "--check"], "flags do not change which verb it is"),
+    ],
+)
+def test_what_never_delegates(
+    argv: list[str], why: str, project: Path, execs: list[tuple[str, ...]]
+) -> None:
+    maybe_delegate(argv)
+    assert execs == [], why
+
+
+def test_a_second_hand_over_never_happens(
+    project: Path, execs: list[tuple[str, ...]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The engine we exec runs this same code on the way in."""
+    monkeypatch.setenv(DELEGATED_ENV, "1")
+    maybe_delegate(["materialize"])
+    assert execs == []
+
+
+def test_a_directory_that_is_not_a_project_is_left_to_the_engine(
+    tmp_path: Path, execs: list[tuple[str, ...]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Declining is the whole response — the refusal is written once, in
+    `current_project`, and a second copy here could only disagree with it."""
+    monkeypatch.chdir(tmp_path)
+    maybe_delegate(["materialize"])
+    assert execs == []
+
+
+def test_the_project_engine_does_not_hand_over_to_itself(
+    project: Path, execs: list[tuple[str, ...]], tools: list[list[str]], monkeypatch
+) -> None:
+    """`uv run lc …` already arrives in the project's environment.
+
+    Delegating would re-exec this same program to reach itself, and
+    re-converge what uv converged a moment ago.
+    """
+    monkeypatch.setattr(sys, "executable", str(project / ".venv" / "bin" / "python"))
+    maybe_delegate(["materialize"])
+
+    assert execs == []
+    assert [c for c in tools if c[:2] == ["uv", "sync"]] == []
+
+
+def test_every_verb_has_a_routing_decision() -> None:
+    """A command added without a routing decision would delegate by
+    default — into a project engine that may be too old to know it, which
+    fails far from its cause. The launcher never imports `commands`, so
+    this test is the only thing binding the two."""
+    from lightcone.cli.commands import main
+
+    assert set(main.commands) == TOOL_ENV_VERBS | DELEGATING_VERBS
+
+
+# =============================================================================
+# Failing loudly
+# =============================================================================
+
+
+def test_an_environment_without_the_engine_is_a_refusal(
+    project: Path, execs: list[tuple[str, ...]]
+) -> None:
+    """Never a fall-through to the tool env: continuing there is exactly
+    the silent version skew the launcher exists to remove."""
+    (project / ".venv" / "bin" / "lc").unlink()
+
+    with pytest.raises(SystemExit) as raised:
+        maybe_delegate(["materialize"])
+
+    assert "uv add lightcone-cli" in str(raised.value)
+    assert execs == []
+
+
+def test_a_failed_converge_is_reported_here(
+    project: Path, execs: list[tuple[str, ...]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Click has not been imported yet, so `_EngineErrorGroup` cannot
+    render this one and the launcher has to say it itself."""
+    from lightcone.engine import project as project_module
+
+    monkeypatch.setattr(
+        project_module,
+        "_run",
+        lambda argv, *, cwd: type("P", (), {"returncode": 1, "stderr": "the lock is stale"})(),
+    )
+    with pytest.raises(SystemExit) as raised:
+        maybe_delegate(["materialize"])
+
+    assert "the lock is stale" in str(raised.value)
+    assert execs == []
+
+
+def test_a_uv_warning_reaches_the_user(
+    project: Path,
+    execs: list[tuple[str, ...]],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The cache-on-another-filesystem warning is the one that must not be
+    swallowed — nothing else would tell anyone their packages are being
+    copied rather than linked."""
+    from lightcone.engine import project as project_module
+
+    monkeypatch.setattr(
+        project_module,
+        "_run",
+        lambda argv, *, cwd: type(
+            "P", (), {"returncode": 0, "stderr": "warning: Failed to hardlink files"}
+        )(),
+    )
+    (project / ".venv" / "bin" / "lc").write_text("#!/bin/sh\n")
+
+    with pytest.raises(SystemExit):
+        maybe_delegate(["status"])
+
+    assert "Failed to hardlink files" in capsys.readouterr().err
+
+
+# =============================================================================
+# What crosses the boundary
+# =============================================================================
+
+
+def test_ambient_uv_steering_does_not_cross(
+    project: Path,
+    execs: list[tuple[str, list[str], dict[str, str]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Measured against uv 0.12.5: `UV_PROJECT_ENVIRONMENT` relocates the
+    venv outright, so an engine handed one would converge and describe two
+    different environments."""
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/tmp/elsewhere")
+    monkeypatch.setenv("UV_NO_BUILD_ISOLATION", "1")
+    monkeypatch.setenv("UV_CACHE_DIR", "/scratch/uv")
+
+    with pytest.raises(SystemExit):
+        maybe_delegate(["materialize"])
+
+    _, _, env = execs[0]
+    assert "UV_PROJECT_ENVIRONMENT" not in env
+    assert "UV_NO_BUILD_ISOLATION" not in env
+    # Kept: where bytes are cached is placement, never content — and it is
+    # what a site registry legitimately supplies.
+    assert env["UV_CACHE_DIR"] == "/scratch/uv"
+
+
+def test_the_hand_over_really_execs(project: Path) -> None:
+    """The one test that runs a real `os.execve`.
+
+    Everything above fakes the exec, which means none of it can catch an
+    argv that is well-formed and unrunnable. Here the engine is a shell
+    script that reports what it was actually given, in a real process.
+    """
+    (project / ".venv" / "bin" / "lc").write_text(
+        '#!/bin/sh\necho "argv:$*"\necho "delegated:$LC_DELEGATED"\n'
+    )
+    (project / ".venv" / "bin" / "lc").chmod(0o755)
+
+    driver = textwrap.dedent(
+        """
+        import sys
+        from lightcone.engine import project
+        project.sync = lambda root: []          # no uv in a subprocess
+        from lightcone.cli.launcher import maybe_delegate
+        maybe_delegate(["materialize", "--refresh"])
+        print("NOT REACHED")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", driver],
+        cwd=project,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent / "src")},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "argv:materialize --refresh" in result.stdout
+    assert "delegated:1" in result.stdout
+    assert "NOT REACHED" not in result.stdout

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -652,6 +652,58 @@ def test_ambient_virtualenv_is_not_passed_to_tools(
     assert env["LC_TEST_CANARY"] == "kept", "the rest of the environment is untouched"
 
 
+def test_ambient_uv_steering_is_scrubbed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`env_version` hashes the install settings *from the project's files*.
+
+    uv reads the same settings from the environment, so an ambient one
+    changes what a sync installs without moving the hash — the identity
+    model stating something untrue. Verified against uv 0.12.5: given
+    these variables, uv relocates the venv, picks another interpreter, and
+    changes which artifacts it materializes.
+    """
+    from lightcone.engine.project import child_env
+
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/somewhere/else")
+    monkeypatch.setenv("UV_PYTHON", "3.9")
+    monkeypatch.setenv("UV_NO_BUILD_ISOLATION", "1")
+    monkeypatch.setenv("UV_FROZEN", "1")
+
+    env = child_env()
+    for name in ("UV_PROJECT_ENVIRONMENT", "UV_PYTHON", "UV_NO_BUILD_ISOLATION", "UV_FROZEN"):
+        assert name not in env
+
+
+def test_where_bytes_are_cached_is_not_scrubbed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """These decide where packages are cached and how they are linked,
+    never what is installed — and they are exactly what a site registry
+    supplies on a machine whose cache cannot live in $HOME."""
+    from lightcone.engine.project import child_env
+
+    monkeypatch.setenv("UV_CACHE_DIR", "/scratch/uv")
+    monkeypatch.setenv("UV_LINK_MODE", "copy")
+
+    env = child_env()
+    assert env["UV_CACHE_DIR"] == "/scratch/uv"
+    assert env["UV_LINK_MODE"] == "copy"
+
+
+def test_every_audited_install_setting_is_scrubbed() -> None:
+    """The scrub and the identity model have to name the same settings.
+
+    `identity` hashes a closed list of settings read from the project's
+    files; every one of them also has an environment spelling. Adding a
+    setting there without adding it here would reopen the hole silently —
+    the hash would cover the file and miss the variable — so the
+    correspondence is asserted rather than remembered.
+    """
+    from lightcone.engine.identity import _INSTALL_SETTINGS
+    from lightcone.engine.project import _UV_SCRUB
+
+    for setting in _INSTALL_SETTINGS:
+        spelling = "UV_" + setting.upper().replace("-", "_")
+        assert spelling in _UV_SCRUB, f"{setting} is hashed but its variable is not scrubbed"
+
+
 def test_relays_uv_warnings_into_the_report(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -653,30 +653,25 @@ def test_ambient_virtualenv_is_not_passed_to_tools(
 
 
 def test_ambient_uv_steering_is_scrubbed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`env_version` hashes the install settings *from the project's files*.
-
-    uv reads the same settings from the environment, so an ambient one
-    changes what a sync installs without moving the hash — the identity
-    model stating something untrue. Verified against uv 0.12.5: given
-    these variables, uv relocates the venv, picks another interpreter, and
-    changes which artifacts it materializes.
-    """
+    """One from each family `_UV_SCRUB` names, which is where the why is."""
     from lightcone.engine.project import child_env
 
     monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/somewhere/else")
     monkeypatch.setenv("UV_PYTHON", "3.9")
     monkeypatch.setenv("UV_NO_BUILD_ISOLATION", "1")
     monkeypatch.setenv("UV_FROZEN", "1")
+    monkeypatch.setenv("UV_NO_CONFIG", "1")
 
     env = child_env()
-    for name in ("UV_PROJECT_ENVIRONMENT", "UV_PYTHON", "UV_NO_BUILD_ISOLATION", "UV_FROZEN"):
+    for name in ("UV_PROJECT_ENVIRONMENT", "UV_PYTHON", "UV_NO_BUILD_ISOLATION"):
         assert name not in env
+    assert "UV_FROZEN" not in env
+    # Not a setting itself, but it makes uv ignore the files identity reads.
+    assert "UV_NO_CONFIG" not in env
 
 
 def test_where_bytes_are_cached_is_not_scrubbed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """These decide where packages are cached and how they are linked,
-    never what is installed — and they are exactly what a site registry
-    supplies on a machine whose cache cannot live in $HOME."""
+    """Placement, never content — and what a site registry supplies."""
     from lightcone.engine.project import child_env
 
     monkeypatch.setenv("UV_CACHE_DIR", "/scratch/uv")
@@ -690,11 +685,10 @@ def test_where_bytes_are_cached_is_not_scrubbed(monkeypatch: pytest.MonkeyPatch)
 def test_every_audited_install_setting_is_scrubbed() -> None:
     """The scrub and the identity model have to name the same settings.
 
-    `identity` hashes a closed list of settings read from the project's
-    files; every one of them also has an environment spelling. Adding a
-    setting there without adding it here would reopen the hole silently —
-    the hash would cover the file and miss the variable — so the
-    correspondence is asserted rather than remembered.
+    Adding a setting to the hash without adding its environment spelling
+    here would reopen the hole silently — the hash would cover the file
+    and miss the variable — so the correspondence is asserted rather than
+    remembered.
     """
     from lightcone.engine.identity import _INSTALL_SETTINGS
     from lightcone.engine.project import _UV_SCRUB
@@ -702,6 +696,35 @@ def test_every_audited_install_setting_is_scrubbed() -> None:
     for setting in _INSTALL_SETTINGS:
         spelling = "UV_" + setting.upper().replace("-", "_")
         assert spelling in _UV_SCRUB, f"{setting} is hashed but its variable is not scrubbed"
+
+
+def test_a_converged_environment_is_probed_not_re_synced(
+    tmp_path: Path, tools: list[list[str]]
+) -> None:
+    """`converge_environment` asks before it writes; `sync` never does.
+
+    The split is the point: a caller that needs the environment to *be*
+    the lock's can take the probe's set-level answer, while a run that
+    needs it to be nothing but the lock's cannot — `--exact` is what
+    prunes a hand-installed extra, and the probe does not see one.
+    """
+    from lightcone.engine.project import converge_environment
+
+    (tmp_path / ".venv").mkdir()
+    assert converge_environment(tmp_path) == []
+    assert all("--check" in c for c in uv_calls(tools)), uv_calls(tools)
+
+
+def test_an_absent_environment_is_synced_without_a_probe(
+    tmp_path: Path, tools: list[list[str]]
+) -> None:
+    """Nothing to ask about — the same rule convergence uses for a
+    derived artifact that is not there yet."""
+    from lightcone.engine.project import converge_environment
+
+    converge_environment(tmp_path)
+    assert [c for c in uv_calls(tools) if "--check" in c] == []
+    assert [c for c in uv_calls(tools) if c[0] == "sync"], tools
 
 
 def test_relays_uv_warnings_into_the_report(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -82,6 +82,9 @@ def test_the_wrong_directory_is_told_to_move_not_to_scaffold(tmp_path: Path) -> 
     message = str(raised.value)
     assert "cd to the root of one" in message
     assert "lc init" not in message
+    # Every verb that takes a project lands here, so the message names
+    # none of them in particular.
+    assert "lc run" not in message
 
 
 def test_the_default_is_the_working_directory(


### PR DESCRIPTION
`lc` is installed once, as a uv tool; the engine that executes a project
lives inside that project's own lock, because `lc init` pins
`lightcone-cli` into its dependencies so the engine that produced a result
stays recoverable from the commit that recorded it. Nothing made those two
meet. Before click sees an argument, `cli/launcher.py` now converges the
project's environment and `exec`s the `lc` inside it.

Layer table: row **3** → ✅.

## What was actually broken

`cluster_for_run()` builds a `LocalCluster(processes=False)`, so the
driver, the graph, `astra.resolve`, the classifier and `worker.materialize`
all ran in the *invoking* process. The only place the project's environment
was ever entered is the recipe exec — and even there the immediate child is
lc's own interpreter. Meanwhile `_lc_version()` resolves
`importlib.metadata` against that same invoking process.

So a project whose lock pinned engine A could be materialized by engine B,
with the manifest recording both and reconciling neither. This is not a
corner case: `uv tool install lightcone-cli`, the documented install,
guarantees the two can differ.

## The interface is argv plus one variable

`LC_DELEGATED=1` is the whole of what crosses. A launcher of any version
has to hand over to a project engine of any age, so anything richer is
something the two would have to agree about — and the older half cannot be
changed.

The launcher decides four things and writes no errors of its own:

| Question | Answer |
|---|---|
| Already delegated? | Return — the engine we exec runs this same code on the way in. |
| A verb at all, and not `init`? | `init` is what *makes* the environment a delegation would hand over to. |
| Is the current directory a uv project? | If not, **decline silently**. `current_project()` already says why, and a second copy of that message here could only disagree with it. |
| Are we already the project's engine? | `uv run lc …` arrives inside the project's environment; delegating would re-exec this program to reach itself. |

A converged `.venv` with no `lc` in it is a refusal naming
`uv add lightcone-cli` — never a fall-through to the tool env, since that
fall-through *is* the silent skew this removes.

There is no discovery step, where spec §4 walks up looking for
`astra.yaml`: the current directory is the project, as everywhere else.

### `lc status` delegates, against spec §4

It and `materialize --check` run the same classification walk, and
`definition_version` hashes what `render_command` produced — so two astra
versions can render one recipe differently. Leaving status in the tool env
is the one way to make two verbs that must differ only in exit code
disagree on the answer. The price, stated where the promise is written:
status converges before it answers. Its "reads only" promise is about the
analysis and the repository, never about not touching `.venv`.

`TOOL_ENV_VERBS` and the click group are held together by a parity test,
since the launcher deliberately never imports `commands.py`. A verb added
without a routing decision would delegate by default, into an engine that
may be too old to know it — failing far from its cause.

## The `UV_*` scrub

It lives in `project.child_env()`, not in the launcher: that is the one
seam every external tool goes through, so one edit covers convergence, a
run's sync, the recipe's `uv run` hop *and* the delegation exec. A
launcher-only scrub would cover the last of those alone.

The list is closed and audited like `identity._INSTALL_SETTINGS`, and every
entry was **verified read by uv 0.12.5** — each given an unparseable value
to see whether uv rejects it. The load-bearing case: `env_version` hashes
the install settings *from the project's files*, and uv reads the same
settings from the environment, so an ambient `UV_NO_BUILD_ISOLATION`
changes what gets installed **without moving the hash**. Measured alongside
it, `UV_PROJECT_ENVIRONMENT` relocates the venv outright and `UV_PYTHON`
changes the interpreter — neither defended against by any flag lc passes.

`UV_CACHE_DIR` and `UV_LINK_MODE` are deliberately kept: they decide where
bytes are cached and how they are linked, never what is installed, and they
are exactly what a site registry supplies on a machine whose cache cannot
live in `$HOME`. Credentials and TLS settings stay for the same reason.
`UV_PROJECT` needs no scrub — measured, the explicit `--project` already
beats it.

A test derives each audited setting's environment spelling and asserts it
is scrubbed, so the hash and the scrub cannot drift apart silently.

## Tests

`tests/test_launcher.py` fakes `os.execve` by *raising* `SystemExit`, since
a fake that returned would let a test run on through code the real caller
can never reach. One test runs a genuine `os.execve` in a subprocess
against a shell-script stand-in for the project's engine — everything else
fakes the exec and so cannot catch an argv that is well-formed and
unrunnable.

`test_cli.py` is untouched: it drives `cli.commands.main` through
`CliRunner`, while delegation hooks into `cli/__init__.py`, which the suite
never calls.

## Verified end to end

Through the real installed console script, not only in-process:

- delegation passes argv verbatim with `LC_DELEGATED=1`;
- an ambient `UV_PROJECT_ENVIRONMENT` creates nothing;
- `UV_CACHE_DIR` survives;
- a failed converge prints one `Error:` line, not a traceback;
- `init` stays in the tool env;
- `lc --help` inside a project costs 91 ms, with no converge and no exec.

## Also here

One-word fix to `current_project`'s refusal: it named `lc run`, but every
verb that takes a project lands there — visible now that the launcher
sends `materialize` and `status` through it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SpUATWSFRu2uCcFFK9pdf
