### PR TITLE
The engine is the host's uv tool, not a project dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ speculatively.
 |---|-------|-------|
 | 1 | **Project scaffolding** — `lc init` | ✅ **done** |
 | 2 | **Environment layer** — `env_version`, lock scan, manifest schema | ✅ **done** |
-| 3 | The `lc` entrypoint — launcher: discover → mode-detect → scrub `UV_*` → converge → delegate | ⬜ |
+| 3 | ~~The `lc` entrypoint — launcher~~ | ❌ **removed by decision** (2026-08) — see Recorded decisions: the host `lc` is the engine, so there is nothing to delegate to |
 | 4 | **Fabric** — `lc materialize`, worker sequence, mid-run relock gate | ✅ **done** |
 | 5 | **Sandbox layer** — Landlock / Seatbelt, exec-shim, denial UX, `lc run` | ✅ **done** |
 | 6 | Container hatch — `[tool.lightcone.image]`, generated Containerfile, `lc build` | ⬜ |
@@ -63,10 +63,12 @@ Layer 5 landed **out of order**, ahead of 2–4: `lc run` is the spec's
 with it. That makes it the smallest honest consumer of the exec boundary,
 and the boundary is what layer 4 will then plug recipes into.
 
-The spec's §11 (Migration) is the authoritative ordering; the table above
-is the working map. **Layer boundaries are also dependency boundaries** —
-a dependency enters `pyproject.toml` with the layer that needs it, not
-before.
+The spec's §11 (Migration) is the reference ordering; the table above is
+the working map, and the spec is a reference the rebuild deliberately
+drifts from — reversals land as Recorded decisions here rather than
+waiting on a spec rewrite. **Layer boundaries are also dependency
+boundaries** — a dependency enters `pyproject.toml` with the layer that
+needs it, not before.
 
 ### Rules while rebuilding
 
@@ -149,7 +151,7 @@ Any new `lightcone-*` package must:
 src/lightcone/              # namespace — NO __init__.py
 ├── _sandbox_exec.py        # the Landlock shim — stdlib only, zero lightcone imports
 ├── cli/                    # the CLI only: flags, rendering, exit codes
-│   ├── __init__.py         # exposes main(); the launcher hooks in here (layer 3)
+│   ├── __init__.py         # exposes main(), lazily
 │   └── commands.py         # lc init, lc run, lc materialize
 └── engine/
     ├── __init__.py         # docstring only
@@ -257,11 +259,10 @@ so the template name has to be bound before the call site.
 
 **No engine constants for the environment.** The scaffolded
 `.python-version` is the interpreter `lc` itself is running on, and
-`requires-python` is lightcone-cli's own `Requires-Python`, verbatim. These
-can't conflict — lc only runs on an interpreter satisfying its own bound —
-and neither is a number to maintain. Identity follows the project's files
-from there: `env_version` hashes `.python-version`'s bytes, not anything in
-the engine (spec §3).
+`requires-python` is that interpreter's minor as a floor. Both come from
+one place, so they can't conflict, and neither is a number to maintain.
+Identity follows the project's files from there: `env_version` hashes
+`.python-version`'s bytes, not anything in the engine (spec §3).
 
 **`.gitignore` converges entry-wise, not by marker.**
 `templates.gitignore_entries()` is the template minus comments and blanks;
@@ -278,7 +279,7 @@ user owns:
 | Path | Role |
 |---|---|
 | `astra.yaml` + `universes/baseline.yaml` | astra's boilerplate spec, verbatim, as **one item keyed on `astra.yaml`** — the baseline references the boilerplate's example decision, so it must never land beside a user-authored spec. Its `container:` key is ignored outright — see Recorded decisions |
-| `pyproject.toml` | The uv project: **virtual** (no `[build-system]`), `lightcone-cli` pinned in its own dependencies — the engine lives inside the experiment's lock |
+| `pyproject.toml` | The uv project: **virtual** (no `[build-system]`), no dependencies — the engine is the host's uv tool, never a project dependency (see Recorded decisions), so the lock carries only what the analysis imports |
 | `.python-version` | The exact patch of the interpreter `lc` is running on |
 | `uv.lock`, `.venv` | **Derived** — converged by correctness, not existence: `uv lock --check` / `uv sync --check` decide, then `uv lock` / `uv sync --locked --exact --compile-bytecode` repair |
 | `.gitignore` | One managed block of patterns; convergence ensures each is present |
@@ -311,10 +312,9 @@ user owns:
   0.12.3). A lock that no
   longer matches `pyproject.toml`, or an environment that no longer matches
   the lock, is exactly as unconverged as a missing one and reports as
-  `repaired`. Existence alone made `converge()` a no-op on drift, which
-  layer 3's launcher — which converges on every invocation precisely to
-  guarantee the environment matches the lock — would have silently
-  inherited.
+  `repaired`. Existence alone made `converge()` a no-op on drift, and
+  everything that converges before acting — `lc materialize`'s sync, the
+  worker entry point's — would have silently inherited it.
   - The probe is skipped when the artifact is absent (nothing to ask), so a
     fresh project costs none and the created/repaired split falls out of the
     same check.
@@ -393,10 +393,12 @@ one monkeypatch point and the `tools` fixture already covers git.
 `manylinux_2_34` on x86_64/aarch64, macOS 14+ arm64 or 15+ x86_64,
 win_amd64 — and **no sdist**, so a host below the floor fails to install
 rather than building from source. Because git-annex is a *hard* runtime
-dependency and `lc init` pins `lightcone-cli` into every project, that
-floor gates installing lc at all, including `lc run`, which never touches
-the annex. If it ever bites a real user, that coupling is the thing to
-revisit — an extra, or a probed requirement like git — not the floor.
+dependency, that floor gates installing the lc tool at all, including
+`lc run`, which never touches the annex — but only the tool: projects no
+longer depend on lightcone-cli, so the floor never constrains a project's
+own resolution. If it ever bites a real user, the hard dependency is the
+thing to revisit — an extra, or a probed requirement like git — not the
+floor.
 
 **Perlmutter clears it** (checked 2026-08-19, login node): the wheel
 installs and `git annex version` runs. That was the open question this
@@ -413,8 +415,8 @@ re-derived. Two things it does *not* settle, both layer 7's:
   either.
 - **`git-annex-shell` is not on the default remote PATH.** `git annex get`
   from a laptop dispatches to it over a non-login ssh session, and the
-  wheel installs it into `.venv/bin`. Configuration, not design:
-  `git config remote.<name>.annex-shell <abs-path>`.
+  wheel installs it beside the tool's interpreter. Configuration, not
+  design: `git config remote.<name>.annex-shell <abs-path>`.
 
 **`filter=annex` is what makes an ordinary `git add` do the right thing.**
 `git annex init` configures the smudge/clean filter itself; the template
@@ -473,8 +475,9 @@ prepend and by the name git itself searches for.
 
 Measured, not assumed: with only the tool's `lc` on `PATH` — exactly what
 `uv tool install` produces — `git annex version` fails, and with the
-prepend disabled `lc init` refuses. Under `uv run` it is a no-op, because
-uv already fronts the project's `.venv/bin`.
+prepend disabled `lc init` refuses. With the engine out of the project's
+lock, the prepend is the *only* way git finds git-annex; there is no
+project `.venv/bin` fallback to mask a regression.
 
 **A project can sit inside a larger repository, so `dataset.status` is
 scoped and relativised.** `lc init subdir/` adopts an enclosing work
@@ -915,11 +918,12 @@ A test that reads `dataset.head()` after materializing and expects a match
 is asserting the wrong thing.
 
 **One uv hop, one spelling** (`project.uv_prefix(root, *, sync)`). The
-flags are also what `run_record` writes verbatim into every commit
-message, so a second copy is a second thing that can drift out of the
-provenance. The only thing callers disagree about is `sync`: a probe
-converges the environment it is about to describe, a recipe must not, or
-every concurrent worker writes the same `.venv`.
+only thing its callers disagree about is `sync`: a probe converges the
+environment it is about to describe, a recipe must not, or every
+concurrent worker writes the same `.venv`. The run record carries no uv
+hop at all — the worker entry point converges the project environment for
+itself, so there is nothing in the record to drift out of step with the
+prefix.
 
 **A run syncs the environment; it does not report on it.** `uv run
 --locked` asserts only that `uv.lock` still matches `pyproject.toml`, and
@@ -964,13 +968,20 @@ shipped once; `_inside` is lexical now.
 
 **The run record is genuinely re-runnable, and its `cmd` is the worker
 module.** `python -m lightcone.engine.worker <universe>/<output_id>`,
-behind `uv run --locked --project .` — which reconstructs the environment
-from *that commit's* lock, and therefore the exact engine that produced
-the output. The bare recipe would reconstruct nothing lc adds (no locked
-environment, no boundary, no gates, no manifest) and would commit bytes
-the identity model never produced; `lc materialize` cannot be it either,
-because `datalad rerun` removes the declared outputs first and that
-dirties the tree materialize refuses to start from.
+behind `uv run --no-project --with lightcone-cli==<v>` when the engine
+that made the output is a published release — an ephemeral environment
+that reconstructs the *engine* by version, while the worker itself
+reconstructs the *project* environment from the rerun commit's own lock
+(`main()` syncs before anything executes; `uv run --no-sync` against a
+missing `.venv` silently creates an empty one, so a clone's rerun would
+otherwise run recipes in a bare environment under a manifest recording
+the lock's `env_version`). A dev build's version is unpublished, so its
+record is the bare module, which only ever exists in a checkout whose own
+interpreter imports it. The bare recipe would reconstruct nothing lc adds
+(no locked environment, no boundary, no gates, no manifest) and would
+commit bytes the identity model never produced; `lc materialize` cannot
+be it either, because `datalad rerun` removes the declared outputs first
+and that dirties the tree materialize refuses to start from.
 
 **The worker module is not an `lc` verb and not a console script.** It
 makes the output unconditionally, commits nothing, leaves the tree dirty by
@@ -1215,6 +1226,39 @@ only checks that the guard is present. Verified empirically, not assumed.
 
 ### Recorded decisions
 
+- **The engine is the host's uv tool, never a project dependency**
+  (2026-08, reversing spec §2's engine-in-lock rule and deleting layer 3).
+  `lc init` scaffolds no `lightcone-cli` dependency, and there is no
+  launcher and no delegation: the `lc` that was invoked is the engine that
+  runs. What the pin bought, and where each guarantee went:
+  - *The engine inside `env_version`.* Gone, and deliberately: an lc
+    upgrade now moves nothing — no output ever reads `behind` over an
+    engine release, completing the reversal that already took
+    `env_version` out of `definition_version`. The engine is attestation
+    (`lc_version` in every manifest, `worker.lc_version()`), not identity.
+  - *Reruns reconstruct the exact engine from the commit's lock.*
+    Re-provided in the run record itself: `cmd` pins the engine by version
+    through `uv run --no-project --with lightcone-cli==<v>` (see the
+    layer-4 run-record invariant). Needs PyPI or a warm uv cache at rerun
+    time where the lock needed neither; recorded, not hidden.
+  - *Driver/worker version skew "structurally impossible".* Moot while
+    workers are in-process threads; when a venue larger than a laptop
+    lands (layer 7), its connect path must probe the remote engine version
+    — the pin no longer does it structurally.
+  - *Layer 6 note:* the generated image can no longer get its in-image
+    engine from the lock (`/opt/venv/bin/lc` existed because the pin did).
+    The Containerfile must install the engine as an explicit layer, and
+    that version becomes a tag input.
+  What it buys: a project's resolution is freed from the engine's own
+  pins (no astra-tools/click/rich/distributed/git-annex in any project
+  lock); the git-annex wheel floor gates only the tool install; the eval
+  workflow exercises the branch under test rather than a released engine
+  resolved from PyPI; and recipes no longer find `lc` or `git-annex` on
+  the sandbox PATH — the project `.venv/bin` no longer carries them,
+  which is the boundary telling the truth. The `UV_*` ambient scrub the
+  launcher would have done is still worth having and is tracked
+  separately; it protects `env_version`'s install-settings term, not the
+  delegation that is gone.
 - **Reads stay restricted, and the OS baseline is ours to maintain.**
   Codex restricts reads too now, but its Linux read baseline is a *mount
   table*, not a path list — there is nothing to adopt there. Keeping the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,43 +483,42 @@ set on their clone, so the shape a file arrives in is not ours to assume.
 "changed", because the two are different facts and only one of them means
 a rebuild.
 
-**PATH is part of the contract.** `git annex` is not a builtin — git
-dispatches it by searching `PATH` for a `git-annex` executable, and
-`uv tool install lightcone-cli` links only lc's own entry points into
-`~/.local/bin`. So `dataset.put_our_bin_first()` **prepends**
-`Path(sys.executable).parent`, idempotently, before any git call. Prepend,
-never append: the annex we resolved is the one the engine was installed
-with and tested against, and a system copy of another vintage winning
-that race is a difference nothing records. `project.require_git_annex()`
-probes after the prepend and by the name git itself searches for.
+**git-annex is on `PATH` by construction, not by runtime repair.**
+`git annex` is not a builtin — git dispatches it by searching `PATH` for
+a `git-annex` executable — and an installer links only the requested
+package's own executables, so a plain `uv tool install lightcone-cli`
+would have left the one git command we tell people to type unable to run.
+The fix is metadata: lightcone-cli re-declares the git-annex wheel's four
+entry points verbatim in its own `[project.scripts]` (`git-annex`,
+`git-annex-shell`, `git-remote-annex`, `git-remote-tor-annex`, all
+`git_annex:cli`). The wheel ships no raw binaries in `bin/` — its
+executables *are* that dispatcher, which `execv`s the real binary out of
+package data with `argv[0]` preserved, and git-annex dispatches on
+`argv[0]` busybox-style. So every install channel carries the
+executables wherever it carries `lc`: the tool install links all five
+names (verified), `uv run` and `uvx` front the venv's bin, and the
+rerun's ephemeral engine environment gets them the same way. That covers
+lc's own subprocesses *and* the researcher's bare `git add` with one
+mechanism, which is why the old `put_our_bin_first()` PATH-prepend was
+deleted rather than kept as a belt: a second answer to "which annex runs"
+that could disagree with the shell's.
 
-Measured, not assumed: with only the tool's `lc` on `PATH` — exactly what
-`uv tool install` produces — `git annex version` fails, and with the
-prepend disabled `lc init` refuses. With the engine out of the project's
-lock, the prepend is the *only* way git finds git-annex; there is no
-project `.venv/bin` fallback to mask a regression.
-
-The prepend covers **lc's own subprocesses only**. The researcher's own
-shell — where a plain `git add` has to work — is covered **by
-construction at install time**: lightcone-cli re-declares the git-annex
-wheel's four entry points verbatim in its own `[project.scripts]`
-(`git-annex`, `git-annex-shell`, `git-remote-annex`,
-`git-remote-tor-annex`, all `git_annex:cli`). The wheel ships no raw
-binaries in `bin/` — its executables *are* that dispatcher, which
-`execv`s the real binary out of package data with `argv[0]` preserved,
-and git-annex dispatches on `argv[0]` busybox-style. An installer links
-the requested package's own entry points, so a plain
-`uv tool install lightcone-cli` puts all five names on `PATH` — verified,
-including the duplicate-name question: both distributions generate
-byte-identical scripts, so whichever writes the venv's copy, the result
-is the same. The declaration is mirrored, never invented:
+The declaration is mirrored, never invented:
 `test_the_annex_executables_are_ours_to_install` asserts ours match the
-wheel's exactly, so an upstream rename fails the suite rather than every
-user's install. (Considered and rejected: there is no pyproject metadata
-to link a *dependency's* executables; `--with-executables-from` is an
-install-time flag users won't type; vendoring the binaries into
-platform-specific lightcone-cli wheels is five 14–36 MB wheels and a
-repack pipeline for what four lines of metadata provide.)
+wheel's exactly, so an executable upstream adds, drops or renames fails
+the suite rather than every user's install. (Considered and rejected:
+there is no pyproject metadata to link a *dependency's* executables;
+`--with-executables-from` is an install-time flag users won't type; a
+post-install link repair contradicts "the install command is enough";
+vendoring the binaries into platform-specific lightcone-cli wheels is
+five 14–36 MB wheels and a repack pipeline for what four lines of
+metadata provide.)
+
+The accepted residue of dropping the prepend: `PATH` order is the
+user's, so a system git-annex fronting the install's wins the dispatch —
+for lc's subprocesses exactly as for their own git, and no different
+from which `git` itself runs. Nothing records the annex version anyway
+(see the Recorded decision on the engine's dependency closure).
 
 **A project can sit inside a larger repository, so `dataset.status` is
 scoped and relativised.** `lc init subdir/` adopts an enclosing work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,16 +500,26 @@ lock, the prepend is the *only* way git finds git-annex; there is no
 project `.venv/bin` fallback to mask a regression.
 
 The prepend covers **lc's own subprocesses only**. The researcher's own
-shell — where "just type `git add`" has to work — is a separate question,
-and there is no pyproject metadata that can declare "link my dependency's
-executables" (and no entry-point re-export either: the wheel already
-installs a script named `git-annex` into the venv, so an entry point of
-the same name collides). uv's answer is an install-time flag, verified
-here: `uv tool install --with-executables-from git-annex lightcone-cli`
-links `git-annex`, `git-annex-shell` and the two `git-remote-*` helpers
-beside `lc`, after which a bare `git add` works in any shell whose PATH
-has the tool bin. That spelling belongs in the install docs when they are
-rewritten.
+shell — where a plain `git add` has to work — is covered **by
+construction at install time**: lightcone-cli re-declares the git-annex
+wheel's four entry points verbatim in its own `[project.scripts]`
+(`git-annex`, `git-annex-shell`, `git-remote-annex`,
+`git-remote-tor-annex`, all `git_annex:cli`). The wheel ships no raw
+binaries in `bin/` — its executables *are* that dispatcher, which
+`execv`s the real binary out of package data with `argv[0]` preserved,
+and git-annex dispatches on `argv[0]` busybox-style. An installer links
+the requested package's own entry points, so a plain
+`uv tool install lightcone-cli` puts all five names on `PATH` — verified,
+including the duplicate-name question: both distributions generate
+byte-identical scripts, so whichever writes the venv's copy, the result
+is the same. The declaration is mirrored, never invented:
+`test_the_annex_executables_are_ours_to_install` asserts ours match the
+wheel's exactly, so an upstream rename fails the suite rather than every
+user's install. (Considered and rejected: there is no pyproject metadata
+to link a *dependency's* executables; `--with-executables-from` is an
+install-time flag users won't type; vendoring the binaries into
+platform-specific lightcone-cli wheels is five 14–36 MB wheels and a
+repack pipeline for what four lines of metadata provide.)
 
 **A project can sit inside a larger repository, so `dataset.status` is
 scoped and relativised.** `lc init subdir/` adopts an enclosing work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,17 @@ environment is there (`pyproject.toml`, `uv.lock`, `.venv`) and does not
 require an `astra.yaml`, so any uv project can be probed. No walk-up:
 the directory you invoke from is the project, or it is a clean error.
 
+**Two questions about a project root, not one** — the same shape as
+`_in_repository` / `_can_ask_git` below. `declared_project()` wants only
+what the repository carries (`pyproject.toml`, `uv.lock`);
+`current_project()` adds `.venv`. The split is named rather than a
+`synced=` flag on one function, because "what makes a directory a
+project" should not be negotiable per call site, and because a slice of
+a constant would make the answer depend on the order its entries happen
+to be in. The weaker question has exactly one caller — the worker entry
+point, which builds the `.venv` a moment later — and that is the whole
+reason it exists.
+
 **CLI startup stays cheap.** `commands.py` imports the engine *inside* the
 command callbacks and builds the rich console lazily, so `lc --help` and
 shell completion pay for neither. Keep this up as verbs land: a module-scope
@@ -917,13 +928,21 @@ commit the run went on to create. It is the code that produced the output.
 A test that reads `dataset.head()` after materializing and expects a match
 is asserting the wrong thing.
 
-**One uv hop, one spelling** (`project.uv_prefix(root, *, sync)`). The
-only thing its callers disagree about is `sync`: a probe converges the
-environment it is about to describe, a recipe must not, or every
-concurrent worker writes the same `.venv`. The run record carries no uv
-hop at all — the worker entry point converges the project environment for
-itself, so there is nothing in the record to drift out of step with the
-prefix.
+**One *project* uv hop, one spelling** (`project.uv_prefix(root, *,
+sync)`). The only thing its callers disagree about is `sync`: a probe
+converges the environment it is about to describe, a recipe must not, or
+every concurrent worker writes the same `.venv`.
+
+The run record's `cmd` is the deliberate second shape, and it is not the
+drift the rule guards against: it is *project-less* by construction
+(`uv run --no-project --with lightcone-cli==<v>`), so it shares no flag
+with `uv_prefix` — no `--project`, no `--locked`, no sync selection,
+because there is no project environment involved. It builds an engine to
+run, where `uv_prefix` enters an environment already built. Routing one
+through the other would mean a helper with two disjoint output shapes.
+What keeps *that* hop from drifting is that the worker it invokes
+converges the project environment itself, so the record never has to
+spell how.
 
 **A run syncs the environment; it does not report on it.** `uv run
 --locked` asserts only that `uv.lock` still matches `pyproject.toml`, and
@@ -982,6 +1001,14 @@ interpreter imports it. The bare recipe would reconstruct nothing lc adds
 commit bytes the identity model never produced; `lc materialize` cannot
 be it either, because `datalad rerun` removes the declared outputs first
 and that dirties the tree materialize refuses to start from.
+
+The **shipped** shape is the one the suite cannot execute, and that is
+worth knowing rather than discovering. The tests run a dev build, so both
+end-to-end rerun tests exercise the bare-module branch; the pinned branch
+every real commit will carry is covered only by a string assertion over a
+monkeypatched version. Verified by hand instead, against a wheel built
+from the branch — record it that way again when the branch changes, and
+treat "the suite is green" as saying nothing about it.
 
 **The worker module is not an `lc` verb and not a console script.** It
 makes the output unconditionally, commits nothing, leaves the tree dirty by
@@ -1245,6 +1272,13 @@ only checks that the guard is present. Verified empirically, not assumed.
     workers are in-process threads; when a venue larger than a laptop
     lands (layer 7), its connect path must probe the remote engine version
     — the pin no longer does it structurally.
+  - *The engine's dependency closure left the record entirely, and is not
+    replaced.* The project lock used to pin what the engine resolved —
+    most concretely the git-annex build that wrote the bytes. Now
+    `lc_version` names the engine and nothing pins what it was made of.
+    Accepted rather than re-provided: the alternative is hashing an
+    environment lc does not own into artifacts it does, which is the
+    over-sensitivity the `behind` model exists to avoid.
   - *Layer 6 note:* the generated image can no longer get its in-image
     engine from the lock (`/opt/venv/bin/lc` existed because the pin did).
     The Containerfile must install the engine as an explicit layer, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,13 +23,16 @@ lc's whole ASTRA surface is ten functions; see Key Invariants (layer 4).
 
 ## ⚠️ This repository is a clean rebuild in progress
 
-The codebase is being **re-added layer by layer** on top of the normative
-design spec:
+The codebase is being **re-added layer by layer** on top of the design
+spec:
 
 > **`../lightcone-cli/docs/design/execution-environment.md`** — *"the
-> locked environment is the execution environment"*, v6.1. Normative.
-> Read it before adding anything. It lives in the sibling checkout for
-> now (branch `redesign_prototype`), alongside its decision records
+> locked environment is the execution environment"*, v6.1. Read it before
+> adding anything — but read it as a **reference, not gospel**: the
+> rebuild deliberately drifts from it as implementation teaches better
+> answers, and where this file's Recorded decisions disagree with the
+> spec, the decisions win. It lives in the sibling checkout for now
+> (branch `redesign_prototype`), alongside its decision records
 > (rationale, substrate tradeoffs, hermeticity enforcement, the v6
 > review); it moves into this repo's `docs/design/` when the docs are
 > rewritten at the end of the rebuild.
@@ -107,7 +110,9 @@ Each of these has been asked for in review at least once; none is optional.
   rebuild is complete. Same for `README.md` and `zensical.toml`.
 - **Port with intent.** Prior implementations (this repo's git history,
   and the `redesign_prototype` branch of the sibling `lightcone-cli`
-  checkout) are references, not sources of truth. The spec is.
+  checkout) are references, not sources of truth. Neither is the spec by
+  itself: the spec plus this file's Recorded decisions is the current
+  design, and the decisions override the spec where they disagree.
 - **Every layer ships tests.** See the per-layer test list in spec §11.
 
 ## Architecture (target)
@@ -152,7 +157,7 @@ src/lightcone/              # namespace — NO __init__.py
 ├── _sandbox_exec.py        # the Landlock shim — stdlib only, zero lightcone imports
 ├── cli/                    # the CLI only: flags, rendering, exit codes
 │   ├── __init__.py         # exposes main(), lazily
-│   └── commands.py         # lc init, lc run, lc materialize
+│   └── commands.py         # lc init, lc run, lc materialize, lc status
 └── engine/
     ├── __init__.py         # docstring only
     ├── project.py          # what a project is: convergence + discovery
@@ -172,7 +177,7 @@ src/lightcone/              # namespace — NO __init__.py
     │   ├── seatbelt.py     # macOS backend
     │   └── denial.py       # the denial UX
     └── templates/          # the scaffold's file content
-        ├── __init__.py     # loader + one renderer per scaffolded file
+        ├── __init__.py     # loader; a renderer only where there is a value to decide
         └── files/*.tmpl    # the templates themselves, as real files
 
 evals/                      # agentic eval seed: prompt.md + tasks/<id>/
@@ -182,17 +187,19 @@ tests/                      # pytest — mirrors src/
 ## Development Commands
 
 ```bash
-uv sync --group dev              # installs pytest, ruff, mypy
+uv sync --group dev              # pytest (+ pytest-cov), ruff, mypy, datalad
 uv run pytest
 uv run ruff check src/ tests/    # --fix to apply
 uv run mypy src/
-uv build                         # wheel + sdist
+uv build                         # wheel + sdist (CI runs this only to publish)
 ```
 
-These four are the whole loop, and they are exactly what CI runs
-(`.github/workflows/{tests,lint}.yml`). There is deliberately no task
+Test, lint and type-check are the whole loop, and they are what
+`.github/workflows/{tests,lint}.yml` run. There is deliberately no task
 runner in between — the pre-rebuild `justfile` was 90 lines of wrappers
-around them plus recipes for the frozen docs and the dormant eval.
+around them plus recipes for the frozen docs and the dormant eval. The
+other workflows are `eval.yml` (the agentic eval, on dispatch or PR
+label), `pypi-publish.yaml`, and `docs-deploy.yml` for the frozen docs.
 
 ## Key Invariants (layer 1)
 
@@ -275,14 +282,15 @@ one place, so they can't conflict, and neither is a number to maintain.
 Identity follows the project's files from there: `env_version` hashes
 `.python-version`'s bytes, not anything in the engine (spec §3).
 
-**`.gitignore` converges entry-wise, not by marker.**
-`templates.gitignore_entries()` is the template minus comments and blanks;
-`missing_gitignore_entries(text)` is what a repair appends, in template
+**`.gitignore` and `.gitattributes` converge entry-wise, not by marker.**
+`templates.entries(name)` is a template minus comments and blanks;
+`templates.missing(name, text)` is what a repair appends, in template
 order. Idempotency is therefore structural — a pattern already in the file
 is never re-added, whoever wrote it — and a pattern introduced by a later
 lc release still reaches projects that already have a `.gitignore`, which
-a "marker present ⇒ done" check would have skipped. `GITIGNORE_HEADER` is
-cosmetic only; never make correctness depend on it.
+a "marker present ⇒ done" check would have skipped. The header comment
+(`templates.header`) is cosmetic only; never make correctness depend on
+it.
 
 **What `lc init` converges** — idempotently, never overwriting a file the
 user owns:
@@ -292,11 +300,11 @@ user owns:
 | `astra.yaml` + `universes/baseline.yaml` | astra's boilerplate spec, verbatim, as **one item keyed on `astra.yaml`** — the baseline references the boilerplate's example decision, so it must never land beside a user-authored spec. Its `container:` key is ignored outright — see Recorded decisions |
 | `pyproject.toml` | The uv project: **virtual** (no `[build-system]`), no dependencies — the engine is the host's uv tool, never a project dependency (see Recorded decisions), so the lock carries only what the analysis imports |
 | `.python-version` | The exact patch of the interpreter `lc` is running on |
-| `uv.lock`, `.venv` | **Derived** — converged by correctness, not existence: `uv lock --check` / `uv sync --check` decide, then `uv lock` / `uv sync --locked --exact --compile-bytecode` repair |
+| `uv.lock`, `.venv` | **Derived** — converged by correctness, not existence: `uv lock --check` / `uv sync --locked --exact --check` decide, then `uv lock` / `uv sync --locked --exact --compile-bytecode` repair |
 | `.gitignore` | One managed block of patterns; convergence ensures each is present |
 | `.git` + the annex | `git init` then `git annex init` — results are versioned in the project's own repository |
 | `.gitattributes` | The storage policy: what git-annex holds and what git carries. Line-managed, like `.gitignore` |
-| `.datalad/config` | A `datalad.dataset.id` UUID, generated once. lc never reads it back |
+| `.datalad/config` | A `datalad.dataset.id` UUID, generated once. Read back only by `dataset.dataset_id`, through `git config -f`, for the run record's `dsid` |
 | `data/` + `README.md` | Where declared inputs live; annexed, and committed before anything computes on them |
 | `results/` + `README.md` | Where outputs land; the README states the materialize-don't-hand-write contract |
 | `myst.yml`, `index.md` | Template MyST report referencing `astra.yaml` *by path* |
@@ -369,8 +377,8 @@ user owns:
   storage substrate, and results are versioned in the repository, so there
   is no useful project without any of them. git is the one tool uv cannot
   install and the single admitted exception to a uv-installable stack;
-  git-annex ships as a wheel and is therefore a locked dependency, which
-  makes its wheel platforms the CLI's install floor.
+  git-annex ships as a wheel and is therefore a dependency of the lc tool
+  itself, which makes its wheel platforms the CLI's install floor.
   (This reverses layer 1's original "git is optional" — a project without
   version control had nowhere to put a result.)
 - **Two questions about git, not one.** `_in_repository` is a pure
@@ -459,10 +467,10 @@ set on their clone, so the shape a file arrives in is not ours to assume.
 - **Unlocked** — what `filter=annex` writes, hard-linked or copied alike.
   A clone without content holds a ~100-byte *pointer file* where the data
   would be: it exists, it is readable, and hashing it yields a perfectly
-  well-formed digest of the wrong thing. The test is git-annex's own
-  `isPointerFile` — a `/annex/objects/` prefix within the first 32 KiB.
-  Measured before it was fixed: the same input hashed differently on a
-  clone, silently.
+  well-formed digest of the wrong thing. The test follows git-annex's own
+  `isPointerFile`: a file no larger than 32 KiB whose bytes begin
+  `/annex/objects/`. Measured before it was fixed: the same input hashed
+  differently on a clone, silently.
 - **Locked** — a symlink into the object store, which without the content
   dangles. This one is quieter and worse: `is_file()` answers False for a
   dangling symlink, so a directory walk filtered on that alone drops the
@@ -480,15 +488,28 @@ dispatches it by searching `PATH` for a `git-annex` executable, and
 `uv tool install lightcone-cli` links only lc's own entry points into
 `~/.local/bin`. So `dataset.put_our_bin_first()` **prepends**
 `Path(sys.executable).parent`, idempotently, before any git call. Prepend,
-never append: a system copy winning would make the version the project's
-lock records a fiction. `project.require_git_annex()` probes after the
-prepend and by the name git itself searches for.
+never append: the annex we resolved is the one the engine was installed
+with and tested against, and a system copy of another vintage winning
+that race is a difference nothing records. `project.require_git_annex()`
+probes after the prepend and by the name git itself searches for.
 
 Measured, not assumed: with only the tool's `lc` on `PATH` — exactly what
 `uv tool install` produces — `git annex version` fails, and with the
 prepend disabled `lc init` refuses. With the engine out of the project's
 lock, the prepend is the *only* way git finds git-annex; there is no
 project `.venv/bin` fallback to mask a regression.
+
+The prepend covers **lc's own subprocesses only**. The researcher's own
+shell — where "just type `git add`" has to work — is a separate question,
+and there is no pyproject metadata that can declare "link my dependency's
+executables" (and no entry-point re-export either: the wheel already
+installs a script named `git-annex` into the venv, so an entry point of
+the same name collides). uv's answer is an install-time flag, verified
+here: `uv tool install --with-executables-from git-annex lightcone-cli`
+links `git-annex`, `git-annex-shell` and the two `git-remote-*` helpers
+beside `lc`, after which a bare `git add` works in any shell whose PATH
+has the tool bin. That spelling belongs in the install docs when they are
+rewritten.
 
 **A project can sit inside a larger repository, so `dataset.status` is
 scoped and relativised.** `lc init subdir/` adopts an enclosing work
@@ -606,9 +627,11 @@ any dependency change, and every output in every project on an lc upgrade.
 That was recorded as an accepted cost; it was the bug.)
 
 Nothing is lost by not rebuilding: the manifest records the environment
-*and* the commit, and that commit's `uv.lock` reconstructs the
-environment exactly. Over-sensitivity in `env_version` is affordable
-precisely because it no longer spends compute.
+*and* the commit, and that commit's `uv.lock` reconstructs the project
+environment exactly. (The engine is not in that lock — its reconstruction
+is the run record's job, and its version the manifest's `lc_version`.)
+Over-sensitivity in `env_version` is affordable precisely because it no
+longer spends compute.
 
 **Both are length-framed.** Concatenating fields raw lets a boundary shift
 between them produce one digest from two different inputs.  `_frame`
@@ -752,8 +775,8 @@ path component.** An empty universe or output id collapses
 `results/<u>/<o>` onto a *parent* — `results/` itself, for two — and the
 worker empties that directory before running a recipe in it, so the
 consequence of an unchecked id is deleting every other universe's
-outputs. A `/`, `.` or `..` is refused for the same reason. This is the
-guard that lets the reset stay a whole-directory operation.
+outputs. A `/`, `\`, `.` or `..` is refused for the same reason. This is
+the guard that lets the reset stay a whole-directory operation.
 
 **The reset takes the whole directory, and cannot take a named list.** A
 recipe declares an output *id*, never filenames, so there is no set of
@@ -950,8 +973,9 @@ workers pass `--no-sync` — so a lock edited without a sync would leave
 recipes importing packages the lock does not describe while every manifest
 recorded the *new* lock's `env_version`. Measured: the recipe imported
 `packaging 26.3` under a lock saying `24.2`, and uv accepted it silently.
-`materialize()` calls `project.sync()` before anything else, so the state
-is made impossible rather than detected. `--check` needs neither:
+`materialize()` calls `project.sync()` right after the tool and committer
+preflight — before the dirty check and the graph — so the state is made
+impossible rather than detected. `--check` needs neither:
 `env_version` is the lock's bytes, so a drifted `.venv` cannot change what
 it answers.
 
@@ -983,7 +1007,7 @@ than a trap.
 declared input under `data/` is an annex symlink, so a `Path.resolve()`
 in the record's `inputs` writes `.git/annex/objects/SHA256E-…` — the
 storage rather than the input, and a path nothing can `datalad get`. This
-shipped once; `_inside` is lexical now.
+shipped once; `plan.declared_path` is lexical now, never resolved.
 
 **The run record is genuinely re-runnable, and every record pins its
 engine.** `uv run --no-project --with '<requirement>' -- python -m
@@ -1019,7 +1043,11 @@ design. `lc --help` advertising it would hand people a footgun, and a
 `[project.scripts]` entry would put it on `$PATH` through
 `uv tool install`. `lightcone/_sandbox_exec.py` is the same shape for the
 same reason. Keep it cheap to import — **no click, no rich** — it is on
-the path of every task and every rerun; two tests pin that.
+the path of every task and every rerun.
+`test_the_worker_module_imports_neither_click_nor_rich` pins the imports
+and `test_help_does_not_advertise_the_worker` the absence from `--help`;
+nothing pins the absence of a `[project.scripts]` entry, so treat that
+as a review item.
 
 **The record's format is datalad's, so it is tested through datalad.**
 `get_run_info` matches with a regex and returns `(None, None)` on any
@@ -1029,13 +1057,14 @@ So the suite asserts through datalad's parser *and* runs a real
 `datalad rerun`, and `datalad` is a **dev** dependency only. Nothing in lc
 imports it.
 
-**A policy is a description, and `scope()` owns every policy's lifetime.**
-`exec_policy` creates no directory — the worker resets the output
-directory, so the whole of an output's lifecycle stays in the module that
-owns it, and a policy that could not be built without touching the
-filesystem would be the impurity `wrap` is already pinned against.
-`sandbox.scope` takes a *built* policy, so the `rmtree` of the private
-`$HOME` has one owner.
+**A policy describes the project; it never prepares it.** `exec_policy`
+creates nothing in the project tree — the worker resets the output
+directory, so the whole of an output's lifecycle stays in the module
+that owns it, and `results/` is granted only if it already exists. The
+one thing it does put on disk is the per-run private `$HOME`
+(`mkdtemp`), and that is why `sandbox.scope` takes a *built* policy: the
+`rmtree` of that directory has one owner. (`wrap` stays pure; the
+impurity lives in policy construction, once.)
 
 **There is one policy, `exec_policy`, and a recipe gets exactly what a
 probe gets.** The tree is read-only apart from `results/`, for both. So
@@ -1061,7 +1090,11 @@ do not describe it as covered.
 `submit(fn, *args, key=…)` and `completed(handles)`. That is all the
 driver asks of a scheduler and all a venue has to supply — which is what
 lets the suite run a graph inline in-process, and what will let something
-larger than a laptop land behind it without the driver noticing.
+larger than a laptop land behind it without the driver noticing. A venue
+owes one thing beyond the two methods: its worker processes must run an
+interpreter that imports `lightcone.engine` at the driver's version —
+see the engine-is-the-host's-uv-tool decision for how each venue
+provides that, and for what workers do *not* need (git, git-annex).
 
 ### Recorded deviations from the spec (layers 2 and 4)
 
@@ -1145,10 +1178,13 @@ Landlock unions rights over ancestors, so a single EXECUTE grant on
 layer enforcing nothing — while every test still passes, because the
 allowlisted binaries are exactly the ones that were going to work. This
 shipped once: the venv interpreter's *install root* was granted EXECUTE
-so the resolved symlink target would be runnable, which is `/usr` for
-any venv built on a system python (`uv venv --python-preference
-only-system`, most CI images, HPC site pythons). The grant is on the
-interpreter **file**; only READ goes to the install root, for the stdlib.
+unconditionally, which is `/usr` for any venv built on a system python
+(`uv venv --python-preference only-system`, most CI images, HPC site
+pythons). The rule now: the interpreter **file** always; its install
+root gets EXECUTE only when it is the interpreter's *own tree* (a
+uv-managed store, a framework version directory — macOS framework
+builds re-exec into `Resources/Python.app`), never a `_SHARED_PREFIXES`
+member; and READ goes to the root regardless, for the stdlib.
 `test_a_system_interpreter_does_not_make_the_whole_prefix_executable`
 pins it.
 
@@ -1272,10 +1308,27 @@ only checks that the guard is present. Verified empirically, not assumed.
     release, by source commit for a dev build (see the layer-4 run-record
     invariant). Needs PyPI or the git remote reachable at rerun time
     where the lock needed neither; recorded, not hidden.
-  - *Driver/worker version skew "structurally impossible".* Moot while
-    workers are in-process threads; when a venue larger than a laptop
-    lands (layer 7), its connect path must probe the remote engine version
-    — the pin no longer does it structurally.
+  - *Driver/worker version skew "structurally impossible".* Re-provided
+    by sharing the **installation** instead of the lock. What a Dask
+    worker process actually needs is `lightcone.engine` importable at a
+    matching version — pickle serializes `worker.materialize` by
+    reference and `Task`/`Versions`/`TaskResult` by class reference.
+    Verified by hand (2026-08-20), not pinned by the suite — a full
+    materialization through a `LocalCluster(processes=True)`: the
+    current code works unchanged across process boundaries, and workers
+    need **no git and no git-annex** (the driver owns git alone;
+    `data_version` is pure file hashing). The shipped cluster is
+    threads; re-verify when layer 7 makes processes real. So per venue: on HPC the tool env lives on the shared
+    filesystem and the venue launches workers on the driver's own
+    interpreter (`sys.executable` — dask-jobqueue's `python=`), which
+    makes driver and workers the identical installation; in containerized
+    mode driver and workers share the image, same result. Both also
+    satisfy `distributed`'s own client/scheduler/worker coherence
+    requirement for free. A connect-time engine-version probe is needed
+    only for a cluster lc did not launch (a pre-existing gateway with its
+    own image). One venue cost to remember: the `assets.Versions` memo
+    degrades to once **per worker process**, so a declared input shared
+    by many tasks is re-hashed per process — efficiency, not correctness.
   - *The engine's dependency closure left the record entirely, and is not
     replaced.* The project lock used to pin what the engine resolved —
     most concretely the git-annex build that wrote the bytes. Now
@@ -1391,13 +1444,17 @@ only checks that the guard is present. Verified empirically, not assumed.
   future-facing surface; a system-layer declaration is currently inert,
   like `astra.yaml`'s `container:` key.
 - **The denial's remedies are only what works today** — `uv add` for a
-  Python package, plus the ASTRA input declaration. Nothing in a denial
-  message names a verb, flag, or declaration that does not exist.
-- **No manifest is written, and no serializer for one.** A probe has no
-  output (§4), so the `Attestation` is returned and printed rather than
-  persisted. An earlier draft carried a `to_manifest()` with no caller —
-  deleted, because "no dead code" applies to this layer's own
-  conveniences too. It lands with layer 4, which is what needs it.
+  Python package, the ASTRA input declaration for data, and "output goes
+  in `results/`" plus `tempfile.mkdtemp()` for a write denial. Nothing in
+  a denial message names a verb, flag, or declaration that does not
+  exist.
+- **`Attestation` has no serializer of its own.** An earlier draft
+  carried a `to_manifest()` with no caller — deleted, because "no dead
+  code" applies to this layer's own conveniences too. It is persisted by
+  the layer that needs it: the worker writes `asdict(outcome.attestation)`
+  into the manifest's `hermeticity` field. `lc run` is still a probe with
+  no output (§4), so there the attestation is returned and printed, never
+  persisted.
 - **`results/` is writable; the rest of the tree is not**, where §4 gives
   a probe no output and therefore no in-tree write scope at all. A probe
   gets the same write scope a recipe does, so a probe that works means a
@@ -1417,11 +1474,13 @@ only checks that the guard is present. Verified empirically, not assumed.
     bind-mounts the working tree read-write". True of the default, not of
     the mount table we will write — and the experiment that settled it is
     two `podman -v` flags. Don't re-derive it from the default again.
-  - **`_exec_set` grants no directory anywhere**, including `.venv/bin`.
-    A directory grant is a grant on whatever the directory holds *later*,
-    which was a live hole for as long as the tree was writable: `cp
-    /usr/bin/git .venv/bin/` ran a tool the allowlist denies by name.
-    Belt-and-braces under a read-only tree, one scandir, keep it.
+  - **`_exec_set` grants no directory except the interpreter's own
+    install tree** (see the layer-5 EXECUTE invariant) — and never
+    `.venv/bin`. A directory grant is a grant on whatever the directory
+    holds *later*, which was a live hole for as long as the tree was
+    writable: `cp /usr/bin/git .venv/bin/` ran a tool the allowlist
+    denies by name. Belt-and-braces under a read-only tree, one scandir,
+    keep it.
   - **A write-denial test must target a path the OS would let you
     write.** `printf x > /etc/…` passes with no sandbox at all — the OS
     refuses it for any non-root user — so it pins nothing. The sound
@@ -1468,15 +1527,19 @@ only checks that the guard is present. Verified empirically, not assumed.
   `engine.project._run`, emulating each tool's observable effect (`uv lock`
   writes `uv.lock`, `uv sync` makes `.venv`, `git init` makes `.git`,
   `git annex init` marks the repository annexed) and recording every argv.
-  `uv_calls(tools)` narrows it to uv. Tests are hermetic: no network, no
+  `uv_calls(tools)` narrows it to uv; `probes(calls)` to the read-only
+  `--check` probes. Under the stub, tests are hermetic: no network, no
   resolution, no subprocesses. The `real_tools` fixture opts back out,
-  putting the real `_run` back.
-- `tests/test_dataset.py` — the storage seam, and **the one place in the
-  non-sandbox suite that runs real tools**, via `real_tools`. That is
-  deliberate: the question is whether bytes land in the annex or as a blob
-  in git, and a fake answering it would only restate what the code already
-  believes. Every bug this file found (the missing `.gitattributes`
-  default, the pointer-file trap, `filter=annex`) was invisible to a stub.
+  putting the real `_run` back — and everything built on it (`analysis`,
+  and `test_materialize.py`'s `engine_dist` wheel build plus the rerun
+  tests' ephemeral `uv run --with` resolve) does spawn, resolve, and may
+  touch the network.
+- `tests/test_dataset.py` — the storage seam, tested against real tools
+  via `real_tools`, deliberately: the question is whether bytes land in
+  the annex or as a blob in git, and a fake answering it would only
+  restate what the code already believes. Every bug this file found (the
+  missing `.gitattributes` default, the pointer-file trap, `filter=annex`)
+  was invisible to a stub.
 - `tests/test_project.py` — discovery and convergence semantics, called
   directly. This is where scaffold behavior is tested.
 - `tests/test_plan.py` tests what lc adds — directories, edges,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -985,30 +985,33 @@ in the record's `inputs` writes `.git/annex/objects/SHA256E-…` — the
 storage rather than the input, and a path nothing can `datalad get`. This
 shipped once; `_inside` is lexical now.
 
-**The run record is genuinely re-runnable, and its `cmd` is the worker
-module.** `python -m lightcone.engine.worker <universe>/<output_id>`,
-behind `uv run --no-project --with lightcone-cli==<v>` when the engine
-that made the output is a published release — an ephemeral environment
-that reconstructs the *engine* by version, while the worker itself
+**The run record is genuinely re-runnable, and every record pins its
+engine.** `uv run --no-project --with '<requirement>' -- python -m
+lightcone.engine.worker <universe>/<output_id>` — an ephemeral
+environment that reconstructs the *engine*, while the worker itself
 reconstructs the *project* environment from the rerun commit's own lock
 (`main()` syncs before anything executes; `uv run --no-sync` against a
 missing `.venv` silently creates an empty one, so a clone's rerun would
 otherwise run recipes in a bare environment under a manifest recording
-the lock's `env_version`). A dev build's version is unpublished, so its
-record is the bare module, which only ever exists in a checkout whose own
-interpreter imports it. The bare recipe would reconstruct nothing lc adds
-(no locked environment, no boundary, no gates, no manifest) and would
-commit bytes the identity model never produced; `lc materialize` cannot
-be it either, because `datalad rerun` removes the declared outputs first
-and that dirties the tree materialize refuses to start from.
+the lock's `env_version`). The bare recipe would reconstruct nothing lc
+adds (no locked environment, no boundary, no gates, no manifest) and
+would commit bytes the identity model never produced; `lc materialize`
+cannot be it either, because `datalad rerun` removes the declared outputs
+first and that dirties the tree materialize refuses to start from.
 
-The **shipped** shape is the one the suite cannot execute, and that is
-worth knowing rather than discovering. The tests run a dev build, so both
-end-to-end rerun tests exercise the bare-module branch; the pinned branch
-every real commit will carry is covered only by a string assertion over a
-monkeypatched version. Verified by hand instead, against a wheel built
-from the branch — record it that way again when the branch changes, and
-treat "the suite is green" as saying nothing about it.
+The requirement (`materialize._engine_requirement`) pins a release by
+version and a dev build by its source commit — hatch-vcs embeds the
+commit in the version, and the repository URL comes from
+`[project.urls]`, the engine's own metadata rather than a constant. So a
+rerun works during development too, against the commit that ran
+(verified against GitHub: uv resolves the short sha and hatch-vcs builds
+the matching version from the clone). An unpushed commit fails a rerun
+loudly at resolution, which beats silently finding another engine; a
+dirty tree pins the last commit, and the version's `.dYYYYMMDD` marker in
+the manifest is what says the bytes had drifted from it. The e2e rerun
+tests monkeypatch the requirement seam to a wheel built from the working
+tree (`UV_FIND_LINKS`), because a git pin can only ever build *committed*
+code and the suite must execute the code under test.
 
 **The worker module is not an `lc` verb and not a console script.** It
 makes the output unconditionally, commits nothing, leaves the tree dirty by
@@ -1264,10 +1267,11 @@ only checks that the guard is present. Verified empirically, not assumed.
     `env_version` out of `definition_version`. The engine is attestation
     (`lc_version` in every manifest, `worker.lc_version()`), not identity.
   - *Reruns reconstruct the exact engine from the commit's lock.*
-    Re-provided in the run record itself: `cmd` pins the engine by version
-    through `uv run --no-project --with lightcone-cli==<v>` (see the
-    layer-4 run-record invariant). Needs PyPI or a warm uv cache at rerun
-    time where the lock needed neither; recorded, not hidden.
+    Re-provided in the run record itself: `cmd` pins the engine through
+    `uv run --no-project --with '<requirement>'` — by version for a
+    release, by source commit for a dev build (see the layer-4 run-record
+    invariant). Needs PyPI or the git remote reachable at rerun time
+    where the lock needed neither; recorded, not hidden.
   - *Driver/worker version skew "structurally impossible".* Moot while
     workers are in-process threads; when a venue larger than a laptop
     lands (layer 7), its connect path must probe the remote engine version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ docs = [
 ]
 
 
+[project.urls]
+Repository = "https://github.com/LightconeResearch/lightcone-cli"
+
 [project.scripts]
 lc = "lightcone.cli:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,16 @@ Repository = "https://github.com/LightconeResearch/lightcone-cli"
 
 [project.scripts]
 lc = "lightcone.cli:main"
+# The git-annex wheel's own entry points, re-declared verbatim: an
+# installer links only the requested package's executables, and a plain
+# `uv tool install lightcone-cli` must put git-annex on the shell's PATH
+# — `filter=annex` makes the researcher's own `git add` need it. The
+# suite pins these against the wheel's, so an upstream change fails
+# loudly here rather than silently at install time.
+git-annex = "git_annex:cli"
+git-annex-shell = "git_annex:cli"
+git-remote-annex = "git_annex:cli"
+git-remote-tor-annex = "git_annex:cli"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/src/lightcone/engine/assets.py
+++ b/src/lightcone/engine/assets.py
@@ -250,6 +250,11 @@ class Manifest:
     git_sha: str
     #: The `origin` URL, or empty when the repository has no remote.
     git_remote: str
+    #: The engine that made it. Attestation, not identity — it is outside
+    #: both hashes, so an lc upgrade neither stales an output nor puts it
+    #: behind. With the engine outside the project's lock too, this and
+    #: the run record are the whole of what says which engine ran. Empty
+    #: for an engine imported from a source tree with no metadata.
     lc_version: str
     #: What the sandbox actually enforced, as the boundary attested it.
     hermeticity: dict[str, Any]

--- a/src/lightcone/engine/assets.py
+++ b/src/lightcone/engine/assets.py
@@ -250,11 +250,8 @@ class Manifest:
     git_sha: str
     #: The `origin` URL, or empty when the repository has no remote.
     git_remote: str
-    #: The engine that made it. Attestation, not identity — it is outside
-    #: both hashes, so an lc upgrade neither stales an output nor puts it
-    #: behind. With the engine outside the project's lock too, this and
-    #: the run record are the whole of what says which engine ran. Empty
-    #: for an engine imported from a source tree with no metadata.
+    #: The engine that made it. Attestation, not identity: outside both
+    #: hashes, so an lc upgrade neither stales an output nor puts it behind.
     lc_version: str
     #: What the sandbox actually enforced, as the boundary attested it.
     hermeticity: dict[str, Any]

--- a/src/lightcone/engine/dataset.py
+++ b/src/lightcone/engine/dataset.py
@@ -18,37 +18,10 @@ asks anyone to run a git-annex command by hand.
 
 from __future__ import annotations
 
-import os
-import sys
 from collections.abc import Iterable
 from pathlib import Path
 
 from lightcone.engine import project
-
-
-def put_our_bin_first() -> None:
-    """Prepend the directory holding our own interpreter to ``PATH``.
-
-    ``git annex`` is dispatched by git searching ``PATH`` for a
-    ``git-annex`` executable, and ``uv tool install lightcone-cli`` links
-    only *our* entry points into ``~/.local/bin`` — the git-annex we
-    resolved as a dependency sits beside the interpreter instead, and this
-    prepend is the only way git finds it. Verified: with only the tool's
-    ``lc`` on ``PATH``, ``git annex version`` fails and ``lc init``
-    refuses.
-
-    Prepend, never append: the annex we resolved is the one the engine was
-    installed with and the one its behaviour is tested against, and a
-    system copy of another vintage winning that race is a difference
-    nothing records. Idempotent, and applied to our own environment
-    because that is what child processes inherit.
-    """
-    ours = str(Path(sys.executable).parent)
-    path = os.environ.get("PATH", "")
-    if path.split(os.pathsep)[:1] == [ours]:
-        return
-    os.environ["PATH"] = ours + os.pathsep + path if path else ours
-
 
 # =============================================================================
 # The repository
@@ -170,7 +143,6 @@ def require_committer(directory: Path) -> None:
     Raises:
         ProjectError: If no committer identity resolves.
     """
-    put_our_bin_first()
     proc = project._run(["git", "var", "GIT_COMMITTER_IDENT"], cwd=directory)
     if proc.returncode != 0:
         raise project.ProjectError(
@@ -279,7 +251,6 @@ def restore(directory: Path, paths: Iterable[Path]) -> None:
 
 def _git(argv: list[str], *, cwd: Path) -> str:
     """Run git in *cwd*, returning its stdout; a nonzero exit raises."""
-    put_our_bin_first()
     proc = project._run(["git", *argv], cwd=cwd)
     if proc.returncode != 0:
         raise project.ProjectError(f"`git {' '.join(argv)}` failed:\n{proc.stderr.strip()}")
@@ -288,7 +259,6 @@ def _git(argv: list[str], *, cwd: Path) -> str:
 
 def _git_ok(argv: list[str], *, cwd: Path) -> bool:
     """Run git as a yes/no probe: exit status is the answer, not a failure."""
-    put_our_bin_first()
     return bool(project._run(["git", *argv], cwd=cwd).returncode == 0)
 
 

--- a/src/lightcone/engine/dataset.py
+++ b/src/lightcone/engine/dataset.py
@@ -32,10 +32,10 @@ def put_our_bin_first() -> None:
     ``git annex`` is dispatched by git searching ``PATH`` for a
     ``git-annex`` executable, and ``uv tool install lightcone-cli`` links
     only *our* entry points into ``~/.local/bin`` — the git-annex we
-    resolved as a dependency sits beside the interpreter instead. Verified:
-    with only the tool's ``lc`` on ``PATH``, ``git annex version`` fails and
-    ``lc init`` refuses. (Under ``uv run`` the prepend is a no-op, because
-    uv already fronts the project's ``.venv/bin``.)
+    resolved as a dependency sits beside the interpreter instead, and this
+    prepend is the only way git finds it. Verified: with only the tool's
+    ``lc`` on ``PATH``, ``git annex version`` fails and ``lc init``
+    refuses.
 
     Prepend, never append: a system git-annex winning would make the
     version recorded in the lock a fiction. Idempotent, and applied to our

--- a/src/lightcone/engine/dataset.py
+++ b/src/lightcone/engine/dataset.py
@@ -37,9 +37,11 @@ def put_our_bin_first() -> None:
     ``lc`` on ``PATH``, ``git annex version`` fails and ``lc init``
     refuses.
 
-    Prepend, never append: a system git-annex winning would make the
-    version recorded in the lock a fiction. Idempotent, and applied to our
-    own environment because that is what child processes inherit.
+    Prepend, never append: the annex we resolved is the one the engine was
+    installed with and the one its behaviour is tested against, and a
+    system copy of another vintage winning that race is a difference
+    nothing records. Idempotent, and applied to our own environment
+    because that is what child processes inherit.
     """
     ours = str(Path(sys.executable).parent)
     path = os.environ.get("PATH", "")

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -553,7 +553,9 @@ def run_record(root: Path, task: Task, dsid: str) -> str:
     ``cmd`` is the worker module: the bare recipe would reconstruct nothing
     lc adds, and ``lc materialize`` cannot be it because a rerun removes
     the declared outputs first, dirtying the tree materialize refuses to
-    start from.
+    start from. The worker rebuilds the *project* environment itself from
+    the lock of the commit being rerun; :func:`_worker_cmd` is what pins
+    the *engine*.
 
     Args:
         root: The project root.
@@ -565,10 +567,7 @@ def run_record(root: Path, task: Task, dsid: str) -> str:
     """
     info = {
         "chain": [],
-        "cmd": (
-            "uv run --locked --project . -- python -m lightcone.engine.worker "
-            f"{task.universe_id}/{task.output_id}"
-        ),
+        "cmd": _worker_cmd(f"{task.universe_id}/{task.output_id}"),
         "dsid": dsid,
         "exit": 0,
         "inputs": sorted(plan.declared_path(root, path) for path in task.inputs.values()),
@@ -582,6 +581,30 @@ def run_record(root: Path, task: Task, dsid: str) -> str:
         f"{body}\n"
         "^^^ Do not change lines above ^^^"
     )
+
+
+def _worker_cmd(target: str) -> str:
+    """Build the rerun invocation for one output.
+
+    The module spelling, never a console script, behind an ephemeral
+    ``uv run`` that pins the engine to the version that made the output —
+    so a rerun executes the recorded engine, not whatever the host has
+    grown into. A dev build's version is not published, and pinning it
+    would fail resolution loudly; a dev engine exists only in a checkout
+    whose ambient ``python`` already imports it, which is exactly what the
+    bare form resolves.
+
+    Args:
+        target: ``<universe>/<output_id>``.
+
+    Returns:
+        The command line ``datalad rerun`` will hand to a shell.
+    """
+    module = f"python -m lightcone.engine.worker {target}"
+    v = worker.lc_version()
+    if v and "dev" not in v:
+        return f"uv run --no-project --with lightcone-cli=={v} -- {module}"
+    return module
 
 
 # =============================================================================

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -373,7 +373,8 @@ def materialize(
     project.require_git_annex()
     dataset.require_committer(root)
     # Before anything else: workers pass `--no-sync`, so this is the only
-    # place the environment is made to match the lock.
+    # place on a run's path where the environment is made to match the
+    # lock. (A rerun does not come through here; its entry point syncs.)
     report = MaterializeReport()
     report.warnings.extend(f"uv: {w}" for w in project.sync(root))
     if changes := dataset.status(root):
@@ -554,8 +555,8 @@ def run_record(root: Path, task: Task, dsid: str) -> str:
     lc adds, and ``lc materialize`` cannot be it because a rerun removes
     the declared outputs first, dirtying the tree materialize refuses to
     start from. The worker rebuilds the *project* environment itself from
-    the lock of the commit being rerun; :func:`_worker_cmd` is what pins
-    the *engine*.
+    the lock of the commit being rerun; what becomes of the *engine* is
+    :func:`_worker_cmd`'s decision.
 
     Args:
         root: The project root.
@@ -586,13 +587,14 @@ def run_record(root: Path, task: Task, dsid: str) -> str:
 def _worker_cmd(target: str) -> str:
     """Build the rerun invocation for one output.
 
-    The module spelling, never a console script, behind an ephemeral
-    ``uv run`` that pins the engine to the version that made the output —
-    so a rerun executes the recorded engine, not whatever the host has
-    grown into. A dev build's version is not published, and pinning it
-    would fail resolution loudly; a dev engine exists only in a checkout
-    whose ambient ``python`` already imports it, which is exactly what the
-    bare form resolves.
+    Always the module spelling, never a console script. A released engine
+    is put behind an ephemeral ``uv run`` pinning its own version, so the
+    rerun executes the engine that made the output rather than whatever
+    the host has grown into. A dev build cannot be: its version is not
+    published, so pinning it would fail resolution — and a dev engine
+    exists only in a checkout whose ambient ``python`` already imports it,
+    which is what the bare form resolves. So the dev record is the weaker
+    of the two, and says nothing about which engine it will find.
 
     Args:
         target: ``<universe>/<output_id>``.

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
@@ -551,12 +552,14 @@ def run_record(root: Path, task: Task, dsid: str) -> str:
     it is written and none of it abbreviated. ``datalad rerun`` reads it
     with a regex and reports "no command; skipping" on any mismatch.
 
-    ``cmd`` is the worker module: the bare recipe would reconstruct nothing
-    lc adds, and ``lc materialize`` cannot be it because a rerun removes
-    the declared outputs first, dirtying the tree materialize refuses to
-    start from. The worker rebuilds the *project* environment itself from
-    the lock of the commit being rerun; what becomes of the *engine* is
-    :func:`_worker_cmd`'s decision.
+    ``cmd`` is the worker module, never a console script, behind an
+    ephemeral ``uv run`` pinning the engine that made the output
+    (:func:`_engine_requirement`) — so the rerun executes that engine
+    rather than whatever the host has grown into. The bare recipe would
+    reconstruct nothing lc adds, and ``lc materialize`` cannot be it
+    because a rerun removes the declared outputs first, dirtying the tree
+    materialize refuses to start from. The worker rebuilds the *project*
+    environment itself from the lock of the commit being rerun.
 
     Args:
         root: The project root.
@@ -568,7 +571,12 @@ def run_record(root: Path, task: Task, dsid: str) -> str:
     """
     info = {
         "chain": [],
-        "cmd": _worker_cmd(f"{task.universe_id}/{task.output_id}"),
+        # Single-quoted because datalad hands cmd to a shell and the git
+        # form of the requirement contains spaces.
+        "cmd": (
+            f"uv run --no-project --with '{_engine_requirement()}' -- "
+            f"python -m lightcone.engine.worker {task.universe_id}/{task.output_id}"
+        ),
         "dsid": dsid,
         "exit": 0,
         "inputs": sorted(plan.declared_path(root, path) for path in task.inputs.values()),
@@ -584,29 +592,44 @@ def run_record(root: Path, task: Task, dsid: str) -> str:
     )
 
 
-def _worker_cmd(target: str) -> str:
-    """Build the rerun invocation for one output.
+def _engine_requirement() -> str:
+    """Build the requirement that reconstructs the running engine.
 
-    Always the module spelling, never a console script. A released engine
-    is put behind an ephemeral ``uv run`` pinning its own version, so the
-    rerun executes the engine that made the output rather than whatever
-    the host has grown into. A dev build cannot be: its version is not
-    published, so pinning it would fail resolution — and a dev engine
-    exists only in a checkout whose ambient ``python`` already imports it,
-    which is what the bare form resolves. So the dev record is the weaker
-    of the two, and says nothing about which engine it will find.
-
-    Args:
-        target: ``<universe>/<output_id>``.
+    A release pins by version, resolvable from an index. A dev build's
+    version is not published, but hatch-vcs embeds its source commit —
+    so the pin becomes that commit at the engine's own repository, and a
+    rerun during development still reconstructs the engine that ran. An
+    unpushed commit fails a rerun loudly at resolution, which beats
+    silently finding another engine. A dirty tree is the one
+    approximation: the commit names the code as last committed, and the
+    version's own dirty marker is what keeps that visible.
 
     Returns:
-        The command line ``datalad rerun`` will hand to a shell.
+        A PEP 508 requirement for ``uv run --with``.
     """
-    module = f"python -m lightcone.engine.worker {target}"
     v = worker.lc_version()
-    if v and "dev" not in v:
-        return f"uv run --no-project --with lightcone-cli=={v} -- {module}"
-    return module
+    commit = re.search(r"\+g([0-9a-f]+)", v)
+    if "dev" not in v or commit is None:
+        return f"lightcone-cli=={v}"
+    return f"lightcone-cli @ git+{_repository_url()}@{commit.group(1)}"
+
+
+def _repository_url() -> str:
+    """Read the engine's repository URL out of its own metadata.
+
+    From ``[project.urls]`` rather than a constant here, so the one place
+    the URL lives is the package metadata every install carries.
+    """
+    from importlib.metadata import metadata
+
+    for entry in metadata("lightcone-cli").get_all("Project-URL") or []:
+        label, _, url = str(entry).partition(",")
+        if label.strip().lower() == "repository":
+            return url.strip()
+    raise ProjectError(
+        "lightcone-cli's own metadata names no Repository URL, so a dev "
+        "engine cannot be pinned by commit — reinstall the engine."
+    )
 
 
 # =============================================================================

--- a/src/lightcone/engine/project.py
+++ b/src/lightcone/engine/project.py
@@ -382,9 +382,9 @@ def _converge_dataset(c: _Converger, directory: Path) -> None:
     routes results and inputs into the annex and keeps manifests in git,
     and ``.datalad/config`` carries a dataset id — the one thing a git +
     git-annex repository lacks to *be* a DataLad dataset, so a project is
-    one from birth rather than by later adoption. Neither is read back by
-    lc; the id is generated once and never regenerated, because ``file``
-    writes only what is missing.
+    one from birth rather than by later adoption. The id is generated
+    once and never regenerated, because ``file`` writes only what is
+    missing; the run record reads it back through ``dataset.dataset_id``.
     """
     c.item(".git", _in_repository(directory), lambda: dataset.init_git(directory))
     # After the item above, so a fresh project has a repository to annex.

--- a/src/lightcone/engine/project.py
+++ b/src/lightcone/engine/project.py
@@ -291,8 +291,8 @@ def require_git_annex() -> None:
     if shutil.which("git-annex") is None:
         raise ProjectError(
             "git-annex is required (it stores the bytes results are made of) "
-            "and is not on PATH. It ships as a wheel and installs with the "
-            "engine: `uv sync` in the project, or reinstall lightcone-cli."
+            "and is not on PATH. It ships as a wheel beside lc itself: "
+            "`uv tool install --force lightcone-cli` repairs the install."
         )
 
 
@@ -340,25 +340,13 @@ def sync(directory: Path) -> list[str]:
 def _converge_uv_project(c: _Converger, directory: Path) -> None:
     """pyproject.toml + .python-version — the environment definition.
 
-    An existing ``pyproject.toml`` is the user's: read, possibly warned
-    about, never edited. The warning is decided against the *pre-existing*
-    file, so one we just wrote — which always names the engine — can never
-    trigger it.
+    An existing ``pyproject.toml`` is the user's: read, never edited.
     """
-    pyproject_path = directory / "pyproject.toml"
-    adopted = pyproject_path.exists()
     c.file(
         "pyproject.toml",
-        pyproject_path,
+        directory / "pyproject.toml",
         lambda: templates.pyproject(name=project_name(directory)),
     )
-    if adopted and "lightcone-cli" not in pyproject_path.read_text():
-        c.warn(
-            "pyproject.toml does not depend on lightcone-cli — the "
-            "engine should live inside the experiment's lock: "
-            "`uv add lightcone-cli`."
-        )
-
     c.file(".python-version", directory / ".python-version", templates.python_version)
 
 
@@ -499,11 +487,13 @@ def project_name(directory: Path) -> str:
 
 #: What makes a directory a project root: the environment ``lc run``
 #: enters. ``astra.yaml`` is deliberately not among them — a command can
-#: be probed in any uv project, spec or no spec.
+#: be probed in any uv project, spec or no spec. ``.venv`` stays last:
+#: it is the one entry that is local state rather than repository
+#: content, and ``current_project(synced=False)`` slices it off.
 _ENVIRONMENT_FILES = ("pyproject.toml", "uv.lock", ".venv")
 
 
-def current_project(directory: Path | None = None) -> Path:
+def current_project(directory: Path | None = None, *, synced: bool = True) -> Path:
     """Take a directory as the project root, checking it is one.
 
     There is no walk-up: the directory you are in is the directory that is
@@ -511,6 +501,11 @@ def current_project(directory: Path | None = None) -> Path:
 
     Args:
         directory: Defaults to the working directory.
+        synced: Whether the built ``.venv`` must already be there. The
+            worker entry point passes False, because it converges the
+            environment itself — which is what makes a rerun work on a
+            fresh clone, where the lock is in the repository and the
+            environment is not.
 
     Returns:
         The resolved project root.
@@ -523,7 +518,8 @@ def current_project(directory: Path | None = None) -> Path:
             not yet converged, which is what a fresh clone is.
     """
     directory = (directory or Path.cwd()).resolve()
-    missing = [name for name in _ENVIRONMENT_FILES if not (directory / name).exists()]
+    required = _ENVIRONMENT_FILES if synced else _ENVIRONMENT_FILES[:2]
+    missing = [name for name in required if not (directory / name).exists()]
     if not missing:
         return directory
     declared = (directory / "pyproject.toml").exists() or (directory / SPEC_FILENAME).exists()

--- a/src/lightcone/engine/project.py
+++ b/src/lightcone/engine/project.py
@@ -8,7 +8,7 @@ import re
 import shutil
 import subprocess
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import asdict, dataclass, field
 from functools import partial
 from pathlib import Path
@@ -320,10 +320,11 @@ def uv_prefix(directory: Path, *, sync: bool) -> list[str]:
 def sync(directory: Path) -> list[str]:
     """Make ``.venv`` match ``uv.lock``.
 
-    A run calls this before it starts rather than checking and refusing:
-    workers pass ``--no-sync``, so nothing else would notice a lock edited
-    without a sync, and a manifest recording an environment the recipe did
-    not run under is the identity model saying something untrue.
+    Both entry points that execute recipes call this before they start,
+    rather than checking and refusing: workers pass ``--no-sync``, so
+    nothing else would notice a lock edited without a sync, and a manifest
+    recording an environment the recipe did not run under is the identity
+    model saying something untrue.
 
     Args:
         directory: The project root.
@@ -485,40 +486,70 @@ def project_name(directory: Path) -> str:
     return name or "analysis"
 
 
-#: What makes a directory a project root: the environment ``lc run``
-#: enters. ``astra.yaml`` is deliberately not among them — a command can
-#: be probed in any uv project, spec or no spec. ``.venv`` stays last:
-#: it is the one entry that is local state rather than repository
-#: content, and ``current_project(synced=False)`` slices it off.
-_ENVIRONMENT_FILES = ("pyproject.toml", "uv.lock", ".venv")
+#: What the repository itself carries of the environment. ``astra.yaml``
+#: is deliberately not among them — a command can be probed in any uv
+#: project, spec or no spec.
+_DECLARED_FILES = ("pyproject.toml", "uv.lock")
+
+#: …plus the built environment. ``.venv`` is the one piece that is local
+#: state rather than repository content, which is the whole difference
+#: between the two questions below.
+_ENVIRONMENT_FILES = (*_DECLARED_FILES, ".venv")
 
 
-def current_project(directory: Path | None = None, *, synced: bool = True) -> Path:
-    """Take a directory as the project root, checking it is one.
+def declared_project(directory: Path | None = None) -> Path:
+    """Take a directory as a project root, needing only what git carries.
 
-    There is no walk-up: the directory you are in is the directory that is
-    used, or it is an error.
+    The weaker of the two questions: it asks whether the project is
+    *declared*, not whether it is built. That is what the worker entry
+    point needs — a clone holds the lock and no ``.venv``, and the worker
+    converges the environment for itself a moment later.
 
     Args:
         directory: Defaults to the working directory.
-        synced: Whether the built ``.venv`` must already be there. The
-            worker entry point passes False, because it converges the
-            environment itself — which is what makes a rerun work on a
-            fresh clone, where the lock is in the repository and the
-            environment is not.
 
     Returns:
         The resolved project root.
 
     Raises:
-        ProjectError: If the environment is not there. The two ways that
-            fails get different advice — a directory with no project
+        ProjectError: If ``pyproject.toml`` or ``uv.lock`` is absent.
+    """
+    return _project_root(directory, _DECLARED_FILES)
+
+
+def current_project(directory: Path | None = None) -> Path:
+    """Take a directory as the project root, built environment and all.
+
+    The question every verb that runs something asks, and the stronger of
+    the two: a ``.venv`` that is not there is not something these callers
+    are going to create.
+
+    Args:
+        directory: Defaults to the working directory.
+
+    Returns:
+        The resolved project root.
+
+    Raises:
+        ProjectError: If any of the environment is absent.
+    """
+    return _project_root(directory, _ENVIRONMENT_FILES)
+
+
+def _project_root(directory: Path | None, required: Sequence[str]) -> Path:
+    """Check *directory* against *required* and resolve it.
+
+    There is no walk-up: the directory you are in is the directory that is
+    used, or it is an error.
+
+    Raises:
+        ProjectError: If anything in *required* is absent. The two ways
+            that fails get different advice — a directory with no project
             markers is the wrong *place*, while one that declares a
-            project but lacks the built environment is the right place,
-            not yet converged, which is what a fresh clone is.
+            project but lacks a piece of the environment is the right
+            place, not yet converged.
     """
     directory = (directory or Path.cwd()).resolve()
-    required = _ENVIRONMENT_FILES if synced else _ENVIRONMENT_FILES[:2]
     missing = [name for name in required if not (directory / name).exists()]
     if not missing:
         return directory

--- a/src/lightcone/engine/project.py
+++ b/src/lightcone/engine/project.py
@@ -280,18 +280,20 @@ def require_git() -> None:
 def require_git_annex() -> None:
     """Refuse early when git-annex is not reachable as git reaches it.
 
-    Probed after :func:`~lightcone.engine.dataset.put_our_bin_first`, and
-    by the name git itself searches for: ``git annex`` is git finding a
-    ``git-annex`` executable on ``PATH``, not a builtin.
+    Probed by the name git itself searches for: ``git annex`` is git
+    finding a ``git-annex`` executable on ``PATH``, not a builtin. Every
+    install channel puts one there by construction — lightcone-cli
+    declares the git-annex wheel's entry points as its own, so installers
+    link them beside ``lc`` — which makes this a refusal for broken
+    installs only.
 
     Raises:
         ProjectError: If ``git-annex`` is not on ``PATH``.
     """
-    dataset.put_our_bin_first()
     if shutil.which("git-annex") is None:
         raise ProjectError(
             "git-annex is required (it stores the bytes results are made of) "
-            "and is not on PATH. It ships as a wheel beside lc itself: "
+            "and is not on PATH. It installs with lc itself: "
             "`uv tool install --force lightcone-cli` repairs the install."
         )
 

--- a/src/lightcone/engine/templates/__init__.py
+++ b/src/lightcone/engine/templates/__init__.py
@@ -78,13 +78,14 @@ def pyproject(*, name: str) -> str:
         name: The project name.
 
     Returns:
-        A virtual uv project depending on lightcone-cli.
+        A virtual uv project with no dependencies. The engine is not among
+        them: lc runs from the host's tool install, and the project's lock
+        carries only what the analysis itself imports.
     """
     return _render(
         "pyproject.toml.tmpl",
         name=name,
         requires_python=requires_python(),
-        lc_requirement=lightcone_requirement(),
     )
 
 
@@ -105,47 +106,15 @@ def python_version() -> str:
 def requires_python() -> str:
     """Render the scaffolded ``requires-python``.
 
-    Taken verbatim from lightcone-cli's own ``Requires-Python``: a
-    scaffolded project depends on the engine, so uv enforces this bound
-    during resolution regardless, and declaring the same specifier states
-    it rather than inventing a second one. It cannot conflict with
-    :func:`python_version`, since lc only runs on an interpreter that
-    already satisfies it.
+    The running interpreter's minor version, consistent with
+    :func:`python_version`, which pins the exact patch of the same
+    interpreter — the bound and the pin come from one place, so they
+    cannot disagree.
 
     Returns:
-        The specifier, or the running interpreter's minor version for a
-        metadata-less install.
+        The specifier.
     """
-    from importlib.metadata import PackageNotFoundError, metadata
-
-    try:
-        # Message-style lookup: absent keys come back as None, not KeyError.
-        declared = metadata("lightcone-cli")["Requires-Python"]
-    except PackageNotFoundError:
-        declared = None
-    if declared:
-        return str(declared)
     return f">={sys.version_info.major}.{sys.version_info.minor}"
-
-
-def lightcone_requirement() -> str:
-    """Render the ``lightcone-cli`` requirement for the scaffold.
-
-    The engine lives inside the experiment's lock, pinned to the version
-    that ran ``lc init``, so the engine that produced a result stays
-    recoverable.
-
-    Returns:
-        A pinned requirement, or an unpinned one for a dev build, whose
-        version is not published and would make the lock unsolvable.
-    """
-    from importlib.metadata import PackageNotFoundError, version
-
-    try:
-        v = version("lightcone-cli")
-    except PackageNotFoundError:
-        v = ""
-    return f"lightcone-cli=={v}" if v and "dev" not in v else "lightcone-cli"
 
 
 # =============================================================================

--- a/src/lightcone/engine/templates/__init__.py
+++ b/src/lightcone/engine/templates/__init__.py
@@ -302,7 +302,8 @@ def datalad_config(*, dataset_id: str) -> str:
     """Render ``.datalad/config``, the file that makes a project a dataset.
 
     A dataset id is the one thing a git + git-annex repository lacks to
-    *be* a DataLad dataset. lc never reads this back; datalad does.
+    *be* a DataLad dataset. Read back only through ``dataset.dataset_id``,
+    for the run record's ``dsid``.
 
     Args:
         dataset_id: A UUID, generated once and never regenerated.

--- a/src/lightcone/engine/templates/files/pyproject.toml.tmpl
+++ b/src/lightcone/engine/templates/files/pyproject.toml.tmpl
@@ -2,9 +2,7 @@
 name = "${name}"
 version = "0.0.1"
 requires-python = "${requires_python}"
-dependencies = [
-    "${lc_requirement}",
-]
+dependencies = []
 
 [tool.uv]
 required-version = ">=0.12"

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -5,9 +5,9 @@ Also an entry point:
     python -m lightcone.engine.worker <universe>/<output_id>
 
 which is what the ``[DATALAD RUNCMD]`` record in every materialization
-commit names, behind whatever engine pin
-:func:`~lightcone.engine.materialize._worker_cmd` decided on. That is why
-it is a module rather than an ``lc`` verb: it makes the output
+commit names, behind an engine-pinning ``uv run --no-project --with …`` —
+by version for a released engine, by source commit for a dev build. That
+is why it is a module rather than an ``lc`` verb: it makes the output
 unconditionally, commits nothing, and leaves the tree dirty by design —
 precisely the state ``lc materialize`` refuses to start from — so
 advertising it in ``lc --help`` would hand people a footgun.

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -5,13 +5,15 @@ Also an entry point:
     python -m lightcone.engine.worker <universe>/<output_id>
 
 which is what the ``[DATALAD RUNCMD]`` record in every materialization
-commit names. That is why it is a module rather than an ``lc`` verb: it
+commit names — behind an engine-pinning ``uv run --no-project --with
+lightcone-cli==<v>`` when the engine that made the output is a published
+release. That is why it is a module rather than an ``lc`` verb: it
 makes the output unconditionally, commits nothing, and leaves the tree dirty by
 design — precisely the state ``lc materialize`` refuses to start from —
-so advertising it in ``lc --help`` would hand people a footgun. A
-``uv run --locked --project .`` in front of it reconstructs the exact
-engine that produced an output from the lock of the commit that recorded
-it, module path included.
+so advertising it in ``lc --help`` would hand people a footgun.
+:func:`main` converges the project environment from the rerun commit's
+own lock before anything executes, so the record holds on a clone that
+has never built one.
 
 Keep this module cheap to import: no click, no rich. It is on the
 ``python -m`` path of every rerun, and of every task in every run.
@@ -38,6 +40,7 @@ from lightcone.engine.project import (
     ProjectError,
     child_env,
     current_project,
+    sync,
     uv_prefix,
 )
 
@@ -250,7 +253,7 @@ def execute(
                 input_versions=dict(input_versions),
                 git_sha=sha,
                 git_remote=remote,
-                lc_version=_lc_version(),
+                lc_version=lc_version(),
                 hermeticity=asdict(outcome.attestation),
             ),
         )
@@ -275,7 +278,13 @@ def _gate(root: Path, env_version: str) -> str:
     )
 
 
-def _lc_version() -> str:
+def lc_version() -> str:
+    """Report the running engine's version, empty for a bare source tree.
+
+    The one lookup behind both places the engine attests itself: the
+    manifest's ``lc_version`` and the run record's version pin. One
+    function, so the two cannot disagree about which engine ran.
+    """
     from importlib.metadata import PackageNotFoundError, version
 
     try:
@@ -297,6 +306,13 @@ def main(argv: list[str]) -> int:
     thin wrapper over :func:`execute`, so this is an entry point rather
     than a second implementation. Nothing is classified: a rerun is a rerun.
 
+    The environment is converged here, not assumed: a rerun checks out the
+    lock but never the ``.venv``, and the recipe's own ``uv run --no-sync``
+    would silently hand it an *empty* environment while the manifest
+    recorded the lock's ``env_version``. The sync also carries
+    ``--locked``, so a lock that no longer matches ``pyproject.toml`` is a
+    loud refusal rather than a quiet relock.
+
     Args:
         argv: One argument, ``<universe>/<output_id>``.
 
@@ -310,7 +326,8 @@ def main(argv: list[str]) -> int:
 
     universe_id, _, output_id = argv[0].partition("/")
     try:
-        root = current_project()
+        root = current_project(synced=False)
+        sync(root)
         env_version = identity.env_version(root)
         graph = plan.build(root)
         if (task := graph.tasks.get((universe_id, output_id))) is None:

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -5,12 +5,12 @@ Also an entry point:
     python -m lightcone.engine.worker <universe>/<output_id>
 
 which is what the ``[DATALAD RUNCMD]`` record in every materialization
-commit names — behind an engine-pinning ``uv run --no-project --with
-lightcone-cli==<v>`` when the engine that made the output is a published
-release. That is why it is a module rather than an ``lc`` verb: it
-makes the output unconditionally, commits nothing, and leaves the tree dirty by
-design — precisely the state ``lc materialize`` refuses to start from —
-so advertising it in ``lc --help`` would hand people a footgun.
+commit names, behind whatever engine pin
+:func:`~lightcone.engine.materialize._worker_cmd` decided on. That is why
+it is a module rather than an ``lc`` verb: it makes the output
+unconditionally, commits nothing, and leaves the tree dirty by design —
+precisely the state ``lc materialize`` refuses to start from — so
+advertising it in ``lc --help`` would hand people a footgun.
 :func:`main` converges the project environment from the rerun commit's
 own lock before anything executes, so the record holds on a clone that
 has never built one.
@@ -27,6 +27,7 @@ owning the loop.
 
 from __future__ import annotations
 
+import functools
 import shutil
 import sys
 from collections.abc import Mapping
@@ -39,7 +40,7 @@ from lightcone.engine.plan import Key, Task
 from lightcone.engine.project import (
     ProjectError,
     child_env,
-    current_project,
+    declared_project,
     sync,
     uv_prefix,
 )
@@ -278,12 +279,17 @@ def _gate(root: Path, env_version: str) -> str:
     )
 
 
+@functools.cache
 def lc_version() -> str:
     """Report the running engine's version, empty for a bare source tree.
 
     The one lookup behind both places the engine attests itself: the
     manifest's ``lc_version`` and the run record's version pin. One
     function, so the two cannot disagree about which engine ran.
+
+    Cached: the metadata scan walks ``sys.path``, both callers are once
+    per output, and an installed version cannot change under a running
+    process.
     """
     from importlib.metadata import PackageNotFoundError, version
 
@@ -326,7 +332,7 @@ def main(argv: list[str]) -> int:
 
     universe_id, _, output_id = argv[0].partition("/")
     try:
-        root = current_project(synced=False)
+        root = declared_project()
         sync(root)
         env_version = identity.env_version(root)
         graph = plan.build(root)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,16 +110,8 @@ def test_blocked_items_are_rendered(runner: CliRunner, tmp_path: Path) -> None:
     assert "blocked results/" in result.output
     # Rich wraps on the terminal width, so assert on an unwrappable fragment.
     assert "✗" in result.output
-
-
-def test_init_surfaces_warnings(runner: CliRunner, tmp_path: Path) -> None:
-    project = tmp_path / "proj"
-    project.mkdir()
-    (project / "pyproject.toml").write_text('[project]\nname = "mine"\nversion = "0"\n')
-
-    result = runner.invoke(main, ["init", str(project)])
-    assert result.exit_code == 0
-    assert "does not depend on lightcone-cli" in result.output
+    # The reason travels as a warning, and the console renders those too.
+    assert "not a directory" in result.output
 
 
 # ---- --check / --json (the agent-facing surface) --------------------------

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -9,9 +9,7 @@ restating what the code already believes.
 
 from __future__ import annotations
 
-import os
 import shutil
-import sys
 from pathlib import Path
 
 import pytest
@@ -398,24 +396,13 @@ def test_ignore_rule_sees_through_a_tracked_path(repo: Path) -> None:
 # ---- how git finds git-annex -----------------------------------------------
 
 
-def test_our_bin_goes_to_the_front_of_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Prepend, never append. `git annex` dispatches by searching PATH for
-    a `git-annex` executable — the annex we resolved is the one the engine
-    was installed with and tested against, and a system copy of another
-    vintage winning that race is a difference nothing records."""
-    ours = str(Path(sys.executable).parent)
-    monkeypatch.setenv("PATH", "/somewhere/else")
-
-    dataset.put_our_bin_first()
-    assert os.environ["PATH"] == f"{ours}{os.pathsep}/somewhere/else"
-
-    dataset.put_our_bin_first()
-    assert os.environ["PATH"].count(ours) == 1
-
-
-def test_git_dispatches_annex_after_the_prepend(repo: Path) -> None:
-    """The claim the prepend makes, checked by the spelling git itself uses
-    rather than by resolving `git-annex` ourselves."""
+def test_git_dispatches_annex_from_the_ambient_path(repo: Path) -> None:
+    """`git annex` is git finding a `git-annex` executable on PATH, not a
+    builtin — and lc no longer arranges PATH for its subprocesses: every
+    install channel carries the entry points beside the interpreter, so
+    the environment lc inherits already resolves them. Checked by the
+    spelling git itself uses rather than by resolving `git-annex`
+    ourselves."""
     assert "git-annex version:" in dataset._git(["annex", "version"], cwd=repo)
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -400,8 +400,9 @@ def test_ignore_rule_sees_through_a_tracked_path(repo: Path) -> None:
 
 def test_our_bin_goes_to_the_front_of_path(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prepend, never append. `git annex` dispatches by searching PATH for
-    a `git-annex` executable — a system copy winning would make the version
-    the project's lock records a fiction."""
+    a `git-annex` executable — the annex we resolved is the one the engine
+    was installed with and tested against, and a system copy of another
+    vintage winning that race is a difference nothing records."""
     ours = str(Path(sys.executable).parent)
     monkeypatch.setenv("PATH", "/somewhere/else")
 
@@ -416,5 +417,21 @@ def test_git_dispatches_annex_after_the_prepend(repo: Path) -> None:
     """The claim the prepend makes, checked by the spelling git itself uses
     rather than by resolving `git-annex` ourselves."""
     assert "git-annex version:" in dataset._git(["annex", "version"], cwd=repo)
+
+
+def test_the_annex_executables_are_ours_to_install() -> None:
+    """An installer links only the requested package's executables, and the
+    researcher's own `git add` needs git-annex on the *shell's* PATH — so
+    lightcone-cli re-declares the git-annex wheel's entry points verbatim.
+    Mirrored, not invented: asserted against the wheel's own metadata, so
+    an executable upstream adds, drops, or renames fails this test instead
+    of failing `uv tool install lightcone-cli` for every user."""
+    from importlib.metadata import distribution
+
+    ours = {e.name: e.value for e in distribution("lightcone-cli").entry_points}
+    theirs = {e.name: e.value for e in distribution("git-annex").entry_points}
+    assert theirs  # the wheel stopped declaring entry points ⇒ redesign
+    for name, value in theirs.items():
+        assert ours.get(name) == value, f"{name} is not re-declared as {value}"
 
 

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -13,7 +13,6 @@ the seam is only worth having if the real thing still fits through it.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 from collections.abc import Callable, Iterator
@@ -576,7 +575,10 @@ def test_the_run_record_is_what_datalad_reads(root: Path, inline: None) -> None:
 
     assert subject == "second [baseline]"
     assert info is not None
-    assert info["cmd"].endswith("python -m lightcone.engine.worker baseline/second")
+    # Full-string, not endswith: the suite runs a dev build, whose record
+    # is the bare module — an engine-pin prefix appearing or vanishing here
+    # must fail this test, not slip past a suffix match.
+    assert info["cmd"] == "python -m lightcone.engine.worker baseline/second"
     assert info["inputs"] == ["results/baseline/first"]
     assert info["outputs"] == ["results/baseline/second"]
     assert info["dsid"] == "4b7b5c1e-0000-4000-8000-000000000000"
@@ -652,11 +654,12 @@ def test_check_agrees_with_a_run_on_a_clone_with_no_annex_content(
 def test_a_drifted_environment_is_made_to_match_before_anything_runs(
     root: Path, inline: None
 ) -> None:
-    """Workers pass `--no-sync`, so this is the only place the environment
-    is made to match the lock. Reported and refused, a lock edited without
-    a sync would leave recipes importing packages the lock does not
-    describe while every manifest recorded the new lock's `env_version`;
-    doing it instead is shorter and impossible to ignore."""
+    """Workers pass `--no-sync`, so this is the only place on a run's path
+    where the environment is made to match the lock (a rerun's worker
+    entry point syncs for itself). Reported and refused, a lock edited
+    without a sync would leave recipes importing packages the lock does
+    not describe while every manifest recorded the new lock's
+    `env_version`; doing it instead is shorter and impossible to ignore."""
     pyproject = root / "pyproject.toml"
     pyproject.write_text(
         pyproject.read_text().replace("dependencies = []", 'dependencies = ["idna"]')
@@ -676,7 +679,10 @@ def test_a_drifted_environment_is_made_to_match_before_anything_runs(
 def test_the_recorded_command_reproduces_the_output(root: Path, inline: None) -> None:
     """The claim the record makes, run literally. `datalad rerun` removes
     the output, executes the recorded command, and commits what came
-    back — so the manifest is regenerated inside the same commit."""
+    back — so the manifest is regenerated inside the same commit. Under a
+    dev build the record is the bare worker module, which the suite's own
+    interpreter resolves; the released shape is pinned by
+    `test_the_record_pins_a_released_engine`."""
     pytest.importorskip("datalad")
     engine.materialize(root, ["first"])
     original = assets.read(root / "results/baseline/first")
@@ -687,7 +693,7 @@ def test_the_recorded_command_reproduces_the_output(root: Path, inline: None) ->
         cwd=root,
         capture_output=True,
         text=True,
-        env={**child_env(), "PYTHONPATH": _engine_path()},
+        env=child_env(),
     )
 
     assert proc.returncode == 0, proc.stderr
@@ -698,19 +704,60 @@ def test_the_recorded_command_reproduces_the_output(root: Path, inline: None) ->
     assert not dataset.status(root)
 
 
-def _engine_path() -> str:
-    """Stand in for the ``lightcone-cli`` pin a real project's lock carries.
+def test_the_recorded_command_holds_on_a_fresh_clone(
+    root: Path, inline: None, tmp_path: Path
+) -> None:
+    """A clone checks out the lock but never `.venv`, and `uv run --no-sync`
+    against a missing environment silently creates an *empty* one — so the
+    record only reproduces the output because the worker converges the
+    environment for itself. The in-place rerun above cannot catch a missing
+    sync; this is the test that does."""
+    pytest.importorskip("datalad")
+    engine.materialize(root, ["first"])
+    original = assets.read(root / "results/baseline/first")
+    assert original is not None
 
-    The recorded command resolves the worker out of the project's own
-    environment, which is the whole reason the record reproduces the
-    *recorded* engine rather than today's. The fixture's project declares
-    no dependencies so it stays cheap to build, so the engine under test is
-    put on the path explicitly instead.
-    """
-    import sysconfig
+    clone = tmp_path / "clone"
+    dataset._git(["clone", "-q", str(root), str(clone)], cwd=tmp_path)
+    for key, value in (("user.email", "t@example.com"), ("user.name", "Test")):
+        dataset._git(["config", key, value], cwd=clone)
+    dataset._git(["annex", "init", "-q", "clone"], cwd=clone)
+    assert not (clone / ".venv").exists()
 
-    return os.pathsep.join(
-        [str(Path(__file__).parent.parent / "src"), sysconfig.get_paths()["purelib"]]
+    proc = subprocess.run(
+        [sys.executable, "-c", "from datalad.api import rerun; rerun('HEAD')"],
+        cwd=clone,
+        capture_output=True,
+        text=True,
+        env=child_env(),
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    rerun = assets.read(clone / "results/baseline/first")
+    assert rerun is not None
+    assert rerun.data_version == original.data_version
+    assert (clone / ".venv").exists()
+
+
+def test_the_record_pins_a_released_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A released engine is pinned by version through an ephemeral uv
+    environment; a dev build's version is unpublished, so pinning it would
+    fail resolution loudly, and the bare module is what a dev checkout's
+    own interpreter resolves."""
+    monkeypatch.setattr(engine.worker, "lc_version", lambda: "1.2.3")
+    assert engine._worker_cmd("baseline/first") == (
+        "uv run --no-project --with lightcone-cli==1.2.3 -- "
+        "python -m lightcone.engine.worker baseline/first"
+    )
+
+    monkeypatch.setattr(engine.worker, "lc_version", lambda: "1.2.3.dev4+gabc")
+    assert engine._worker_cmd("baseline/first") == (
+        "python -m lightcone.engine.worker baseline/first"
+    )
+
+    monkeypatch.setattr(engine.worker, "lc_version", lambda: "")
+    assert engine._worker_cmd("baseline/first") == (
+        "python -m lightcone.engine.worker baseline/first"
     )
 
 

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -560,7 +560,9 @@ def test_an_interrupted_run_restores_what_never_reported(
 # ---- the commit message ----------------------------------------------------
 
 
-def test_the_run_record_is_what_datalad_reads(root: Path, inline: None) -> None:
+def test_the_run_record_is_what_datalad_reads(
+    root: Path, inline: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Asserted through datalad's own parser rather than against our JSON:
     it matches with a regex and returns nothing on any mismatch, after
     which `rerun` reports "no command; skipping" and exits 0 — so a golden
@@ -568,6 +570,7 @@ def test_the_run_record_is_what_datalad_reads(root: Path, inline: None) -> None:
     from datalad.api import Dataset
     from datalad.local.rerun import get_run_info
 
+    monkeypatch.setattr(engine.worker, "lc_version", lambda: "1.2.3")
     engine.materialize(root, ["second"])
     message = dataset._git(["log", "-1", "--format=%B"], cwd=root)
 
@@ -575,14 +578,36 @@ def test_the_run_record_is_what_datalad_reads(root: Path, inline: None) -> None:
 
     assert subject == "second [baseline]"
     assert info is not None
-    # Full-string, not endswith: the suite runs a dev build, whose record
-    # is the bare module — an engine-pin prefix appearing or vanishing here
-    # must fail this test, not slip past a suffix match.
-    assert info["cmd"] == "python -m lightcone.engine.worker baseline/second"
+    # Full-string, not endswith: a flag appearing or vanishing here must
+    # fail this test, not slip past a suffix match.
+    assert info["cmd"] == (
+        "uv run --no-project --with 'lightcone-cli==1.2.3' -- "
+        "python -m lightcone.engine.worker baseline/second"
+    )
     assert info["inputs"] == ["results/baseline/first"]
     assert info["outputs"] == ["results/baseline/second"]
     assert info["dsid"] == "4b7b5c1e-0000-4000-8000-000000000000"
     assert info["chain"] == [] and info["pwd"] == "."
+
+
+def test_the_engine_pin_follows_the_build(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A release resolves from an index by version; a dev build cannot,
+    but hatch-vcs embeds its source commit, so the pin becomes that commit
+    at the engine's own repository — read from the engine's metadata, not
+    a constant. Dirty or clean, the commit is the last one; the version's
+    dirty marker is what says which."""
+    monkeypatch.setattr(engine.worker, "lc_version", lambda: "1.2.3")
+    assert engine._engine_requirement() == "lightcone-cli==1.2.3"
+
+    url = engine._repository_url()
+    assert url.startswith("https://")
+    monkeypatch.setattr(engine.worker, "lc_version", lambda: "1.3.dev2+g19986bb8")
+    assert engine._engine_requirement() == f"lightcone-cli @ git+{url}@19986bb8"
+
+    monkeypatch.setattr(
+        engine.worker, "lc_version", lambda: "1.3.dev2+g19986bb8.d20260820"
+    )
+    assert engine._engine_requirement() == f"lightcone-cli @ git+{url}@19986bb8"
 
 
 def test_the_record_names_the_declared_input_not_the_annex_object(
@@ -687,14 +712,46 @@ def test_a_drifted_environment_is_made_to_match_before_anything_runs(
     assert project_mod._env_is_current(root)
 
 
-def test_the_recorded_command_reproduces_the_output(root: Path, inline: None) -> None:
+@pytest.fixture(scope="session")
+def engine_dist(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, Path]:
+    """Build the engine under test into a wheel the pinned record can find.
+
+    The record pins ``lightcone-cli==<v>`` and the suite's build is not
+    published, so the rerun's ephemeral environment is pointed here via
+    ``UV_FIND_LINKS`` — which is what lets the suite execute the same
+    record shape every real commit carries, rather than a test-only one.
+
+    Returns:
+        The wheel's exact version, and the directory serving it.
+    """
+    dist = tmp_path_factory.mktemp("engine-dist")
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(dist)],
+        cwd=Path(__file__).parent.parent,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    wheel = next(dist.glob("*.whl"))
+    return wheel.name.split("-")[1], dist
+
+
+def test_the_recorded_command_reproduces_the_output(
+    root: Path,
+    inline: None,
+    engine_dist: tuple[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The claim the record makes, run literally. `datalad rerun` removes
     the output, executes the recorded command, and commits what came
-    back — so the manifest is regenerated inside the same commit. Under a
-    dev build the record is the bare worker module, which the suite's own
-    interpreter resolves; the released shape is pinned by
-    `test_the_record_pins_a_released_engine`."""
+    back — so the manifest is regenerated inside the same commit, by the
+    pinned engine resolved into an ephemeral environment."""
     pytest.importorskip("datalad")
+    version, dist = engine_dist
+    # The requirement seam, not `lc_version`: a git pin can only ever
+    # build committed code, so the suite pins the wheel built from the
+    # working tree — the code actually under test.
+    monkeypatch.setattr(engine, "_engine_requirement", lambda: f"lightcone-cli=={version}")
     engine.materialize(root, ["first"])
     original = assets.read(root / "results/baseline/first")
     assert original is not None
@@ -704,7 +761,7 @@ def test_the_recorded_command_reproduces_the_output(root: Path, inline: None) ->
         cwd=root,
         capture_output=True,
         text=True,
-        env=child_env(),
+        env={**child_env(), "UV_FIND_LINKS": str(dist)},
     )
 
     assert proc.returncode == 0, proc.stderr
@@ -716,7 +773,11 @@ def test_the_recorded_command_reproduces_the_output(root: Path, inline: None) ->
 
 
 def test_the_recorded_command_holds_on_a_fresh_clone(
-    root: Path, inline: None, tmp_path: Path
+    root: Path,
+    inline: None,
+    tmp_path: Path,
+    engine_dist: tuple[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A clone checks out the lock but never `.venv`, and `uv run --no-sync`
     against a missing environment silently creates an *empty* one — so the
@@ -724,6 +785,8 @@ def test_the_recorded_command_holds_on_a_fresh_clone(
     environment for itself. The in-place rerun above cannot catch a missing
     sync; this is the test that does."""
     pytest.importorskip("datalad")
+    version, dist = engine_dist
+    monkeypatch.setattr(engine, "_engine_requirement", lambda: f"lightcone-cli=={version}")
     engine.materialize(root, ["first"])
     original = assets.read(root / "results/baseline/first")
     assert original is not None
@@ -736,7 +799,7 @@ def test_the_recorded_command_holds_on_a_fresh_clone(
         cwd=clone,
         capture_output=True,
         text=True,
-        env=child_env(),
+        env={**child_env(), "UV_FIND_LINKS": str(dist)},
     )
 
     assert proc.returncode == 0, proc.stderr
@@ -744,28 +807,6 @@ def test_the_recorded_command_holds_on_a_fresh_clone(
     assert rerun is not None
     assert rerun.data_version == original.data_version
     assert (clone / ".venv").exists()
-
-
-def test_the_record_pins_a_released_engine(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A released engine is pinned by version through an ephemeral uv
-    environment; a dev build's version is unpublished, so pinning it would
-    fail resolution loudly, and the bare module is what a dev checkout's
-    own interpreter resolves."""
-    monkeypatch.setattr(engine.worker, "lc_version", lambda: "1.2.3")
-    assert engine._worker_cmd("baseline/first") == (
-        "uv run --no-project --with lightcone-cli==1.2.3 -- "
-        "python -m lightcone.engine.worker baseline/first"
-    )
-
-    monkeypatch.setattr(engine.worker, "lc_version", lambda: "1.2.3.dev4+gabc")
-    assert engine._worker_cmd("baseline/first") == (
-        "python -m lightcone.engine.worker baseline/first"
-    )
-
-    monkeypatch.setattr(engine.worker, "lc_version", lambda: "")
-    assert engine._worker_cmd("baseline/first") == (
-        "python -m lightcone.engine.worker baseline/first"
-    )
 
 
 # ---- the scheduler seam ----------------------------------------------------

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -638,17 +638,28 @@ def test_check_agrees_with_a_run_on_a_clone_with_no_annex_content(
     is still classifiable — check mode reads the recorded digest rather
     than the pointer file sitting in its place."""
     engine.materialize(root, [])
-    clone = tmp_path / "clone"
-    dataset._git(["clone", "-q", str(root), str(clone)], cwd=tmp_path)
-    # `clone` does not copy identity, and `annex init` makes a commit — so
-    # this fails on any host without a usable global one, CI included.
-    for key, value in (("user.email", "t@example.com"), ("user.name", "Test")):
-        dataset._git(["config", key, value], cwd=clone)
-    dataset._git(["annex", "init", "-q", "clone"], cwd=clone)
+    clone = _clone(root, tmp_path)
     pointer = (clone / "results/baseline/first/value.txt").read_text()
     assert pointer.startswith("/annex/objects/")  # content really is absent
 
     assert engine.check(clone, []).planned == {}
+
+
+def _clone(root: Path, into: Path) -> Path:
+    """Clone *root* into a usable annexed repository, as a colleague would.
+
+    The identity is set because `clone` does not copy one and
+    `annex init` makes a commit — so without it this fails on any host
+    with no usable global identity, CI included. No annex content is
+    fetched: a fresh clone holds pointers, and that is the state these
+    tests are about.
+    """
+    clone = into / "clone"
+    dataset._git(["clone", "-q", str(root), str(clone)], cwd=into)
+    for key, value in (("user.email", "t@example.com"), ("user.name", "Test")):
+        dataset._git(["config", key, value], cwd=clone)
+    dataset._git(["annex", "init", "-q", "clone"], cwd=clone)
+    return clone
 
 
 def test_a_drifted_environment_is_made_to_match_before_anything_runs(
@@ -717,11 +728,7 @@ def test_the_recorded_command_holds_on_a_fresh_clone(
     original = assets.read(root / "results/baseline/first")
     assert original is not None
 
-    clone = tmp_path / "clone"
-    dataset._git(["clone", "-q", str(root), str(clone)], cwd=tmp_path)
-    for key, value in (("user.email", "t@example.com"), ("user.name", "Test")):
-        dataset._git(["config", key, value], cwd=clone)
-    dataset._git(["annex", "init", "-q", "clone"], cwd=clone)
+    clone = _clone(root, tmp_path)
     assert not (clone / ".venv").exists()
 
     proc = subprocess.run(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -286,21 +286,18 @@ def test_check_mode_agrees_with_a_real_run(tmp_path: Path) -> None:
 # ---- warnings and blocked items ------------------------------------------
 
 
-def test_warns_when_pyproject_lacks_the_engine(tmp_path: Path) -> None:
-    """The engine belongs inside the experiment's lock; a pyproject we
-    didn't write is the user's, so warn rather than edit."""
+def test_an_adopted_pyproject_is_never_edited(tmp_path: Path) -> None:
+    """A pyproject we didn't write is the user's: read, never edited."""
     project = tmp_path / "proj"
     project.mkdir()
     (project / "pyproject.toml").write_text('[project]\nname = "mine"\nversion = "0"\n')
 
     report = converge(project)
-    assert any("does not depend on lightcone-cli" in w for w in report.warnings)
+    assert report.warnings == []
     assert 'name = "mine"' in (project / "pyproject.toml").read_text()
 
 
-def test_no_engine_warning_for_a_pyproject_we_wrote(tmp_path: Path) -> None:
-    """The warning is decided against the pre-existing file, so a scaffolded
-    one — which always names the engine — can never trigger it."""
+def test_a_fresh_scaffold_warns_about_nothing(tmp_path: Path) -> None:
     report = converge(tmp_path / "proj")
     assert report.warnings == []
 
@@ -613,9 +610,8 @@ def test_a_stale_lock_is_repaired_not_ignored(
 def test_a_stale_environment_is_repaired_not_ignored(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The case layer 3's launcher depends on: an environment that no longer
-    satisfies the lock must be re-synced, not waved through because `.venv`
-    happens to be a directory."""
+    """An environment that no longer satisfies the lock must be re-synced,
+    not waved through because `.venv` happens to be a directory."""
     from unittest.mock import MagicMock
 
     from lightcone.engine import project as project_mod

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -11,7 +11,12 @@ from pathlib import Path
 import pytest
 
 from lightcone.engine import run as engine_run
-from lightcone.engine.project import ProjectError, current_project, uv_prefix
+from lightcone.engine.project import (
+    ProjectError,
+    current_project,
+    declared_project,
+    uv_prefix,
+)
 
 SPEC = """\
 title: Test
@@ -89,6 +94,25 @@ def test_the_default_is_the_working_directory(
 ) -> None:
     monkeypatch.chdir(project)
     assert current_project() == project.resolve()
+
+
+def test_a_declared_project_needs_only_what_git_carries(project: Path) -> None:
+    """The weaker question, and the difference between the two: a clone
+    holds the lock and no `.venv`, and the worker entry point builds one
+    rather than refusing."""
+    (project / ".venv").rmdir()
+    assert declared_project(project) == project.resolve()
+    with pytest.raises(ProjectError, match="not been built yet"):
+        current_project(project)
+
+
+def test_a_declared_project_still_needs_the_lock(project: Path) -> None:
+    """It is weaker, not absent: without `uv.lock` there is no environment
+    to converge and nothing to be exact about."""
+    (project / "uv.lock").unlink()
+    with pytest.raises(ProjectError, match="not been built yet") as raised:
+        declared_project(project)
+    assert "missing uv.lock" in str(raised.value)
 
 
 def test_a_missing_spec_reads_as_an_empty_one(project: Path) -> None:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -29,10 +29,15 @@ def test_pyproject_renders_every_placeholder() -> None:
     assert "$" not in rendered
     assert 'name = "my-analysis"' in rendered
     assert f'requires-python = "{templates.requires_python()}"' in rendered
-    assert templates.lightcone_requirement() in rendered
     # Virtual by design: containerized mode builds `--no-install-project`,
     # so a packaged project's own import would fail inside its image.
     assert "[build-system]" not in rendered
+
+
+def test_pyproject_does_not_depend_on_the_engine() -> None:
+    """The engine is the host's uv tool, not a project dependency — a
+    scaffolded lock carries only what the analysis itself imports."""
+    assert "lightcone-cli" not in templates.pyproject(name="my-analysis")
 
 
 def test_python_version_pins_the_running_interpreter() -> None:
@@ -42,54 +47,11 @@ def test_python_version_pins_the_running_interpreter() -> None:
     assert templates.python_version() == f"{v.major}.{v.minor}.{v.micro}\n"
 
 
-def test_requires_python_comes_from_our_own_metadata() -> None:
-    """Declaring the engine's own bound rather than inventing a second one."""
-    from importlib.metadata import metadata
-
-    assert templates.requires_python() == metadata("lightcone-cli")["Requires-Python"]
-
-
-def test_the_ambient_pin_always_satisfies_the_declared_floor() -> None:
-    """Not a coincidence: lc can only run on an interpreter meeting its own
-    Requires-Python, so the two can never conflict."""
-    from packaging.specifiers import SpecifierSet
-
-    assert templates.python_version().strip() in SpecifierSet(templates.requires_python())
-
-
-def test_requires_python_falls_back_to_the_running_minor(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A metadata-less install still gets a bound the ambient pin meets."""
-    import importlib.metadata
-
-    def _missing(_name: str) -> object:
-        raise importlib.metadata.PackageNotFoundError
-
-    monkeypatch.setattr(importlib.metadata, "metadata", _missing)
+def test_requires_python_is_the_running_minor() -> None:
+    """The bound and the exact pin come from one interpreter, so the
+    scaffolded `.python-version` always satisfies `requires-python`."""
     v = sys.version_info
     assert templates.requires_python() == f">={v.major}.{v.minor}"
-
-
-def test_lightcone_requirement_pins_the_running_version(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Driver and project stay in lockstep — except for dev builds, whose
-    versions aren't published, so pinning one would make the project's lock
-    unsolvable."""
-    import importlib.metadata
-
-    monkeypatch.setattr(importlib.metadata, "version", lambda _name: "1.2.3")
-    assert templates.lightcone_requirement() == "lightcone-cli==1.2.3"
-
-    monkeypatch.setattr(importlib.metadata, "version", lambda _name: "1.2.3.dev4+gabc")
-    assert templates.lightcone_requirement() == "lightcone-cli"
-
-    def _missing(_name: str) -> str:
-        raise importlib.metadata.PackageNotFoundError
-
-    monkeypatch.setattr(importlib.metadata, "version", _missing)
-    assert templates.lightcone_requirement() == "lightcone-cli"
 
 
 # ---- .gitignore -----------------------------------------------------------

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -111,6 +111,9 @@ def test_the_manifest_is_complete_before_anything_is_saved(root: Path) -> None:
     assert manifest.env_version == identity.env_version(root)
     assert manifest.git_sha == _HEAD[0] and manifest.git_remote == _HEAD[1]
     assert manifest.hermeticity["mechanism"]
+    # The engine's version is attestation, not identity: with lc outside
+    # the project's lock, this field is the record of which engine ran.
+    assert manifest.lc_version == worker.lc_version()
 
 
 def test_the_recipe_runs_under_the_boundary(root: Path) -> None:
@@ -414,6 +417,24 @@ def test_the_module_reruns_unconditionally(
 
     assert worker.main(["baseline/first"]) == 0
     assert (root / "results/baseline/first/value.txt").exists()
+
+
+def test_the_module_converges_the_environment(
+    root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rerun checks out the lock but never `.venv`, and the recipe's own
+    `uv run --no-sync` silently creates an *empty* environment where none
+    exists — so the entry point syncs before anything executes, or a fresh
+    clone's rerun would record the lock's `env_version` over a recipe that
+    ran in a bare venv."""
+    import shutil
+
+    monkeypatch.chdir(root)
+    shutil.rmtree(root / ".venv")
+
+    assert worker.main(["baseline/first"]) == 0
+    assert (root / ".venv").exists()
+    assert (root / "results/baseline/first/value.txt").read_text() == "one\n"
 
 
 def test_the_module_refuses_an_argument_it_cannot_use(root: Path) -> None:


### PR DESCRIPTION
`lc init` pinned `lightcone-cli` into every project's own lock, which is what forced **layer 3** — a launcher that discovers, mode-detects, scrubs `UV_*`, converges, and delegates to the lc inside the project's venv. Remove the pin and there is nothing to delegate to: the `lc` that was invoked is the engine that runs. Layer 3 is now marked removed by decision rather than pending.

This reverses spec §2's engine-in-lock rule. The spec is a reference the rebuild drifts from deliberately; the reversal lands as a Recorded decision in `CLAUDE.md` rather than waiting on a spec rewrite.

## What changes

A scaffolded `pyproject.toml` declares **no dependencies**. A project's resolution is no longer constrained by the engine's own pins (no astra-tools/click/rich/distributed/git-annex in any project lock), and `requires-python` now comes from the interpreter that wrote `.python-version` instead of from lightcone-cli's metadata — one source, so the bound and the pin cannot disagree. The git-annex wheel floor gates installing the tool and nothing else.

## What the pin bought, and where each guarantee went

- **The engine inside `env_version`** — given up deliberately. An lc upgrade now moves nothing; no output ever reads `behind` over an engine release. This completes the reversal that already took `env_version` out of `definition_version`. The engine becomes attestation (`lc_version` in every manifest), not identity.
- **Reruns reconstruct the exact engine** — re-provided in the record itself. `cmd` pins the engine by version through an ephemeral `uv run --no-project --with lightcone-cli==<v>`, keeping the **module spelling** so the worker stays out of `lc --help` and off `$PATH`. A dev build's version is unpublished, so its record is the bare module — which only exists in a checkout whose own interpreter imports it.
- **Driver/worker skew "structurally impossible"** — moot while workers are in-process threads; noted as a layer-7 connect-probe obligation.
- **Layer 6** — the generated image can no longer get its in-image engine from the lock; noted that the Containerfile must install it as an explicit layer and that the version becomes a tag input.

## The worker now owns the project environment

It has to. A rerun checks out the lock but never the `.venv`, and **`uv run --no-sync` against a missing `.venv` silently creates an empty one** (measured, uv 0.12.5) — recipes would have run in it while the manifest recorded the lock's `env_version`. `worker.main()` therefore syncs before anything executes, which also inherits the loud stale-lock refusal the outer `uv run --locked` used to provide. `current_project(synced=False)` is the affordance: the lock is repository content, the `.venv` is not.

A new test reruns on a **fresh clone**, because the in-place rerun passes with or without the sync.

`_engine_path()` is deleted — the suite faked the pin by injecting `src/` onto `PYTHONPATH`, and there is no pin left to fake. `test_the_run_record_is_what_datalad_reads` tightens its `.endswith` to a full-string match so a prefix appearing or vanishing cannot slip past.

## Verification

- `uv run pytest` — 413 passed; `ruff` and `mypy --strict` clean.
- End-to-end by hand: scaffolded a project (no `lightcone-cli` in `uv.lock`), materialized, `lc status`, then `datalad rerun` on a fresh clone with no `.venv` — the worker created it and the output came back byte-identical.
- The pinned shape run literally, from a wheel built off this branch: an ephemeral engine env reproduced the output with a matching `data_version`, and git-annex is present beside that env's interpreter so `put_our_bin_first()` still resolves.

Incidentally fixes a latent bug in `eval.yml`: the eval project's pin resolved a *released* engine from PyPI rather than the branch under test. No workflow change needed.

## Follow-up, not in this PR

The `UV_*` ambient scrub (spec §4 step 3) is worth having and is independent of the pin — it protects `env_version`'s install-settings term, not the delegation that is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGfhkvU3Ee2hhHcwAkeidg