### PR TITLE
Layer 6: the container hatch — OCI runtimes as the exec boundary

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,10 @@ jobs:
       # Landlock or Seatbelt would otherwise report green while testing
       # nothing at all.
       LC_SANDBOX_TESTS_REQUIRED: "1"
+      # Same rule for the container smoke tests, on the runners that carry
+      # the runtimes (ubuntu ships podman and a running docker daemon).
+      # macOS runners have no podman machine, so there the suite skips.
+      LC_CONTAINER_TESTS_REQUIRED: ${{ matrix.os == 'ubuntu-latest' && '1' || '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,6 +562,16 @@ the rule for the next. The item records **`blocked`**, not a warning —
 success and commit nothing — and it names `<file>:<line>:<pattern>`,
 because `.gitignore` convergence only ever appends and cannot fix this.
 
+**A new managed `.gitattributes` line is always appended at the *end* of
+the template.** Repair is append-only, so a project scaffolded under an
+older template receives new lines at the bottom of its file — and
+`gitattributes_disorder` judges against template order. A line added
+anywhere but last makes lc write an order it then reports as blocked, on
+every project scaffolded before the line existed. The layer-6 image line
+sits after the manifest exemption for exactly this reason (the patterns
+are disjoint, so the order is free), and every future line takes the
+same slot.
+
 **`.gitattributes` can be *unrepairable*, and that is a second blocked
 item.** The file is last-match-wins, and a repair only appends — so a
 project that already carries `results/** annex.largefiles=anything`
@@ -1375,9 +1385,17 @@ spec's `dpkg_snapshot_sha256` residue: apt is name-pinned, so a rebuild
 months later yields different bytes under the same tag, and the archive
 keeps the bytes themselves. The dot-path is the trap:
 **git-annex routes dotfiles to git whatever `annex.largefiles` says**,
-so the add must opt in (`dataset.save(..., dotfiles=True)`, per-add like
-`annex.thin`) or the archive lands as a full blob in git, silently, with
-every test green — `test_dataset.py` pins both directions. The archive
+so `dataset.save` opts in unconditionally (`annex.dotfiles=true`,
+per-add like `annex.thin`) — without it the archive, or a `.cache.h5` a
+recipe writes into its output directory, lands as a full blob in git,
+silently, with every test green. The attributes alone decide from
+there (dot-named manifests keep their own exemption); a user's plain
+`git add` keeps git-annex's stock behavior. `test_dataset.py` pins both
+directions. And because `.gitattributes` is user-authored and lc only
+appends, the build **probes the routing with `git check-attr` before
+saving** — an archive the attributes would hand to git is a refusal
+naming the line, the same probe-don't-assume rule as the `results/`
+ignore check. The archive
 is the arch it was built for (recorded in the manifest); multi-arch is a
 layer-7 item, as is apptainer/singularity — which is *why* the format is
 `docker-archive`: all four runtimes consume it, and HPC hosts that
@@ -1397,12 +1415,17 @@ datalad's docker adapter makes — never a tag, so a retagged store image
 cannot substitute. **A dropped archive never substitutes**: a rebuild is
 a new archive commit under a new id; old manifests keep naming what ran.
 
-**Builds and the archive commit happen only on a clean tree.** The dirty
-check runs before `ensure_image` in materialize, and `lc build` refuses
-dirt itself: `dataset.save` stages scoped but commits the whole index, so
-a build on a dirty tree would sweep the user's staged edits into the
-image commit — and the tag derives from `pyproject.toml`, so the
-declaration must be committed before the image it defines.
+**Builds and the archive commit happen only on a clean tree, and only
+after the graph.** The dirty check runs before `ensure_image` in
+materialize, and `lc build` refuses dirt itself: `dataset.save` stages
+scoped but commits the whole index, so a build on a dirty tree would
+sweep the user's staged edits into the image commit — and the tag
+derives from `pyproject.toml`, so the declaration must be committed
+before the image it defines. The graph (spec validation, the lock scan)
+resolves before the image too, in materialize and in the worker entry
+point alike: a refusal over a typo must not cost a minutes-long build or
+leave an archive commit behind a failed run, and a failing sync must not
+bury "no output `x`".
 
 **Two identities, one document.** The canonical identity document
 (declaration resolved + the uv digest; the interpreter pin deliberately
@@ -1422,14 +1445,24 @@ containerized `exec_policy` shape is the same policy minus the host: no
 OS read baseline, no stdlib root, no exec set — the image *is* those,
 and everything in it was declared — leaving exactly the paths that
 become mounts, project `:ro`, `results/` `:rw`, declared inputs `:ro`,
-the private HOME `:rw`, `--tmpfs /tmp`. No in-container Landlock, no
-seccomp probe, no shim-in-image: the engine container never gets the
-tree `:rw`, so mounts alone express the whole policy, and the
-attestation (`mechanism: podman|docker`, `fs: declared`,
-`network: denied`) is derived flag-for-flag from the argv — `--network
-none` is the codebase's one honest `denied`, loopback intact. One
-`OCIBackend`, data-parameterized: podman and docker differ in spellings
-(`--userns=keep-id`+`--pull=never` vs `--user uid:gid`), not shape.
+the private HOME `:rw`, `--tmpfs /tmp`, over a **`--read-only` rootfs**:
+without that flag a write outside the declared set *succeeds* into the
+container's ephemeral layer and vanishes while the run attests
+`fs: declared` — the silent-loss path, closed by making it a denial.
+Mounts are **resolved source, declared destination** — the containerized
+policy is the one shape that keeps its paths unresolved, because they
+are addresses the recipe uses (a symlinked `/data` input resolved on
+both sides would leave the container with no `/data` at all).
+`--security-opt label=disable`, because SELinux hosts otherwise refuse
+every bind read and `:z` would relabel the user's own files. No
+in-container Landlock, no seccomp probe, no shim-in-image: the engine
+container never gets the tree `:rw`, so mounts alone express the whole
+policy, and the attestation (`mechanism: podman|docker`,
+`fs: declared`, `network: denied`) is derived flag-for-flag from the
+argv — `--network none` is the codebase's one honest `denied`, loopback
+intact. One `OCIBackend`, data-parameterized: podman and docker differ
+in spellings (`--userns=keep-id`+`--pull=never` vs `--user uid:gid`),
+not shape.
 Runtime is **host capability** — detected podman → docker, the
 `detect()` discipline on a second axis, with `container.backend()`
 holding the only mode branch — and never part of any identity. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1141,8 +1141,9 @@ provides that, and for what workers do *not* need (git, git-annex).
   `definition_version`, `env_version`, `data_version`, `decisions`,
   `input_versions`, `git_sha`,
   `git_remote`, `lc_version`, `hermeticity` — and, since layer 6,
-  `image` (`{tag, id, archive, arch}`, `None` on the host; see the
-  layer-6 invariants for why it is defaulted). Spec §3's longer list —
+  `image` (`{tag, id, archive, arch}`, defaulting to ``None`` because
+  that is the true value for a host run — not back-compat machinery,
+  and `SCHEMA_VERSION` stays 1 pre-release). Spec §3's longer list —
   `uv_version`, `platform`, `worker_runtime`, `python_build`,
   `dpkg_snapshot_sha256`, `sdist_built`, `env_snapshot`, `gpu_driver` —
   is attestation nothing here reads; it lands with the verb that reads
@@ -1406,10 +1407,11 @@ is load-bearing: `lc build` and the materialize preflight may **build +
 save + commit** (announced by the CLI, which owns the console — the
 engine never prints); the probe and the worker entry point only ever
 **find** — a missing archive refuses naming the exact `lc build`
-(`lc run` never builds; the worker never writes git), unfetched content
-refuses naming the exact `git annex get` (the existing
-`ContentNotFetchedError` machinery, verbatim), and an unloaded image is
-a silent `<runtime> load`. Execution pins the **id** — sha256 of the
+(`lc run` never builds; the worker never commits), unfetched content is
+**fetched by lc itself** (`git annex get`, driver-side — the storage
+invariant is that nobody is ever asked to run an annex command by hand,
+so the refusal is reserved for a fetch with no reachable copy), and an
+unloaded image is a silent `<runtime> load`. Execution pins the **id** — sha256 of the
 archive's config blob, readable with no runtime, the same computation
 datalad's docker adapter makes — never a tag, so a retagged store image
 cannot substitute. **A dropped archive never substitutes**: a rebuild is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1011,6 +1011,19 @@ its sync touches only ignored paths — so both modes run one order.)
 `--check` needs neither: `env_version` is the lock's bytes, so a drifted
 `.venv` cannot change what it answers.
 
+**A run fetches its declared inputs; the read-only verbs never do.**
+`materialize` batch-runs `git annex get` over the graph's in-tree
+declared inputs before anything hashes (driver-side — the storage
+invariant that nobody is ever asked to run an annex command by hand),
+so a bytes-free clone materializes straight to up-to-date. A failed
+fetch is a *warning*, never a refusal: independent tasks still run and
+the task whose input is unreachable reports its own failure. `--check`
+and `status` stay transfer-free — there an unfetched input is a
+reported fact, and the report now says `lc materialize` resolves it.
+Out-of-tree inputs are not fetched (no annex holds them — the recorded
+weaker promise), and `test_check_mode_never_fetches` pins the read-only
+half.
+
 **A run takes every core, and there is no flag to say otherwise.** How
 much of a machine a run may use — and which machine — is one question, and
 it belongs to a declared execution backend rather than to a `--jobs` knob

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ speculatively.
 | 3 | ~~The `lc` entrypoint — launcher~~ | ❌ **removed by decision** (2026-08) — see Recorded decisions: the host `lc` is the engine, so there is nothing to delegate to |
 | 4 | **Fabric** — `lc materialize`, worker sequence, mid-run relock gate | ✅ **done** |
 | 5 | **Sandbox layer** — Landlock / Seatbelt, exec-shim, denial UX, `lc run` | ✅ **done** |
-| 6 | Container hatch — `[tool.lightcone.image]`, generated Containerfile, `lc build` | ⬜ |
+| 6 | **Container hatch** — `[tool.lightcone.image]`, `lc build`, OCI runtimes as the exec boundary, the image archived in the dataset | ✅ **done** |
 | 7 | Venues — Perlmutter, hub/GKE, Cloud Build | ⬜ |
 | 8 | `lc verify`, WRROC export | ⬜ |
 
@@ -160,9 +160,11 @@ src/lightcone/              # namespace — NO __init__.py
 │   └── commands.py         # lc init, lc run, lc materialize, lc status
 └── engine/
     ├── __init__.py         # docstring only
-    ├── project.py          # what a project is: convergence + discovery
+    ├── project.py          # what a project is: convergence, discovery, mode
     ├── dataset.py          # the git + git-annex seam: how a project stores
     ├── identity.py         # env_version, definition_version, the lock scan
+    ├── image.py            # the system layer: declaration, Containerfile, tag — pure
+    ├── container.py        # runtimes, the build, the archived image — impure
     ├── assets.py           # an output: its directory, its manifest, its state
     ├── plan.py             # the spec, read as a graph of tasks
     ├── worker.py           # making one output; also the `python -m` entry point
@@ -175,6 +177,7 @@ src/lightcone/              # namespace — NO __init__.py
     │   ├── boundary.py     # detect() + run(): the mechanism-blind half
     │   ├── landlock.py     # Linux backend
     │   ├── seatbelt.py     # macOS backend
+    │   ├── oci.py          # containerized backend: the mount table as mechanism
     │   └── denial.py       # the denial UX
     └── templates/          # the scaffold's file content
         ├── __init__.py     # loader; a renderer only where there is a value to decide
@@ -275,12 +278,15 @@ wrong, and one the type checker cannot catch. The two `*_repair`
 functions stay named because `_Converger.file` hands them the text alone,
 so the template name has to be bound before the call site.
 
-**No engine constants for the environment.** The scaffolded
-`.python-version` is the interpreter `lc` itself is running on, and
-`requires-python` is that interpreter's minor as a floor. Both come from
-one place, so they can't conflict, and neither is a number to maintain.
-Identity follows the project's files from there: `env_version` hashes
-`.python-version`'s bytes, not anything in the engine (spec §3).
+**No engine constants for the environment — in direct mode.** The
+scaffolded `.python-version` is the interpreter `lc` itself is running
+on, and `requires-python` is that interpreter's minor as a floor. Both
+come from one place, so they can't conflict, and neither is a number to
+maintain. Identity follows the project's files from there: a direct
+project's `env_version` hashes `.python-version`'s bytes, not anything
+in the engine. The scoping is deliberate: containerized mode's default
+base and uv digests *are* engine constants, by spec-§2 design — see the
+layer-6 invariants for what moves when they do.
 
 **`.gitignore` and `.gitattributes` converge entry-wise, not by marker.**
 `templates.entries(name)` is a template minus comments and blanks;
@@ -577,9 +583,12 @@ regenerated — it identifies the dataset across clones and siblings.
 Verified, not assumed: `datalad status` recognises a freshly scaffolded
 project with no `--force` adoption step, and `Dataset('.').id` is the UUID
 we wrote. The reciprocal is a standing non-goal: **lc never requires
-datalad, never imports it, and never parses `.datalad/`.** A researcher
-who wants `datalad get`, siblings or RIA stores runs `uv add datalad` in
-their own project.
+datalad, never imports it, and never parses `.datalad/`.** lc *writes*
+under it — the dataset id, and since layer 6 the image archives and the
+`datalad.containers.*` config keys — but reads nothing back except
+through `git config -f`, and the archive is read as an image, never as
+datalad state. A researcher who wants `datalad get`, siblings or RIA
+stores runs `uv add datalad` in their own project.
 
 **Annexed files are ordinary writable files.** `filter=annex` keeps them
 unlocked, so an output can be overwritten in place and nothing needs to
@@ -982,11 +991,15 @@ workers pass `--no-sync` — so a lock edited without a sync would leave
 recipes importing packages the lock does not describe while every manifest
 recorded the *new* lock's `env_version`. Measured: the recipe imported
 `packaging 26.3` under a lock saying `24.2`, and uv accepted it silently.
-`materialize()` calls `project.sync()` right after the tool and committer
-preflight — before the dirty check and the graph — so the state is made
-impossible rather than detected. `--check` needs neither:
-`env_version` is the lock's bytes, so a drifted `.venv` cannot change what
-it answers.
+`materialize()` converges right after the dirty check — before the graph
+— so the state is made impossible rather than detected. (The dirty check
+moved *in front* of the converge with layer 6: in containerized mode the
+converge can commit an image archive, and `dataset.save` stages scoped
+but commits the whole index, so on a dirty tree the user's staged edits
+would be swept into the image commit. Direct mode is order-insensitive —
+its sync touches only ignored paths — so both modes run one order.)
+`--check` needs neither: `env_version` is the lock's bytes, so a drifted
+`.venv` cannot change what it answers.
 
 **A run takes every core, and there is no flag to say otherwise.** How
 much of a machine a run may use — and which machine — is one question, and
@@ -1117,14 +1130,19 @@ provides that, and for what workers do *not* need (git, git-annex).
   `schema_version`, `output_id`, `universe_id`, `recipe`,
   `definition_version`, `env_version`, `data_version`, `decisions`,
   `input_versions`, `git_sha`,
-  `git_remote`, `lc_version`, `hermeticity`. Spec §3's longer list —
-  `uv_version`, `platform`, `python_build`, `worker_runtime`, `image`,
+  `git_remote`, `lc_version`, `hermeticity` — and, since layer 6,
+  `image` (`{tag, id, archive, arch}`, `None` on the host; see the
+  layer-6 invariants for why it is defaulted). Spec §3's longer list —
+  `uv_version`, `platform`, `worker_runtime`, `python_build`,
   `dpkg_snapshot_sha256`, `sdist_built`, `env_snapshot`, `gpu_driver` —
-  is either layer 6's or attestation nothing here reads; it lands with the
-  verb that reads it.
-- **`env_version` has three terms, not five.** The
-  `[tool.lightcone.image]` and `Containerfile.extra` terms are layer 6's,
-  and hashing an empty shape for them now would be foreshadowing.
+  is attestation nothing here reads; it lands with the verb that reads
+  it (`worker_runtime` is additionally derivable from
+  `hermeticity.mechanism`, so it may never land at all).
+- **`env_version` has four terms.** Layer 6 added the image term —
+  the system layer's identity document, hashed as the literal `null`
+  for a direct project so the formula stays one formula. (The spec's
+  separate `Containerfile.extra` term went with the concept; see the
+  layer-6 decisions.)
 - **A recipe is handed to `bash -c`.** ASTRA recipes are command lines,
   not argv, and `bash` is in the exec allowlist — so it is granted by the
   same rule that grants everything else a recipe may run.
@@ -1225,9 +1243,11 @@ from anything a command could return, and it never falls through to
 running the command unsandboxed.
 
 **Layer boundaries showed up as parameters we did *not* add.**
-`writable_project`, output-dir write scope, scratch dirs, `in_container()`,
-and the `podman*`/`pod*` attestation branches all belong to layers 4 and 6
-and are absent, not stubbed.
+`writable_project`, output-dir write scope, and scratch dirs belong to
+later layers and are absent, not stubbed. (Layer 6 then landed the
+`podman`/`docker` attestation values and the containerized policy shape
+— as one keyword on `exec_policy` and one backend, not as the stubs this
+rule kept out.)
 
 **The macOS profile is vendored, not authored.**
 `sandbox/profiles/{base,network,platform-defaults}.sbpl` come from the codex CLI
@@ -1299,6 +1319,159 @@ last**, after the guard. Get that order wrong and layer 4 materializes on
 Linux and refuses on macOS, with the golden test still green because it
 only checks that the guard is present. Verified empirically, not assumed.
 
+## Key Invariants (layer 6)
+
+**Mode is derived, never configured.** A `[tool.lightcone.image]` table
+in `pyproject.toml` *is* the escalation to containerized mode; deleting
+it is the way back. `project.mode()` reads presence only; what the table
+*means* is `engine/image.py`'s question, so an invalid declaration
+refuses where it is consumed, naming the key at fault.
+
+**The user never sees a Containerfile.** The whole declaration surface is
+Modal-shaped TOML — `base` (digest-pinned or the default constant),
+`apt-install`, `run-commands`, `env` — a closed set, because every key is
+hashed. `pip_install` deliberately has no equivalent: the Python
+environment is the lock's business, never the image's, and `run-commands`
+is the bounded escape (this deletes spec §2's `Containerfile.extra`).
+The render exists only inside a transient build context; the image's
+`LABEL io.lightcone.image` carries the identity document, so the archive
+stays self-describing without one.
+
+**The engine never enters the image.** The container is the *recipe's*
+execution world: driver, git, annex, dask and classification all stay the
+host's `lc`, and exactly two things ever run in-image — the environment
+converge (`container.sync`, network on, project `:rw`, host uv cache
+mounted, into `.lightcone/venv`) and each recipe/probe exec
+(`--network none`). This deviates from spec v6.1's full-stack rule,
+recorded: v6.1's reason was the host-sync deadlock, which the
+in-container sync solves, and the spec's own Perlmutter row ("recipe
+wrap, step 3 only — never the dask worker") is this exact shape. What it
+buys: no delegation machinery, no git through a `--userns=keep-id` bind
+mount, no engine version in the tag, and one engine per run by
+construction. The host `.venv` is inert in containerized mode
+(`current_project` does not require it; `lc init` converges no
+environment — a host sync of a containerized lock is the deadlock in
+miniature); `.lightcone/` is gitignored machine state.
+
+**The image is the system layer only.** Base + apt (only when
+`apt-install` is nonempty — the engine needs nothing from apt, so spec
+§2's rule is restored) + the pinned uv + the pinned interpreter into
+`/opt/python`. No git, no engine, and **no project file ever enters the
+build context** — the context is a scratch directory holding one rendered
+Containerfile, which is what makes "code edits never trigger a build"
+structural. `bash` is a base-contract check (recipes are `bash -c`), and
+each contract violation is a reserved exit code mapped to a refusal
+naming the base (43 musl, 44 no bash, 45 no apt), never a raw build log.
+The readability `chmod` rides inside the layers that write `/opt` — a
+layer of its own would copy-on-write the whole interpreter tree into
+every archive, doubling it.
+
+**The dataset is the image store; runtime stores are caches.** `lc build`
+saves the image as a `docker-archive` at
+`.datalad/environments/<tag>/image` — the `datalad containers-add`
+layout — annexed and committed, so the exact bytes travel through
+`git annex get` with no registry and no credentials. This supersedes the
+spec's `dpkg_snapshot_sha256` residue: apt is name-pinned, so a rebuild
+months later yields different bytes under the same tag, and the archive
+keeps the bytes themselves. The dot-path is the trap:
+**git-annex routes dotfiles to git whatever `annex.largefiles` says**,
+so the add must opt in (`dataset.save(..., dotfiles=True)`, per-add like
+`annex.thin`) or the archive lands as a full blob in git, silently, with
+every test green — `test_dataset.py` pins both directions. The archive
+is the arch it was built for (recorded in the manifest); multi-arch is a
+layer-7 item, as is apptainer/singularity — which is *why* the format is
+`docker-archive`: all four runtimes consume it, and HPC hosts that
+cannot build obtain images through the repository.
+
+**`ensure_image` is one function with three strictnesses**, and the split
+is load-bearing: `lc build` and the materialize preflight may **build +
+save + commit** (announced by the CLI, which owns the console — the
+engine never prints); the probe and the worker entry point only ever
+**find** — a missing archive refuses naming the exact `lc build`
+(`lc run` never builds; the worker never writes git), unfetched content
+refuses naming the exact `git annex get` (the existing
+`ContentNotFetchedError` machinery, verbatim), and an unloaded image is
+a silent `<runtime> load`. Execution pins the **id** — sha256 of the
+archive's config blob, readable with no runtime, the same computation
+datalad's docker adapter makes — never a tag, so a retagged store image
+cannot substitute. **A dropped archive never substitutes**: a rebuild is
+a new archive commit under a new id; old manifests keep naming what ran.
+
+**Builds and the archive commit happen only on a clean tree.** The dirty
+check runs before `ensure_image` in materialize, and `lc build` refuses
+dirt itself: `dataset.save` stages scoped but commits the whole index, so
+a build on a dirty tree would sweep the user's staged edits into the
+image commit — and the tag derives from `pyproject.toml`, so the
+declaration must be committed before the image it defines.
+
+**Two identities, one document.** The canonical identity document
+(declaration resolved + the uv digest; the interpreter pin deliberately
+absent — its raw bytes are already an `env_version` frame) feeds
+`env_version` as its fourth frame, `null` for direct projects — so
+declaring an image, or an engine release that bumps the default-base or
+uv constants, puts containerized outputs `behind`, honestly, while
+direct projects never move on an engine release. The **tag** hashes the
+rendered Containerfile *and* the document, so a render-only generator
+change rebuilds the image without staling anything — accepted residue,
+attested by the manifest's image id and the archive's bytes. Read from
+`pyproject.toml` only, never `identity._uv_config()` — uv's
+"`uv.toml` replaces `[tool.uv]`" rule must not reach this table.
+
+**The mount table is the mechanism** (`sandbox/oci.py`). The
+containerized `exec_policy` shape is the same policy minus the host: no
+OS read baseline, no stdlib root, no exec set — the image *is* those,
+and everything in it was declared — leaving exactly the paths that
+become mounts, project `:ro`, `results/` `:rw`, declared inputs `:ro`,
+the private HOME `:rw`, `--tmpfs /tmp`. No in-container Landlock, no
+seccomp probe, no shim-in-image: the engine container never gets the
+tree `:rw`, so mounts alone express the whole policy, and the
+attestation (`mechanism: podman|docker`, `fs: declared`,
+`network: denied`) is derived flag-for-flag from the argv — `--network
+none` is the codebase's one honest `denied`, loopback intact. One
+`OCIBackend`, data-parameterized: podman and docker differ in spellings
+(`--userns=keep-id`+`--pull=never` vs `--user uid:gid`), not shape.
+Runtime is **host capability** — detected podman → docker, the
+`detect()` discipline on a second axis, with `container.backend()`
+holding the only mode branch — and never part of any identity. The
+containerized `tmp_home` lives under the project's `.lightcone/` rather
+than the system temp dir: it is a mount source, and macOS's podman
+machine shares the project tree while `/var/folders` arrives empty.
+
+**The seam learned one asymmetry, `contains_prefix`.** A host mechanism
+keeps the `uv run` hop *outside* the wrap (trusted host plumbing); a
+backend that is itself a world takes it *inside* — there is no trusted
+host plumbing inside a container — and applies the env overlay natively
+as `--env` flags, never through `boundary.env_argv`'s host-resolved
+`env` binary (NixOS resolves it to a path no Debian image has). Declared
+on every backend, so a new mechanism must answer the question. The
+container environment is an allowlist: the overlay plus `LC_SANDBOX`,
+never the ambient environment.
+
+**The record stays runtime-neutral, and the worker is its executor.**
+`cmd` is still the engine-pinned worker — verified against
+datalad-container's source before deciding: `containers-run` expands its
+`cmdexec` template at *record* time and `datalad rerun` executes the
+literal string (the extension has no rerun hook), so a bare-recipe `cmd`
+would rerun on the host, unconfined, with no manifest. Instead the
+record is declarative — the task id, the commit's own spec, the
+committed archive — and the worker re-resolves container *and runtime*
+on the rerun host, keeping the sandbox, the gates and the manifest. The
+containerized record adds `extra_inputs: [<archive>]`, which stock
+`datalad rerun` fetches through the annex before executing — the smoke
+suite proves the whole claim on a bytes-free clone. `lc build` also
+writes `datalad.containers.<tag>.{image,cmdexec}` so ad-hoc
+`datalad containers-run` works for humans, explicitly outside lc's
+guarantees.
+
+**The runtime is resolved once per run and handed down** — the HEAD
+discipline, a frozen `container.Runtime` through `worker.materialize` —
+because resolving per task could answer differently mid-run. The rerun
+entry point resolves its own, as it does HEAD: it *is* the driver of its
+one-task run. `lc status` gained the three header lines (mode, image
+state, sandbox) — repository facts only, no runtime and no network
+required, which is where the denial note and the runtime-missing
+refusal point.
+
 ### Recorded decisions
 
 - **The engine is the host's uv tool, never a project dependency**
@@ -1345,10 +1518,11 @@ only checks that the guard is present. Verified empirically, not assumed.
     Accepted rather than re-provided: the alternative is hashing an
     environment lc does not own into artifacts it does, which is the
     over-sensitivity the `behind` model exists to avoid.
-  - *Layer 6 note:* the generated image can no longer get its in-image
-    engine from the lock (`/opt/venv/bin/lc` existed because the pin did).
-    The Containerfile must install the engine as an explicit layer, and
-    that version becomes a tag input.
+  - *Layer 6 resolved its note the other way:* the image gets **no
+    engine layer at all**. The engine stays on the host in containerized
+    mode too — the container is the recipe's world, never the engine's —
+    so the engine version is not a tag input and an lc upgrade still
+    rebuilds nothing. See the layer-6 invariants.
   What it buys: a project's resolution is freed from the engine's own
   pins (no astra-tools/click/rich/distributed/git-annex in any project
   lock); the git-annex wheel floor gates only the tool install; the eval
@@ -1414,6 +1588,31 @@ only checks that the guard is present. Verified empirically, not assumed.
   (spec §2), so a scaffolded project simply carries a key no code path
   consults. Don't "fix" this by reconciling the two — a later layer will
   decide whether the key is dropped upstream, refused, or migrated.
+- **Multi-runtime, podman recommended** (2026-08, layer 6 — superseding
+  an earlier "podman only" plan decision). podman and docker ship
+  tested; the backend seam and the `docker-archive` format are chosen so
+  apptainer/singularity become thin layer-7 backends over the same
+  archive (they exec `docker-archive:` content directly, and HPC hosts
+  that cannot build obtain images through the annex). Build-capable
+  (podman|docker) and run-capable (all four, eventually) are therefore
+  separate questions in `container.py`. docker's daemon is probed at
+  detection — a CLI with the daemon down is the common broken state.
+- **Bare-recipe run records: considered and rejected** (2026-08).
+  datalad expands container templates at *record* time and `rerun`
+  executes the literal string — datalad-container has no rerun hook — so
+  a record whose `cmd` is the recipe replays on the host, unconfined,
+  with no manifest, and a containerized spelling would freeze one
+  runtime's flags into git forever. The worker-as-executor keeps the
+  record declarative and runtime-neutral; mechanical no-lc replay is
+  layer 8's WRROC export, for which the manifest + archive now carry
+  everything.
+- **Single-arch archives, recorded residue** (layer 6 → layer 7). The
+  committed archive is the architecture it was built for, and the
+  manifest says which. An Apple-silicon build cannot serve an amd64
+  venue; solving that (arch-suffixed archive paths, `--platform`
+  cross-builds) is layer 7's, with the venue that makes it real. Old
+  archives accumulate in annex history; reclaiming them is the user's
+  `git annex unused`/`drop` — no GC verb.
 
 ### Recorded deviations from the spec
 
@@ -1448,15 +1647,12 @@ only checks that the guard is present. Verified empirically, not assumed.
   `--require-sandbox` / `--no-sandbox` / `--sandbox-debug` are all
   absent: there is no hatch to escape the sandbox, so there is nothing
   for the flags to switch. The verb takes a command and nothing else.
-- **`lc run` does not detect containerized mode.** The
-  `[tool.lightcone.image]` refusal was removed with the rest of the
-  future-facing surface; a system-layer declaration is currently inert,
-  like `astra.yaml`'s `container:` key.
 - **The denial's remedies are only what works today** — `uv add` for a
-  Python package, the ASTRA input declaration for data, and "output goes
-  in `results/`" plus `tempfile.mkdtemp()` for a write denial. Nothing in
-  a denial message names a verb, flag, or declaration that does not
-  exist.
+  Python package, the system layer (`apt-install` + the containerize
+  note, real since layer 6), the ASTRA input declaration for data, and
+  "output goes in `results/`" plus `tempfile.mkdtemp()` for a write
+  denial. Nothing in a denial message names a verb, flag, or declaration
+  that does not exist.
 - **`Attestation` has no serializer of its own.** An earlier draft
   carried a `to_manifest()` with no caller — deleted, because "no dead
   code" applies to this layer's own conveniences too. It is persisted by
@@ -1521,6 +1717,8 @@ only checks that the guard is present. Verified empirically, not assumed.
 | Change what gets converged | `src/lightcone/engine/project.py` + `tests/test_project.py` | `_Converger.item` / `.file`; repairs only ever append |
 | Change how a project stores bytes | `src/lightcone/engine/dataset.py` + `templates/files/gitattributes.tmpl` | Every command through `project._run`; test it against a real annex (`real_tools`) |
 | Change how an output is identified | `src/lightcone/engine/identity.py` + `tests/test_identity.py` | Sensitivity tests both ways: what must move the hash, and what must not |
+| Change what the image is made of | `src/lightcone/engine/image.py` + `tests/test_image.py` | Pure; structure-and-ordering tests, never byte goldens; every declaration key is hashed |
+| Change how images are built, stored or entered | `src/lightcone/engine/container.py` (+ `sandbox/oci.py` for the exec argv) + `tests/test_container.py` | Everything through `project._run`; keep the three `ensure_image` strictnesses; runtime differences are spellings inside `OCIBackend`, never new shapes |
 | Change when an output is remade | `src/lightcone/engine/assets.py` + `tests/test_assets.py` | One `classify()`, two callers; `--check` differs by one input value, never by logic. Ask first whether the thing that moved *contradicts* the project or is a *circumstance* — the second is `behind`, not `stale` |
 | Change how the spec becomes a graph | `src/lightcone/engine/plan.py` + `tests/test_plan.py` | Ask `astra.resolve`; if the answer is missing, the fix is a PR to astra-tools. Anything ambiguous is a `ProjectError`, never a guess |
 | Change how a recipe runs | `src/lightcone/engine/worker.py` + `tests/test_worker.py` | Never raises, never writes git; mutation-check every denial test |
@@ -1595,6 +1793,24 @@ The sandbox suite splits along the seam, which is what makes it cheap:
 - `tests/test_run.py` — what `lc run` decides *before* it execs: the
   current-directory project check, declared inputs, the uv hop. Nothing
   spawns.
+- `tests/test_image.py` — **pure**: the declaration, the document, the
+  render's structure and ordering, tag sensitivity both ways, and the
+  `env_version` integration. `tests/test_sandbox_oci.py` — **pure**: the
+  mount table, the argv spellings, the attestation, and the
+  `contains_prefix` composition through a recorded fake `Popen`.
+- `tests/test_container.py` — the image lifecycle against a **stubbed**
+  `project._run` that models each runtime command's observable effect
+  (a `save` writes a structurally real docker-archive, a `load` marks
+  the id present), so every refusal and every strictness is asserted on
+  recorded argv with nothing spawned.
+- `tests/test_container_smoke.py` — **the runtime's answer**, gated like
+  the enforcement suite: skips without a runtime,
+  `LC_CONTAINER_TESTS_REQUIRED=1` on Linux CI turns the skip into a hard
+  failure, and two tests cover the guard itself. Parameterized over the
+  runtimes present. It builds a real image, commits a real archive into
+  a real annex, materializes through the real Dask cluster, and runs a
+  real `datalad rerun` on a bytes-free clone — the record's whole claim.
+  Each denial sits beside its mutation check.
 
 Note the autouse `tools` fixture stubs `engine.project._run` only —
 sandbox tests spawn real processes deliberately, and are the one place in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,3 +94,7 @@ follow_untyped_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# The container smoke tests leave ~200 MB image archives in each test's
+# tmp_path; keeping every passing run's directories exhausts a tmpfs.
+tmp_path_retention_policy = "failed"
+tmp_path_retention_count = 1

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -182,6 +182,14 @@ def run(command: tuple[str, ...]) -> None:
 # =============================================================================
 
 
+def _announce_build(tag: str) -> None:
+    """Say a minutes-long image build is coming — one wording, both verbs."""
+    _console().print(
+        f"building [bold]{tag}[/bold] if nothing refuses first — the first build "
+        "after an environment change can take minutes"
+    )
+
+
 @main.command()
 @click.option(
     "--json",
@@ -203,7 +211,7 @@ def build(as_json: bool) -> None:
     from lightcone.engine.project import current_project
 
     root = current_project()
-    state, tag = engine_container.image_state(root)
+    state, tag, _ = engine_container.image_state(root)
     if state == "direct":
         if as_json:
             click.echo(json.dumps({"mode": "direct"}))
@@ -214,10 +222,7 @@ def build(as_json: bool) -> None:
             )
         return
     if state == "absent" and not as_json:
-        _console().print(
-            f"building [bold]{tag}[/bold] — first build after an environment change; "
-            "this can take minutes"
-        )
+        _announce_build(tag)
     runtime, action = engine_container.build(root)
     if as_json:
         click.echo(
@@ -296,12 +301,9 @@ def materialize(
         # so before handing over. Conditional mood, deliberately: the
         # engine's own refusals (a dirty tree, an invalid spec) come
         # first and cost no build, so this must promise nothing.
-        state, tag = engine_container.image_state(root)
+        state, tag, _ = engine_container.image_state(root)
         if state == "absent":
-            _console().print(
-                f"this run will build [bold]{tag}[/bold] — first run after an "
-                "environment change; this can take minutes"
-            )
+            _announce_build(tag)
     if check_only:
         report = engine.check(root, targets, refresh=refresh)
     else:
@@ -356,8 +358,7 @@ def status(as_json: bool) -> None:
         described = {
             "present": "built",
             "absent": "needs build — run `lc build`",
-            "unfetched": f"content not fetched — git annex get "
-            f".datalad/environments/{tag}/image",
+            "unfetched": f"content not fetched — git annex get {report.image['archive']}",
         }[state]
         lines.append(f"  image:   {tag} — {described}")
     lines.append(f"  sandbox: {report.sandbox}")

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -178,6 +178,65 @@ def run(command: tuple[str, ...]) -> None:
 
 
 # =============================================================================
+# lc build
+# =============================================================================
+
+
+@main.command()
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit the result as JSON on stdout.",
+)
+def build(as_json: bool) -> None:
+    """Build the project's system-layer image, and commit it.
+
+    Containerized projects only — a project containerizes by declaring
+    [tool.lightcone.image] in pyproject.toml. The image is saved into the
+    repository (.datalad/environments/) as versioned content, so clones
+    obtain the exact bytes with `git annex get` instead of rebuilding.
+    Idempotent: an image that is already built and committed is left
+    alone.
+    """
+    from lightcone.engine import container as engine_container
+    from lightcone.engine.project import current_project
+
+    root = current_project()
+    state, tag = engine_container.image_state(root)
+    if state == "direct":
+        if as_json:
+            click.echo(json.dumps({"mode": "direct"}))
+        else:
+            _console().print(
+                "direct mode — no image to build; declare [bold]\\[tool.lightcone.image][/bold] "
+                "in pyproject.toml to containerize this project."
+            )
+        return
+    if state == "absent" and not as_json:
+        _console().print(
+            f"building [bold]{tag}[/bold] — first build after an environment change; "
+            "this can take minutes"
+        )
+    runtime, action = engine_container.build(root)
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "mode": "containerized",
+                    "tag": runtime.image_tag,
+                    "id": runtime.image_id,
+                    "archive": runtime.archive,
+                    "action": action,
+                }
+            )
+        )
+        return
+    verb = "Built and committed" if action == "built" else "Already built —"
+    _console().print(f"[green]✓[/green] {verb} {runtime.image_tag} ({runtime.archive})")
+
+
+# =============================================================================
 # lc materialize
 # =============================================================================
 
@@ -226,10 +285,21 @@ def materialize(
     records the environment and the commit that produced it. Pass
     --refresh to remake those too.
     """
+    from lightcone.engine import container as engine_container
     from lightcone.engine import materialize as engine
     from lightcone.engine.project import current_project
 
     root = current_project()
+    if not check_only and not as_json:
+        # The engine never prints, and the build it is about to run can
+        # take minutes — so the one place that owns the console says so
+        # before handing over, instead of after.
+        state, tag = engine_container.image_state(root)
+        if state == "absent":
+            _console().print(
+                f"building [bold]{tag}[/bold] — first run after an environment change; "
+                "this can take minutes"
+            )
     if check_only:
         report = engine.check(root, targets, refresh=refresh)
     else:
@@ -278,9 +348,21 @@ def status(as_json: bool) -> None:
         click.echo(json.dumps(report.as_dict(), indent=2))
         return
 
+    lines = [f"  mode:    {report.mode}"]
+    if report.image is not None:
+        tag, state = report.image["tag"], report.image["state"]
+        described = {
+            "present": "built",
+            "absent": "needs build — run `lc build`",
+            "unfetched": f"content not fetched — git annex get "
+            f".datalad/environments/{tag}/image",
+        }[state]
+        lines.append(f"  image:   {tag} — {described}")
+    lines.append(f"  sandbox: {report.sandbox}")
+    lines.append("")
     marks = {"current": "[dim]·[/dim]", "behind": "[cyan]·[/cyan]", "stale": "[yellow]![/yellow]"}
     width = max((len(o.output) for o in report.outputs), default=0)
-    lines = [
+    lines += [
         # The commit gets a column of its own, for every state and not only
         # the interesting ones: "which code made this" is the question the
         # verb exists to answer, and it has an answer for a current output

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -182,14 +182,6 @@ def run(command: tuple[str, ...]) -> None:
 # =============================================================================
 
 
-def _announce_build(tag: str) -> None:
-    """Say a minutes-long image build is coming — one wording, both verbs."""
-    _console().print(
-        f"building [bold]{tag}[/bold] if nothing refuses first — the first build "
-        "after an environment change can take minutes"
-    )
-
-
 @main.command()
 @click.option(
     "--json",
@@ -222,7 +214,7 @@ def build(as_json: bool) -> None:
             )
         return
     if state == "absent" and not as_json:
-        _announce_build(tag)
+        _console().print(f"building [bold]{tag}[/bold] — this can take minutes")
     runtime, action = engine_container.build(root)
     if as_json:
         click.echo(
@@ -303,7 +295,10 @@ def materialize(
         # first and cost no build, so this must promise nothing.
         state, tag, _ = engine_container.image_state(root)
         if state == "absent":
-            _announce_build(tag)
+            _console().print(
+                f"image absent — the run rebuilds [bold]{tag}[/bold] first "
+                "(this can take minutes)"
+            )
     if check_only:
         report = engine.check(root, targets, refresh=refresh)
     else:
@@ -358,7 +353,7 @@ def status(as_json: bool) -> None:
         described = {
             "present": "built",
             "absent": "needs build — run `lc build`",
-            "unfetched": f"content not fetched — git annex get {report.image['archive']}",
+            "unfetched": "content not in this clone — the next build or run fetches it",
         }[state]
         lines.append(f"  image:   {tag} — {described}")
     lines.append(f"  sandbox: {report.sandbox}")

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -291,14 +291,16 @@ def materialize(
 
     root = current_project()
     if not check_only and not as_json:
-        # The engine never prints, and the build it is about to run can
-        # take minutes — so the one place that owns the console says so
-        # before handing over, instead of after.
+        # The engine never prints, and the build it may be about to run
+        # can take minutes — so the one place that owns the console says
+        # so before handing over. Conditional mood, deliberately: the
+        # engine's own refusals (a dirty tree, an invalid spec) come
+        # first and cost no build, so this must promise nothing.
         state, tag = engine_container.image_state(root)
         if state == "absent":
             _console().print(
-                f"building [bold]{tag}[/bold] — first run after an environment change; "
-                "this can take minutes"
+                f"this run will build [bold]{tag}[/bold] — first run after an "
+                "environment change; this can take minutes"
             )
     if check_only:
         report = engine.check(root, targets, refresh=refresh)

--- a/src/lightcone/engine/assets.py
+++ b/src/lightcone/engine/assets.py
@@ -27,7 +27,7 @@ from typing import Any, Literal
 from lightcone.engine.project import ProjectError
 
 MANIFEST_FILENAME = ".lightcone-manifest.json"
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 #: Excluded from the content hash: the manifest is written *after* the
 #: hash it contains, so hashing it would be circular.
@@ -107,12 +107,12 @@ def data_version(path: Path) -> str:
             being in this clone, in either of the shapes that takes.
     """
     if path.is_symlink() and not path.exists():
-        _refuse_unfetched(path)
+        require_fetched(path)
     if not path.exists():
         raise FileNotFoundError(path)
     h = hashlib.sha256()
     if path.is_file():
-        _refuse_unfetched(path)
+        require_fetched(path)
         h.update(b"file:")
         _feed(h, path)
         return f"sha256:{h.hexdigest()}"
@@ -130,7 +130,7 @@ def data_version(path: Path) -> str:
         if p.name not in _HASH_EXCLUDE and (p.is_file() or (p.is_symlink() and not p.exists()))
     ]
     for p in sorted(files, key=lambda x: x.relative_to(path).as_posix()):
-        _refuse_unfetched(p)
+        require_fetched(p)
         h.update(b"path:")
         h.update(p.relative_to(path).as_posix().encode())
         h.update(b"\0data:")
@@ -175,7 +175,7 @@ class Versions:
         return known
 
 
-def _refuse_unfetched(path: Path) -> None:
+def require_fetched(path: Path) -> None:
     """Refuse a file whose content this clone does not hold.
 
     An annexed file takes one of two shapes, and a researcher can convert
@@ -187,7 +187,7 @@ def _refuse_unfetched(path: Path) -> None:
     without the content simply dangles.
 
     Args:
-        path: A file about to be hashed.
+        path: A file whose bytes are about to be used.
 
     Raises:
         ContentNotFetchedError: If *path* is either shape without its
@@ -255,6 +255,13 @@ class Manifest:
     lc_version: str
     #: What the sandbox actually enforced, as the boundary attested it.
     hermeticity: dict[str, Any]
+    #: The image the recipe ran in — ``{tag, id, archive, arch}`` — or
+    #: ``None`` on the host. Defaulted, and that is not back-compat
+    #: machinery: ``None`` is the *true* value for every manifest a
+    #: container-less engine wrote, and without the default those
+    #: manifests would read as absent and the whole project would go
+    #: stale over a field that changes nothing about the bytes.
+    image: dict[str, Any] | None = None
     schema_version: int = field(default=SCHEMA_VERSION)
 
     def as_dict(self) -> dict[str, Any]:

--- a/src/lightcone/engine/assets.py
+++ b/src/lightcone/engine/assets.py
@@ -27,7 +27,7 @@ from typing import Any, Literal
 from lightcone.engine.project import ProjectError
 
 MANIFEST_FILENAME = ".lightcone-manifest.json"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 1
 
 #: Excluded from the content hash: the manifest is written *after* the
 #: hash it contains, so hashing it would be circular.

--- a/src/lightcone/engine/container.py
+++ b/src/lightcone/engine/container.py
@@ -1,0 +1,486 @@
+"""Container runtimes: building the system layer, storing it, entering it.
+
+The dataset is the image store; runtime-local stores are caches. An image
+is built once, saved as a ``docker-archive`` at
+``.datalad/environments/<tag>/image``, and committed — annexed bytes that
+travel through ``git annex get`` like any other project content. Every
+machine that runs the project *loads* that archive into whatever runtime
+it has, so the bytes that made an output are the bytes a rerun enters,
+name-pinned apt notwithstanding. A dropped archive never substitutes: a
+rebuild is a new archive under a new id, never the old reference.
+
+Runtime is host capability, not project state — podman is preferred,
+docker accepted — and the archive format is the one all of podman,
+docker, and (later, on HPC) apptainer/singularity consume, which is why
+build-capable and run-capable are separate questions.
+
+Every command goes through :func:`~lightcone.engine.project._run`, the
+seam the whole engine shares, so the suite never spawns a runtime.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+from lightcone.engine import assets, dataset, image, project, sandbox
+from lightcone.engine.project import ProjectError, _check_call
+
+
+@dataclass(frozen=True)
+class Runtime:
+    """The execution world one run enters, resolved once by whoever owns it.
+
+    The driver resolves it and hands it to every task — the same
+    discipline as the run's HEAD read — because resolving per task could
+    answer differently mid-run. The rerun entry point resolves its own,
+    because it *is* the driver of its one-task run.
+    """
+
+    root: Path
+    mode: Literal["direct", "containerized"]
+    #: Where the project environment lives: ``.venv``, or the in-image
+    #: ``.lightcone/venv``.
+    env_dir: Path
+    #: ``podman`` or ``docker``; empty in direct mode.
+    runtime: str = ""
+    image_tag: str = ""
+    #: The image id (bare hex of its config blob) — execution pins on
+    #: this, never the tag, so a retagged image cannot substitute.
+    image_id: str = ""
+    #: The committed archive, project-relative — what the run record's
+    #: ``extra_inputs`` names and the manifest's ``image`` records.
+    archive: str = ""
+    #: The architecture the archive was built for.
+    arch: str = ""
+
+
+def runtime_for_run(root: Path, *, build: bool) -> Runtime:
+    """Resolve the execution world, converging the image where allowed.
+
+    The three image checks are repository questions first and runtime
+    questions second: archive committed, content fetched, loaded into the
+    local store. Only the first check's miss differs by caller — *build*
+    is true for ``lc build`` and the materialize preflight, which may
+    build and commit on a tree their own dirty check just proved clean;
+    everything else (the probe, the rerun entry point) refuses naming the
+    exact ``lc build``, because ``lc run`` never builds and the worker
+    never writes git.
+
+    Args:
+        root: The project root.
+        build: Whether a missing archive may be built and committed.
+
+    Returns:
+        The resolved runtime; a direct-mode one costs a TOML read.
+
+    Raises:
+        ProjectError: If no runtime is usable, the archive is missing and
+            *build* is false, its content is not in this clone, or the
+            build fails.
+    """
+    if project.mode(root) == "direct":
+        return Runtime(root=root, mode="direct", env_dir=project.env_dir(root))
+
+    name = runtime_name(root)
+    tag = image.tag(root)
+    archive = image.archive_path(root, tag)
+    if not archive.exists() and not archive.is_symlink():
+        if not build:
+            raise ProjectError(
+                f"the system-layer image `{tag}` has not been built — this verb "
+                "never builds one. Run `lc build` first."
+            )
+        _build(root, name, tag, archive)
+    # Both annexed shapes of an absent archive — the pointer file and the
+    # dangling symlink — refuse here with the exact `git annex get` line.
+    assets.require_fetched(archive)
+    image_id, arch = archive_identity(archive)
+    if not _loaded(root, name, image_id):
+        _check(root, [name, "load", "-i", str(archive)])
+    return Runtime(
+        root=root,
+        mode="containerized",
+        env_dir=project.env_dir(root),
+        runtime=name,
+        image_tag=tag,
+        image_id=image_id,
+        archive=archive.relative_to(root).as_posix(),
+        arch=arch,
+    )
+
+
+def runtime_name(root: Path) -> str:
+    """Detect which container runtime this host offers.
+
+    podman first — rootless podman needs no daemon and no group — then
+    docker, whose CLI without a reachable daemon is probed rather than
+    trusted, because `docker` on PATH with the daemon down is the common
+    broken state and "cannot connect to the socket" mid-run is a worse
+    message than this one.
+
+    Args:
+        root: The project root, for the probe's working directory.
+
+    Returns:
+        ``"podman"`` or ``"docker"``.
+
+    Raises:
+        ProjectError: If neither is usable.
+    """
+    if shutil.which("podman"):
+        _machine_preflight(root)
+        return "podman"
+    if shutil.which("docker"):
+        if project._run(["docker", "info"], cwd=root).returncode != 0:
+            raise ProjectError(
+                "docker is installed but its daemon is not reachable — start it "
+                "(or install podman, which needs no daemon), then retry. "
+                "`lc status` shows what this project needs."
+            )
+        return "docker"
+    raise ProjectError(
+        "this project is containerized and needs a container runtime: install "
+        "podman (recommended: https://podman.io/docs/installation) or docker. "
+        "`lc status` shows what this project needs."
+    )
+
+
+def backend(runtime: Runtime) -> sandbox.Backend:
+    """Pick the exec boundary for a resolved runtime.
+
+    The only *mode* branch above the sandbox seam, mirroring
+    ``sandbox.detect()``'s only *platform* branch: containerized mode is
+    entered through the OCI backend, whose mount table is the
+    enforcement; direct mode probes the host as it always has.
+
+    Args:
+        runtime: A resolved runtime.
+
+    Returns:
+        The backend the exec goes through.
+    """
+    if runtime.mode == "direct":
+        return sandbox.detect()
+    from lightcone.engine.sandbox.oci import OCIBackend
+
+    return OCIBackend(
+        runtime=cast(Literal["podman", "docker"], runtime.runtime),
+        image_id=runtime.image_id,
+        root=runtime.root,
+        user_flags=tuple(uid_flags(runtime.runtime)),
+    )
+
+
+def build(root: Path) -> tuple[Runtime, str]:
+    """Converge the system-layer image, the whole of ``lc build``.
+
+    Refuses a dirty tree before anything else: the archive is committed,
+    ``dataset.save`` stages scoped but commits the whole index, and the
+    tag derives from ``pyproject.toml`` — so the declaration must be
+    committed before the image it defines, and nothing of the user's may
+    be swept into the image commit.
+
+    Args:
+        root: The project root.
+
+    Returns:
+        The resolved runtime, and one word for what happened: ``built``
+        if this call built and committed the archive, ``present`` if it
+        was already there.
+
+    Raises:
+        ProjectError: On a direct-mode project, a dirty tree, a missing
+            committer identity, or a failed build.
+    """
+    if project.mode(root) == "direct":
+        raise ProjectError(
+            "direct mode — no image to build; declare [tool.lightcone.image] "
+            "in pyproject.toml to containerize this project."
+        )
+    project.require_git()
+    project.require_git_annex()
+    dataset.require_committer(root)
+    if dataset.status(root):
+        raise ProjectError(
+            "uncommitted changes — the image is derived from pyproject.toml and "
+            "committed into the repository, so `lc build` needs the tree to say "
+            "what it is building from. Commit first, then re-run `lc build`."
+        )
+    archive = image.archive_path(root, image.tag(root))
+    existed = archive.exists() or archive.is_symlink()
+    return runtime_for_run(root, build=True), ("present" if existed else "built")
+
+
+def runtime_hint() -> str:
+    """Name the runtime a run here would pick, or empty. Never a refusal.
+
+    For ``lc status``'s header, which reports rather than gates — a
+    missing runtime is a fact there, not a failure, and the daemon probe
+    is skipped because a header must not cost a subprocess.
+
+    Returns:
+        ``"podman"``, ``"docker"``, or ``""``.
+    """
+    for name in ("podman", "docker"):
+        if shutil.which(name):
+            return name
+    return ""
+
+
+def image_state(root: Path) -> tuple[str, str]:
+    """Report where the project's image stands, without a runtime.
+
+    Repository facts only, so ``lc status`` and the CLI's pre-build
+    announcement work on hosts with no runtime at all.
+
+    Args:
+        root: The project root.
+
+    Returns:
+        ``(state, tag)`` — state is ``direct``, ``absent`` (never built),
+        ``unfetched`` (committed, content elsewhere) or ``present``.
+    """
+    if project.mode(root) == "direct":
+        return ("direct", "")
+    tag = image.tag(root)
+    archive = image.archive_path(root, tag)
+    if not archive.exists() and not archive.is_symlink():
+        return ("absent", tag)
+    try:
+        assets.require_fetched(archive)
+    except assets.ContentNotFetchedError:
+        return ("unfetched", tag)
+    return ("present", tag)
+
+
+def sync(root: Path, runtime: Runtime) -> list[str]:
+    """Converge ``.lightcone/venv`` inside the image. The containerized twin
+    of ``project.sync``.
+
+    The one container run that gets the network and a writable project
+    mount — converge once, then execute without writing to the
+    environment, the same discipline as direct mode. The host's uv cache
+    is mounted at its identical path, so a complete environment
+    materializes from cache hits in about a second; the cache location is
+    ``uv cache dir``'s answer, never a guess, because that is uv's own
+    resolution of env, config and platform.
+
+    Args:
+        root: The project root.
+        runtime: A resolved containerized runtime.
+
+    Returns:
+        Whatever uv warned about, lifted out of its progress output.
+
+    Raises:
+        ProjectError: If uv fails inside the container.
+    """
+    cache = _check(root, ["uv", "cache", "dir"]).strip()
+    argv = [
+        runtime.runtime, "run", "--rm", "--entrypoint", "",
+        *uid_flags(runtime.runtime),
+        "-v", f"{root}:{root}:rw",
+        "-v", f"{cache}:{cache}:rw",
+        "--env", f"UV_CACHE_DIR={cache}",
+        "--env", f"UV_PROJECT_ENVIRONMENT={runtime.env_dir}",
+        "-w", str(root),
+        runtime.image_id,
+        "uv", "sync", "--locked", "--exact", "--compile-bytecode", "--project", str(root),
+    ]  # fmt: skip
+    return _check_call(argv, cwd=root)
+
+
+def archive_identity(path: Path) -> tuple[str, str]:
+    """Read an archive's image id and architecture, with no runtime.
+
+    The id is the sha256 of the image's config blob — the same value
+    ``podman inspect`` reports and the same computation datalad's docker
+    adapter makes — so execution can pin by id before anything is loaded.
+
+    Args:
+        path: A ``docker-archive`` file with its content present.
+
+    Returns:
+        ``(bare hex id, architecture)``.
+
+    Raises:
+        ProjectError: If the file is not a readable docker-archive.
+    """
+    try:
+        with tarfile.open(path) as tar:
+            listing = tar.extractfile("manifest.json")
+            assert listing is not None  # a member, not a directory
+            config_name = json.load(listing)[0]["Config"]
+            blob = tar.extractfile(config_name)
+            assert blob is not None
+            config = blob.read()
+    except (OSError, KeyError, IndexError, json.JSONDecodeError, tarfile.TarError) as e:
+        raise ProjectError(
+            f"{path} is not a readable image archive ({e}) — it was committed by "
+            "`lc build`; rebuild it with `lc build` after removing the file."
+        ) from e
+    return (
+        hashlib.sha256(config).hexdigest(),
+        str(json.loads(config).get("architecture", "")),
+    )
+
+
+def uid_flags(runtime: str) -> list[str]:
+    """The flags that keep files written through a mount owned by the user.
+
+    podman maps the invoking uid into the container (``--userns=keep-id``);
+    docker has no equivalent spelling, so the container simply runs as the
+    invoking uid — without which a rootful docker writes root-owned files
+    into ``results/`` that the host's git cannot manage. The missing
+    passwd entry that leaves behind is covered by the private-HOME
+    overlay every exec already gets.
+
+    Args:
+        runtime: ``"podman"`` or ``"docker"``.
+
+    Returns:
+        The argv fragment.
+    """
+    if runtime == "podman":
+        return ["--userns=keep-id", "--pull=never"]
+    return ["--user", f"{os.getuid()}:{os.getgid()}"]
+
+
+# =============================================================================
+# Building
+# =============================================================================
+
+
+def _build(root: Path, runtime: str, tag: str, archive: Path) -> None:
+    """Build the image, save it as *archive*, and commit it.
+
+    The build context is an empty scratch directory holding only the
+    rendered Containerfile — no project file ever enters it, which is
+    what makes "code edits never trigger a build" structural rather than
+    observed. The archive commit is scoped to the environment directory
+    plus ``.datalad/config`` (the ``datalad containers-run`` interop
+    keys), and the caller has already proven the tree clean.
+    """
+    with tempfile.TemporaryDirectory(prefix="lc-build-") as context:
+        containerfile = Path(context) / "Containerfile"
+        containerfile.write_text(image.containerfile(root))
+        proc = project._run(
+            [runtime, "build", "-t", tag, "-f", str(containerfile), context], cwd=root
+        )
+        if proc.returncode != 0:
+            raise ProjectError(_build_failure(tag, proc.stderr))
+
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    save_format = ["--format", "docker-archive"] if runtime == "podman" else []
+    _check(root, [runtime, "save", *save_format, "-o", str(archive), tag])
+
+    relative = archive.relative_to(root).as_posix()
+    for key, value in (
+        ("image", relative),
+        # Doubled braces survive datalad's record-time `.format`, so
+        # `{pwd}` is substituted at run time like any datalad command.
+        ("cmdexec", "podman run --rm -v {{pwd}}:{{pwd}} -w {{pwd}} docker-archive:{img} {cmd}"),
+    ):
+        _check(
+            root,
+            ["git", "config", "-f", ".datalad/config", f"datalad.containers.{tag}.{key}", value],
+        )
+    dataset.save(
+        root,
+        [archive.parent, root / ".datalad" / "config"],
+        f"Add the system-layer image {tag}",
+        # Without this the archive lands as a full blob in git — the
+        # annex routes dotfile paths to git whatever the attributes say.
+        dotfiles=True,
+    )
+
+
+def _build_failure(tag: str, stderr: str) -> str:
+    """Turn a build log into the refusal it means. Never the raw log."""
+    for line in stderr.splitlines():
+        if "Unable to locate package" in line:
+            package = line.rsplit(" ", 1)[-1]
+            return (
+                f"no apt package named `{package}` — check the name in "
+                f"[tool.lightcone.image] apt-install (search with "
+                f"`apt-cache search {package}`)."
+            )
+    contract = {
+        "43": "the base image is musl-based — manylinux wheels and uv-managed "
+        "interpreters need glibc; use a Debian-family `base`.",
+        "44": "the base image has no bash, and recipes run through `bash -c` — "
+        "use a base that carries bash, or a Debian-family `base`.",
+        "45": "the base image has no apt, and `apt-install` is declared — use a "
+        "Debian-family `base`, or move the packages to `run-commands`.",
+    }
+    for code, message in contract.items():
+        if f"exit status {code}" in stderr or f"exit code: {code}" in stderr:
+            return message
+    tail = "\n".join(stderr.strip().splitlines()[-15:])
+    return f"building `{tag}` failed:\n{tail}"
+
+
+# =============================================================================
+# The local store, and the podman machine
+# =============================================================================
+
+
+def _loaded(root: Path, runtime: str, image_id: str) -> bool:
+    """Whether the runtime's local store already holds *image_id*."""
+    probe = ["image", "exists" if runtime == "podman" else "inspect", image_id]
+    return project._run([runtime, *probe], cwd=root).returncode == 0
+
+
+def _machine_preflight(root: Path) -> None:
+    """Refuse a macOS podman machine that cannot mount what a run needs.
+
+    podman on macOS runs inside a Linux VM, and a bind mount whose source
+    is outside the VM's shared directories arrives *empty* — no error,
+    just a project with nothing in it. Linux needs none of this.
+    """
+    if sys.platform != "darwin":
+        return
+    proc = project._run(["podman", "machine", "inspect"], cwd=root)
+    if proc.returncode != 0:
+        raise ProjectError(
+            "containerized mode on macOS runs in a podman machine, and there is "
+            "none — one-time setup:\n  podman machine init\n  podman machine start"
+        )
+    try:
+        mounts = [
+            str(m.get("Source", "")) for m in json.loads(proc.stdout)[0].get("Mounts", [])
+        ]
+    except (json.JSONDecodeError, IndexError, KeyError, TypeError):
+        return  # an unreadable inspect is not a refusal; the mount will speak
+    shared = [m for m in mounts if m]
+    if shared and not any(
+        str(root) == m or str(root).startswith(m.rstrip("/") + "/") for m in shared
+    ):
+        raise ProjectError(
+            f"{root} is outside the podman machine's shared directories "
+            f"({', '.join(shared)}), so its bind mount would arrive empty. Share "
+            f"it:\n  podman machine stop\n  podman machine set --volume {root}\n"
+            "  podman machine start"
+        )
+
+
+# =============================================================================
+# Running tools
+# =============================================================================
+
+
+def _check(root: Path, argv: list[str]) -> str:
+    """Run a tool via the shared seam; a nonzero exit is a refusal."""
+    proc = project._run(argv, cwd=root)
+    if proc.returncode != 0:
+        raise ProjectError(f"`{' '.join(argv)}` failed:\n{proc.stderr.strip()}")
+    return str(proc.stdout or "")

--- a/src/lightcone/engine/container.py
+++ b/src/lightcone/engine/container.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shutil
 import sys
 import tarfile
@@ -287,6 +288,9 @@ def sync(root: Path, runtime: Runtime) -> list[str]:
     cache = _check(root, ["uv", "cache", "dir"]).strip()
     argv = [
         runtime.runtime, "run", "--rm", "--entrypoint", "",
+        # Same reason as the exec boundary's flag: SELinux hosts refuse
+        # bind reads from container_t, and relabeling user data is worse.
+        "--security-opt", "label=disable",
         *uid_flags(runtime.runtime),
         "-v", f"{root}:{root}:rw",
         "-v", f"{cache}:{cache}:rw",
@@ -370,6 +374,22 @@ def _build(root: Path, runtime: str, tag: str, archive: Path) -> None:
     plus ``.datalad/config`` (the ``datalad containers-run`` interop
     keys), and the caller has already proven the tree clean.
     """
+    relative = archive.relative_to(root).as_posix()
+    # The archive is committed, so its routing must be checked *before*
+    # the bytes exist: with `.gitattributes` not sending it to the annex
+    # — a user-authored file lc only ever appends to — a several-hundred-
+    # MB blob would land in git itself, silently, and every clone would
+    # carry it forever. The same probe-don't-assume rule as the ignore
+    # check on `results/`.
+    routed = project._run(["git", "check-attr", "annex.largefiles", "--", relative], cwd=root)
+    if "anything" not in routed.stdout:
+        raise ProjectError(
+            "the image archive would be committed to git itself instead of the "
+            f"annex — .gitattributes does not route `{relative}`. Add the line\n"
+            "  .datalad/environments/*/image annex.largefiles=anything\n"
+            "(`lc init` repairs this), then re-run."
+        )
+
     with tempfile.TemporaryDirectory(prefix="lc-build-") as context:
         containerfile = Path(context) / "Containerfile"
         containerfile.write_text(image.containerfile(root))
@@ -380,15 +400,29 @@ def _build(root: Path, runtime: str, tag: str, archive: Path) -> None:
             raise ProjectError(_build_failure(tag, proc.stderr))
 
     archive.parent.mkdir(parents=True, exist_ok=True)
+    # Saved beside its final name and renamed into place: a save that
+    # dies midway must not leave a partial archive that the dirty-tree
+    # refusal would then tell the user to commit.
+    partial = archive.parent / "image.partial"
     save_format = ["--format", "docker-archive"] if runtime == "podman" else []
-    _check(root, [runtime, "save", *save_format, "-o", str(archive), tag])
+    try:
+        _check(root, [runtime, "save", *save_format, "-o", str(partial), tag])
+    except ProjectError:
+        partial.unlink(missing_ok=True)
+        raise
+    partial.replace(archive)
 
-    relative = archive.relative_to(root).as_posix()
     for key, value in (
         ("image", relative),
         # Doubled braces survive datalad's record-time `.format`, so
         # `{pwd}` is substituted at run time like any datalad command.
-        ("cmdexec", "podman run --rm -v {{pwd}}:{{pwd}} -w {{pwd}} docker-archive:{img} {cmd}"),
+        # The template names the runtime that built the image — best-
+        # effort interop for humans, outside lc's guarantees either way.
+        (
+            "cmdexec",
+            f"{runtime} run --rm -v {{{{pwd}}}}:{{{{pwd}}}} -w {{{{pwd}}}} "
+            "docker-archive:{img} {cmd}",
+        ),
     ):
         _check(
             root,
@@ -398,9 +432,6 @@ def _build(root: Path, runtime: str, tag: str, archive: Path) -> None:
         root,
         [archive.parent, root / ".datalad" / "config"],
         f"Add the system-layer image {tag}",
-        # Without this the archive lands as a full blob in git — the
-        # annex routes dotfile paths to git whatever the attributes say.
-        dotfiles=True,
     )
 
 
@@ -414,16 +445,19 @@ def _build_failure(tag: str, stderr: str) -> str:
                 f"[tool.lightcone.image] apt-install (search with "
                 f"`apt-cache search {package}`)."
             )
+    # Anchored on the failing instruction as well as the code: the error
+    # names the STEP that died, and a user's own run-command exiting 43
+    # (curl does) must not be diagnosed as a musl base.
     contract = {
-        "43": "the base image is musl-based — manylinux wheels and uv-managed "
-        "interpreters need glibc; use a Debian-family `base`.",
-        "44": "the base image has no bash, and recipes run through `bash -c` — "
-        "use a base that carries bash, or a Debian-family `base`.",
-        "45": "the base image has no apt, and `apt-install` is declared — use a "
-        "Debian-family `base`, or move the packages to `run-commands`.",
+        ("43", "ldd --version"): "the base image is musl-based — manylinux wheels and "
+        "uv-managed interpreters need glibc; use a Debian-family `base`.",
+        ("44", "command -v bash"): "the base image has no bash, and recipes run through "
+        "`bash -c` — use a base that carries bash, or a Debian-family `base`.",
+        ("45", "command -v apt-get"): "the base image has no apt, and `apt-install` is "
+        "declared — use a Debian-family `base`, or move the packages to `run-commands`.",
     }
-    for code, message in contract.items():
-        if f"exit status {code}" in stderr or f"exit code: {code}" in stderr:
+    for (code, instruction), message in contract.items():
+        if re.search(rf"exit (status|code):? {code}\b", stderr) and instruction in stderr:
             return message
     tail = "\n".join(stderr.strip().splitlines()[-15:])
     return f"building `{tag}` failed:\n{tail}"
@@ -456,20 +490,30 @@ def _machine_preflight(root: Path) -> None:
             "none — one-time setup:\n  podman machine init\n  podman machine start"
         )
     try:
-        mounts = [
-            str(m.get("Source", "")) for m in json.loads(proc.stdout)[0].get("Mounts", [])
-        ]
+        machine = json.loads(proc.stdout)[0]
+        state = str(machine.get("State", ""))
+        mounts = [str(m.get("Source", "")) for m in machine.get("Mounts", [])]
     except (json.JSONDecodeError, IndexError, KeyError, TypeError):
         return  # an unreadable inspect is not a refusal; the mount will speak
+    if state and state != "running":
+        # `inspect` succeeds on a stopped machine, so without this the
+        # preflight passes and the run dies later on a raw connection
+        # error, far from the one-command fix.
+        raise ProjectError(
+            f"the podman machine is {state}, not running — start it:\n"
+            "  podman machine start"
+        )
     shared = [m for m in mounts if m]
-    if shared and not any(
-        str(root) == m or str(root).startswith(m.rstrip("/") + "/") for m in shared
-    ):
+    if not any(str(root) == m or str(root).startswith(m.rstrip("/") + "/") for m in shared):
+        # An empty share list refuses too: a bind whose source the VM
+        # does not share arrives *empty*, no error — a project with
+        # nothing in it. (Declared inputs outside the tree are not
+        # checked here; their mounts carry the same risk, recorded.)
         raise ProjectError(
             f"{root} is outside the podman machine's shared directories "
-            f"({', '.join(shared)}), so its bind mount would arrive empty. Share "
-            f"it:\n  podman machine stop\n  podman machine set --volume {root}\n"
-            "  podman machine start"
+            f"({', '.join(shared) or 'none'}), so its bind mount would arrive "
+            f"empty. Share it:\n  podman machine stop\n"
+            f"  podman machine set --volume {root}\n  podman machine start"
         )
 
 

--- a/src/lightcone/engine/container.py
+++ b/src/lightcone/engine/container.py
@@ -85,13 +85,13 @@ def runtime_for_run(root: Path, *, build: bool) -> Runtime:
     """Resolve the execution world, converging the image where allowed.
 
     The three image checks are repository questions first and runtime
-    questions second: archive committed, content fetched, loaded into the
-    local store. Only the first check's miss differs by caller — *build*
-    is true for ``lc build`` and the materialize preflight, which may
-    build and commit on a tree their own dirty check just proved clean;
-    everything else (the probe, the rerun entry point) refuses naming the
-    exact ``lc build``, because ``lc run`` never builds and the worker
-    never writes git.
+    questions second: archive committed, content fetched (through the
+    annex, by lc itself), loaded into the local store. Only the first
+    check's miss differs by caller — *build* is true for ``lc build`` and
+    the materialize preflight, which may build and commit on a tree their
+    own dirty check just proved clean; everything else (the probe, the
+    rerun entry point) refuses naming the exact ``lc build``, because
+    ``lc run`` never builds and the worker never commits.
 
     Args:
         root: The project root.
@@ -102,8 +102,8 @@ def runtime_for_run(root: Path, *, build: bool) -> Runtime:
 
     Raises:
         ProjectError: If no runtime is usable, the archive is missing and
-            *build* is false, its content is not in this clone, or the
-            build fails.
+            *build* is false, its content cannot be fetched from any
+            reachable copy, or the build fails.
     """
     if project.mode(root) == "direct":
         return Runtime(root=root, mode="direct", env_dir=project.env_dir(root))
@@ -118,9 +118,7 @@ def runtime_for_run(root: Path, *, build: bool) -> Runtime:
                 "never builds one. Run `lc build` first."
             )
         _build(root, name, tag, archive)
-    # Both annexed shapes of an absent archive — the pointer file and the
-    # dangling symlink — refuse here with the exact `git annex get` line.
-    assets.require_fetched(archive)
+    _fetch(root, archive)
     image_id, arch = archive_identity(archive)
     if not _loaded(root, name, image_id):
         _check_call([name, "load", "-i", str(archive)], cwd=root)
@@ -133,6 +131,35 @@ def runtime_for_run(root: Path, *, build: bool) -> Runtime:
         image_id=image_id,
         arch=arch,
     )
+
+
+def _fetch(root: Path, archive: Path) -> None:
+    """Bring the archive's bytes into this clone, if they are elsewhere.
+
+    lc fetches its own artifact rather than printing a git-annex command —
+    the storage invariant is that nobody is ever asked to run one by hand.
+    Covers both annexed shapes of absent content (the pointer file and the
+    dangling symlink); the refusal is reserved for a fetch that genuinely
+    cannot happen, with git-annex's own reason.
+
+    Raises:
+        ProjectError: If no reachable copy could supply the content.
+    """
+    relative = archive.relative_to(root).as_posix()
+    try:
+        assets.require_fetched(archive)
+        return
+    except assets.ContentNotFetchedError:
+        pass
+    got = project._run(["git", "annex", "get", "--", relative], cwd=root)
+    if got.returncode != 0:
+        raise ProjectError(
+            f"the image archive `{relative}` is not in this clone, and fetching it "
+            f"failed:\n{got.stderr.strip()}\n"
+            "It needs a reachable remote that holds the content — or rebuild a new "
+            "image with `lc build`."
+        )
+    assets.require_fetched(archive)
 
 
 def _committed(archive: Path) -> bool:

--- a/src/lightcone/engine/container.py
+++ b/src/lightcone/engine/container.py
@@ -57,11 +57,28 @@ class Runtime:
     #: The image id (bare hex of its config blob) — execution pins on
     #: this, never the tag, so a retagged image cannot substitute.
     image_id: str = ""
-    #: The committed archive, project-relative — what the run record's
-    #: ``extra_inputs`` names and the manifest's ``image`` records.
-    archive: str = ""
     #: The architecture the archive was built for.
     arch: str = ""
+
+    @property
+    def archive(self) -> str:
+        """The committed archive, project-relative — what the run record's
+        ``extra_inputs`` names. Derived through :func:`image.archive_path`
+        so this cannot become a second spelling of the layout."""
+        return image.archive_path(self.root, self.image_tag).relative_to(self.root).as_posix()
+
+    def manifest_image(self) -> dict[str, str] | None:
+        """This world as the manifest's ``image`` field; ``None`` on the
+        host. Beside the data, so a field added here cannot be forgotten
+        at the write site — the ``asdict(attestation)`` discipline."""
+        if self.mode == "direct":
+            return None
+        return {
+            "tag": self.image_tag,
+            "id": self.image_id,
+            "archive": self.archive,
+            "arch": self.arch,
+        }
 
 
 def runtime_for_run(root: Path, *, build: bool) -> Runtime:
@@ -94,7 +111,7 @@ def runtime_for_run(root: Path, *, build: bool) -> Runtime:
     name = runtime_name(root)
     tag = image.tag(root)
     archive = image.archive_path(root, tag)
-    if not archive.exists() and not archive.is_symlink():
+    if not _committed(archive):
         if not build:
             raise ProjectError(
                 f"the system-layer image `{tag}` has not been built — this verb "
@@ -106,7 +123,7 @@ def runtime_for_run(root: Path, *, build: bool) -> Runtime:
     assets.require_fetched(archive)
     image_id, arch = archive_identity(archive)
     if not _loaded(root, name, image_id):
-        _check(root, [name, "load", "-i", str(archive)])
+        _check_call([name, "load", "-i", str(archive)], cwd=root)
     return Runtime(
         root=root,
         mode="containerized",
@@ -114,9 +131,18 @@ def runtime_for_run(root: Path, *, build: bool) -> Runtime:
         runtime=name,
         image_tag=tag,
         image_id=image_id,
-        archive=archive.relative_to(root).as_posix(),
         arch=arch,
     )
+
+
+def _committed(archive: Path) -> bool:
+    """Whether the repository carries the archive, in either annexed shape.
+
+    A dangling symlink *is* a committed archive (a locked clone without
+    the content), so the naive ``exists()`` misreads it as never built
+    and tells the user to rebuild an image the repository already has.
+    """
+    return archive.exists() or archive.is_symlink()
 
 
 def runtime_name(root: Path) -> str:
@@ -137,22 +163,23 @@ def runtime_name(root: Path) -> str:
     Raises:
         ProjectError: If neither is usable.
     """
-    if shutil.which("podman"):
+    name = runtime_hint()
+    if name == "podman":
         _machine_preflight(root)
-        return "podman"
-    if shutil.which("docker"):
+    elif name == "docker":
         if project._run(["docker", "info"], cwd=root).returncode != 0:
             raise ProjectError(
                 "docker is installed but its daemon is not reachable — start it "
                 "(or install podman, which needs no daemon), then retry. "
                 "`lc status` shows what this project needs."
             )
-        return "docker"
-    raise ProjectError(
-        "this project is containerized and needs a container runtime: install "
-        "podman (recommended: https://podman.io/docs/installation) or docker. "
-        "`lc status` shows what this project needs."
-    )
+    else:
+        raise ProjectError(
+            "this project is containerized and needs a container runtime: install "
+            "podman (recommended: https://podman.io/docs/installation) or docker. "
+            "`lc status` shows what this project needs."
+        )
+    return name
 
 
 def backend(runtime: Runtime) -> sandbox.Backend:
@@ -173,11 +200,16 @@ def backend(runtime: Runtime) -> sandbox.Backend:
         return sandbox.detect()
     from lightcone.engine.sandbox.oci import OCIBackend
 
+    # `--pull=never` beside the uid flags rather than inside them: it is
+    # a pull policy (a typo'd reference must fail, not fetch), podman's
+    # spelling only, and filing it under uid mapping is where the next
+    # reader would not look.
+    pull = ("--pull=never",) if runtime.runtime == "podman" else ()
     return OCIBackend(
         runtime=cast(Literal["podman", "docker"], runtime.runtime),
         image_id=runtime.image_id,
         root=runtime.root,
-        user_flags=tuple(uid_flags(runtime.runtime)),
+        user_flags=(*uid_flags(runtime.runtime), *pull),
     )
 
 
@@ -216,8 +248,7 @@ def build(root: Path) -> tuple[Runtime, str]:
             "committed into the repository, so `lc build` needs the tree to say "
             "what it is building from. Commit first, then re-run `lc build`."
         )
-    archive = image.archive_path(root, image.tag(root))
-    existed = archive.exists() or archive.is_symlink()
+    existed = image_state(root)[0] != "absent"
     return runtime_for_run(root, build=True), ("present" if existed else "built")
 
 
@@ -237,7 +268,7 @@ def runtime_hint() -> str:
     return ""
 
 
-def image_state(root: Path) -> tuple[str, str]:
+def image_state(root: Path) -> tuple[str, str, str]:
     """Report where the project's image stands, without a runtime.
 
     Repository facts only, so ``lc status`` and the CLI's pre-build
@@ -247,20 +278,23 @@ def image_state(root: Path) -> tuple[str, str]:
         root: The project root.
 
     Returns:
-        ``(state, tag)`` — state is ``direct``, ``absent`` (never built),
-        ``unfetched`` (committed, content elsewhere) or ``present``.
+        ``(state, tag, archive)`` — state is ``direct``, ``absent``
+        (never built), ``unfetched`` (committed, content elsewhere) or
+        ``present``; archive is the project-relative path a remedy can
+        name, carried here so no renderer respells the layout.
     """
     if project.mode(root) == "direct":
-        return ("direct", "")
+        return ("direct", "", "")
     tag = image.tag(root)
     archive = image.archive_path(root, tag)
-    if not archive.exists() and not archive.is_symlink():
-        return ("absent", tag)
+    relative = archive.relative_to(root).as_posix()
+    if not _committed(archive):
+        return ("absent", tag, relative)
     try:
         assets.require_fetched(archive)
     except assets.ContentNotFetchedError:
-        return ("unfetched", tag)
-    return ("present", tag)
+        return ("unfetched", tag, relative)
+    return ("present", tag, relative)
 
 
 def sync(root: Path, runtime: Runtime) -> list[str]:
@@ -285,7 +319,10 @@ def sync(root: Path, runtime: Runtime) -> list[str]:
     Raises:
         ProjectError: If uv fails inside the container.
     """
-    cache = _check(root, ["uv", "cache", "dir"]).strip()
+    asked = project._run(["uv", "cache", "dir"], cwd=root)
+    if asked.returncode != 0:
+        raise ProjectError(f"`uv cache dir` failed:\n{asked.stderr.strip()}")
+    cache = asked.stdout.strip()
     argv = [
         runtime.runtime, "run", "--rm", "--entrypoint", "",
         # Same reason as the exec boundary's flag: SELinux hosts refuse
@@ -298,9 +335,53 @@ def sync(root: Path, runtime: Runtime) -> list[str]:
         "--env", f"UV_PROJECT_ENVIRONMENT={runtime.env_dir}",
         "-w", str(root),
         runtime.image_id,
-        "uv", "sync", "--locked", "--exact", "--compile-bytecode", "--project", str(root),
+        # The same sync `project.sync` runs, spelled once for both modes.
+        "uv", *project._SYNC_ARGS, "--project", str(root),
     ]  # fmt: skip
     return _check_call(argv, cwd=root)
+
+
+def converge(runtime: Runtime) -> list[str]:
+    """Make the environment match the lock, whichever world this is.
+
+    The one spelling of the mode dispatch, so the entry points that
+    converge (materialize, the rerun worker) cannot drift apart. The
+    probe deliberately does not call this in direct mode — its syncing
+    ``uv run`` hop *is* its converge, documented at the call site.
+
+    Args:
+        runtime: The resolved runtime.
+
+    Returns:
+        Whatever uv warned about.
+    """
+    if runtime.mode == "direct":
+        return project.sync(runtime.root)
+    return sync(runtime.root, runtime)
+
+
+def policy_for(runtime: Runtime, read_paths: list[Path]) -> sandbox.Policy:
+    """Build the exec policy for a resolved runtime.
+
+    The one place the ``env_dir``/``containerized`` pair is assembled —
+    two settings that must always agree, projected from the single value
+    every caller already holds. Lives here rather than in the policy
+    module so the mechanism-free policy layer never learns what a
+    ``Runtime`` is.
+
+    Args:
+        runtime: The resolved runtime.
+        read_paths: Declared inputs, as :func:`sandbox.exec_policy` takes.
+
+    Returns:
+        The policy for this world.
+    """
+    return sandbox.exec_policy(
+        runtime.root,
+        read_paths=read_paths,
+        env_dir=runtime.env_dir,
+        containerized=runtime.mode == "containerized",
+    )
 
 
 def archive_identity(path: Path) -> tuple[str, str]:
@@ -355,7 +436,7 @@ def uid_flags(runtime: str) -> list[str]:
         The argv fragment.
     """
     if runtime == "podman":
-        return ["--userns=keep-id", "--pull=never"]
+        return ["--userns=keep-id"]
     return ["--user", f"{os.getuid()}:{os.getgid()}"]
 
 
@@ -381,8 +462,8 @@ def _build(root: Path, runtime: str, tag: str, archive: Path) -> None:
     # MB blob would land in git itself, silently, and every clone would
     # carry it forever. The same probe-don't-assume rule as the ignore
     # check on `results/`.
-    routed = project._run(["git", "check-attr", "annex.largefiles", "--", relative], cwd=root)
-    if "anything" not in routed.stdout:
+    routed = dataset._git(["check-attr", "annex.largefiles", "--", relative], cwd=root)
+    if "anything" not in routed:
         raise ProjectError(
             "the image archive would be committed to git itself instead of the "
             f"annex — .gitattributes does not route `{relative}`. Add the line\n"
@@ -406,7 +487,7 @@ def _build(root: Path, runtime: str, tag: str, archive: Path) -> None:
     partial = archive.parent / "image.partial"
     save_format = ["--format", "docker-archive"] if runtime == "podman" else []
     try:
-        _check(root, [runtime, "save", *save_format, "-o", str(partial), tag])
+        _check_call([runtime, "save", *save_format, "-o", str(partial), tag], cwd=root)
     except ProjectError:
         partial.unlink(missing_ok=True)
         raise
@@ -424,9 +505,9 @@ def _build(root: Path, runtime: str, tag: str, archive: Path) -> None:
             "docker-archive:{img} {cmd}",
         ),
     ):
-        _check(
-            root,
-            ["git", "config", "-f", ".datalad/config", f"datalad.containers.{tag}.{key}", value],
+        dataset._git(
+            ["config", "-f", ".datalad/config", f"datalad.containers.{tag}.{key}", value],
+            cwd=root,
         )
     dataset.save(
         root,
@@ -517,14 +598,3 @@ def _machine_preflight(root: Path) -> None:
         )
 
 
-# =============================================================================
-# Running tools
-# =============================================================================
-
-
-def _check(root: Path, argv: list[str]) -> str:
-    """Run a tool via the shared seam; a nonzero exit is a refusal."""
-    proc = project._run(argv, cwd=root)
-    if proc.returncode != 0:
-        raise ProjectError(f"`{' '.join(argv)}` failed:\n{proc.stderr.strip()}")
-    return str(proc.stdout or "")

--- a/src/lightcone/engine/dataset.py
+++ b/src/lightcone/engine/dataset.py
@@ -192,7 +192,7 @@ def dataset_id(directory: Path) -> str:
     return found.stdout.strip() if found.returncode == 0 else ""
 
 
-def save(directory: Path, paths: Iterable[Path], message: str) -> bool:
+def save(directory: Path, paths: Iterable[Path], message: str, *, dotfiles: bool = False) -> bool:
     """Commit *paths*.
 
     A plain ``git add``: ``.gitattributes`` sets ``filter=annex``, so git's
@@ -213,12 +213,22 @@ def save(directory: Path, paths: Iterable[Path], message: str) -> bool:
         directory: The repository root.
         paths: What to stage, absolute or repository-relative.
         message: The commit message.
+        dotfiles: Let the annex take files under dot-directories.
+            git-annex routes dotfiles to git regardless of what
+            ``annex.largefiles`` says unless this is set, so the image
+            archive under ``.datalad/environments/`` would land as a
+            full blob in git — silently, with every test green — and
+            every clone would carry the bytes forever. Per-add and
+            opt-in, because the driver's ordinary saves never touch a
+            dotfile and a repo-wide setting would change what a user's
+            own ``git add`` does.
 
     Returns:
         False if there was nothing to commit.
     """
     relative = [_rel(directory, p) for p in paths]
-    _git(["-c", "annex.thin=true", "add", "-A", "--", *relative], cwd=directory)
+    routing = ["-c", "annex.dotfiles=true"] if dotfiles else []
+    _git(["-c", "annex.thin=true", *routing, "add", "-A", "--", *relative], cwd=directory)
     if _git_ok(["diff", "--cached", "--quiet"], cwd=directory):
         return False
     _git(["commit", "-q", "-m", message], cwd=directory)

--- a/src/lightcone/engine/dataset.py
+++ b/src/lightcone/engine/dataset.py
@@ -192,7 +192,7 @@ def dataset_id(directory: Path) -> str:
     return found.stdout.strip() if found.returncode == 0 else ""
 
 
-def save(directory: Path, paths: Iterable[Path], message: str, *, dotfiles: bool = False) -> bool:
+def save(directory: Path, paths: Iterable[Path], message: str) -> bool:
     """Commit *paths*.
 
     A plain ``git add``: ``.gitattributes`` sets ``filter=annex``, so git's
@@ -209,26 +209,31 @@ def save(directory: Path, paths: Iterable[Path], message: str, *, dotfiles: bool
     `git add` and whose tools very much do open files for update, so it is
     passed per-add and never written to the repository's config.
 
+    ``annex.dotfiles`` is set for the same reason ``annex.thin`` is:
+    without it, git-annex routes any file under a dot-directory to git
+    *regardless* of what ``annex.largefiles`` says — so the image archive
+    under ``.datalad/environments/``, or a ``.cache.h5`` a recipe writes
+    into its output directory, would land as a full blob in git,
+    silently, with every test green, and every clone would carry the
+    bytes forever. With it, ``annex.largefiles`` alone decides — which is
+    the storage policy the ``.gitattributes`` template already states,
+    dot-named manifests staying in git through their own exemption.
+    Per-add and never written to the repository's config, so a user's
+    own ``git add`` keeps git-annex's stock behavior.
+
     Args:
         directory: The repository root.
         paths: What to stage, absolute or repository-relative.
         message: The commit message.
-        dotfiles: Let the annex take files under dot-directories.
-            git-annex routes dotfiles to git regardless of what
-            ``annex.largefiles`` says unless this is set, so the image
-            archive under ``.datalad/environments/`` would land as a
-            full blob in git — silently, with every test green — and
-            every clone would carry the bytes forever. Per-add and
-            opt-in, because the driver's ordinary saves never touch a
-            dotfile and a repo-wide setting would change what a user's
-            own ``git add`` does.
 
     Returns:
         False if there was nothing to commit.
     """
     relative = [_rel(directory, p) for p in paths]
-    routing = ["-c", "annex.dotfiles=true"] if dotfiles else []
-    _git(["-c", "annex.thin=true", *routing, "add", "-A", "--", *relative], cwd=directory)
+    _git(
+        ["-c", "annex.thin=true", "-c", "annex.dotfiles=true", "add", "-A", "--", *relative],
+        cwd=directory,
+    )
     if _git_ok(["diff", "--cached", "--quiet"], cwd=directory):
         return False
     _git(["commit", "-q", "-m", message], cwd=directory)

--- a/src/lightcone/engine/identity.py
+++ b/src/lightcone/engine/identity.py
@@ -8,8 +8,9 @@ when it moves, the artifact on disk is no longer an instance of the thing
 the spec describes, so keeping it would be mislabelling it.
 
 ``env_version`` is the environment's identity: the lock's bytes, the
-interpreter pin's bytes, and the settings that decide *which artifacts*
-``uv sync`` materializes from that lock. It is deliberately
+interpreter pin's bytes, the settings that decide *which artifacts*
+``uv sync`` materializes from that lock, and — for a containerized
+project — the system layer's identity document. It is deliberately
 over-sensitive — raw lock bytes, so a comment reflow moves it — because
 the alternative is a parse that silently disagrees with uv about what the
 lock means.
@@ -47,6 +48,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from lightcone.engine import image
 from lightcone.engine.project import ProjectError
 
 #: The closed, audited list of uv settings that change *which artifacts* a
@@ -75,9 +77,11 @@ def env_version(root: Path) -> str:
     """Compute the environment identity of a project.
 
     ``sha256(uv.lock bytes ‖ .python-version bytes ‖ canonical
-    install-settings JSON)``, length-framed. Read fresh on every call: this
-    is also the mid-run gate's baseline, and a cached value would check
-    nothing.
+    install-settings JSON ‖ canonical image identity document)``,
+    length-framed. A direct-mode project hashes the literal ``null`` for
+    the image term, so this stays one formula rather than two. Read fresh
+    on every call: this is also the mid-run gate's baseline, and a cached
+    value would check nothing.
 
     Args:
         root: The project root.
@@ -100,6 +104,7 @@ def env_version(root: Path) -> str:
     _frame(h, "uv.lock", lock.read_bytes())
     _frame(h, "python-version", pin.read_bytes())
     _frame(h, "install-settings", _install_settings(root).encode())
+    _frame(h, "image", (image.identity_document(root) or "null").encode())
     return f"sha256:{h.hexdigest()}"
 
 

--- a/src/lightcone/engine/image.py
+++ b/src/lightcone/engine/image.py
@@ -24,6 +24,14 @@ carries no project files, so a code edit can never trigger a build.
 
 This module is pure: no subprocess, and no filesystem beyond reading
 ``pyproject.toml`` and ``.python-version``.
+
+The render is assembled by hand rather than through a library, checked
+rather than assumed (2026-08): no established Containerfile-*authoring*
+library exists — the maintained ones are Engine clients, and the
+generators are small templating wrappers — and everything hard here is
+the validation and the identity, which none of them carry. Assembling
+lines from a validated model is also what the ecosystem's own generators
+(Modal, repo2docker) do.
 """
 
 from __future__ import annotations
@@ -43,6 +51,13 @@ from lightcone.engine.project import ProjectError
 #: stays a pure function of the repository plus the engine. An engine
 #: release that bumps this moves both the tag and ``env_version`` for
 #: containerized projects — the system layer genuinely changed.
+#:
+#: Vanilla debian-slim, deliberately *without* Python — the same family
+#: as Modal's ``debian_slim()`` default but not the same content: Modal's
+#: carries their own Python build, while here the base never supplies the
+#: interpreter. uv installs the exact ``.python-version`` pin during the
+#: build, so "which python ran" is identical under any base — swap in a
+#: CUDA image and the interpreter, and its identity, do not move.
 DEFAULT_BASE = (
     "docker.io/library/debian:bookworm-slim"
     "@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241"

--- a/src/lightcone/engine/image.py
+++ b/src/lightcone/engine/image.py
@@ -1,0 +1,300 @@
+"""The system layer: what a containerized project declares, and its identity.
+
+A project escalates to containerized mode by declaring a
+``[tool.lightcone.image]`` table in ``pyproject.toml`` — the table's
+presence *is* the escalation, and it is the whole user-facing surface.
+Nobody ever writes or sees a Containerfile: the render exists only inside
+a transient build context, and everything about the image is derived from
+the declaration plus this module's constants.
+
+The surface is deliberately shaped like Modal's image builders, as TOML:
+``base`` (``from_registry``), ``apt-install`` (``apt_install``),
+``run-commands`` (``run_commands``) and ``env`` (``env``). There is no
+``pip_install`` equivalent on purpose — the Python environment is the
+lock's business, never the image's. ``run-commands`` is the bounded
+escape for anything apt cannot say.
+
+Two derived identities, for two different questions. The **identity
+document** is canonical JSON of the resolved declaration plus the
+generator's pinned inputs; it feeds ``env_version``, so a system-layer
+change puts outputs behind. The **tag** additionally hashes the rendered
+Containerfile text, so a generator change rebuilds the image even when
+the document is unchanged. Code is an input to neither — the image
+carries no project files, so a code edit can never trigger a build.
+
+This module is pure: no subprocess, and no filesystem beyond reading
+``pyproject.toml`` and ``.python-version``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lightcone.engine.project import ProjectError
+
+#: The default base image. Digest-pinned to the multi-arch manifest list,
+#: so the reference is one string on every architecture and the image
+#: stays a pure function of the repository plus the engine. An engine
+#: release that bumps this moves both the tag and ``env_version`` for
+#: containerized projects — the system layer genuinely changed.
+DEFAULT_BASE = (
+    "docker.io/library/debian:bookworm-slim"
+    "@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241"
+)
+
+#: Where the pinned uv binary is copied from. Manifest-list digest, so the
+#: text is architecture-independent while each build gets its own arch.
+UV_IMAGE = (
+    "ghcr.io/astral-sh/uv:0.12.5"
+    "@sha256:e85be844203885286c60ffad8a858d48afb6c5a5c237ca0e67f12e74b8f174b1"
+)
+
+#: Where the pinned interpreter is installed inside the image.
+PYTHON_INSTALL_DIR = "/opt/python"
+
+#: The closed key set. Closed because every key is hashed into identity —
+#: a key that did nothing would still move ``env_version``, and one that
+#: did something unhashed would be an identity hole.
+_KEYS = ("base", "apt-install", "run-commands", "env")
+
+
+@dataclass(frozen=True)
+class Declaration:
+    """A parsed ``[tool.lightcone.image]`` table, defaults resolved."""
+
+    #: The digest-pinned base reference — declared, or :data:`DEFAULT_BASE`.
+    base: str
+    apt_install: tuple[str, ...]
+    run_commands: tuple[str, ...]
+    env: tuple[tuple[str, str], ...]
+
+
+def declaration(root: Path) -> Declaration | None:
+    """Read the project's system-layer declaration.
+
+    Args:
+        root: The project root.
+
+    Returns:
+        The parsed declaration, or ``None`` for a direct-mode project.
+
+    Raises:
+        ProjectError: If the table carries an unknown key, a wrong type,
+            or a ``base`` that is not digest-pinned. Raised at parse time
+            so the refusal fires on every verb that reads identity, not
+            just at build time.
+    """
+    table = _table(root)
+    if table is None:
+        return None
+    if unknown := sorted(set(table) - set(_KEYS)):
+        raise ProjectError(
+            f"[tool.lightcone.image] has no key `{unknown[0]}` — the surface is "
+            f"{', '.join(f'`{k}`' for k in _KEYS)}, and every key is part of the "
+            "environment's identity, so nothing unrecognised can be carried along."
+        )
+    base = table.get("base", DEFAULT_BASE)
+    if not isinstance(base, str) or not base:
+        raise ProjectError("[tool.lightcone.image] `base` must be an image reference string.")
+    if "@sha256:" not in base:
+        raise ProjectError(
+            f"[tool.lightcone.image] `base` is not digest-pinned: `{base}`. A tag can "
+            "move under the project, so the image would stop being a pure function of "
+            "the repository. Pin it: `base = \"<ref>@sha256:<digest>\"` "
+            "(find the digest with `podman image inspect` after a pull)."
+        )
+    return Declaration(
+        base=base,
+        apt_install=tuple(sorted(_strings(table, "apt-install"))),
+        run_commands=tuple(_strings(table, "run-commands")),
+        env=tuple(sorted(_env(table).items())),
+    )
+
+
+def identity_document(root: Path) -> str | None:
+    """Build the canonical JSON that is the image's identity.
+
+    The resolved declaration plus the generator's pinned inputs. Every
+    key is emitted whether or not the project set it — the
+    install-settings discipline: a project relying on a default and one
+    spelling it out are the same environment only until the default
+    changes. The interpreter pin is deliberately absent: its raw bytes
+    are already a frame of ``env_version``, and the rendered
+    Containerfile carries it into the tag.
+
+    Args:
+        root: The project root.
+
+    Returns:
+        The document, or ``None`` for a direct-mode project.
+    """
+    declared = declaration(root)
+    if declared is None:
+        return None
+    return json.dumps(
+        {
+            "apt": list(declared.apt_install),
+            "base": declared.base,
+            "env": dict(declared.env),
+            "run": list(declared.run_commands),
+            "uv": UV_IMAGE,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def containerfile(root: Path) -> str:
+    """Render the Containerfile for this project's system layer.
+
+    Generated and transient — it exists only inside a build context and
+    is never written into the project. The layering is fixed here, never
+    user-ordered: base, contract checks, apt, the pinned uv, the pinned
+    interpreter, then the declared ``env`` and ``run-commands``. The
+    contract checks turn a base that cannot work into a pointed refusal
+    (via their reserved exit codes) instead of a downstream mystery.
+
+    Args:
+        root: The project root, which must be containerized.
+
+    Returns:
+        The Containerfile text.
+
+    Raises:
+        ProjectError: If the project is direct-mode, the declaration is
+            invalid, or ``.python-version`` is missing.
+    """
+    declared = declaration(root)
+    if declared is None:
+        raise ProjectError(f"{root} declares no [tool.lightcone.image] — nothing to build.")
+    pin = root / ".python-version"
+    if not pin.is_file():
+        raise ProjectError(
+            f"{root}: no .python-version — the image bakes the exact interpreter, "
+            "so the pin is an input to it; run `lc init` to scaffold one."
+        )
+
+    lines = [
+        f"FROM {declared.base}",
+        # The contract checks, each a reserved exit code the builder maps
+        # to a refusal naming the base: 43 musl, 44 no bash, 45 no apt.
+        "RUN if ldd --version 2>&1 | grep -qi musl; then exit 43; fi",
+        "RUN command -v bash >/dev/null || exit 44",
+    ]
+    if declared.apt_install:
+        lines += [
+            "RUN command -v apt-get >/dev/null || exit 45",
+            "RUN apt-get update && apt-get install -y --no-install-recommends "
+            + " ".join(declared.apt_install)
+            + " && rm -rf /var/lib/apt/lists/*",
+        ]
+    lines += [
+        f"COPY --from={UV_IMAGE} /uv /usr/local/bin/uv",
+        # The chmod rides in the same layer as the install: rootless uid
+        # mapping runs as an arbitrary user, so everything lc bakes must
+        # be world-readable — and a chmod layer of its own would
+        # copy-on-write every byte it touches, doubling the interpreter
+        # in every archive.
+        f"RUN UV_PYTHON_INSTALL_DIR={PYTHON_INSTALL_DIR} uv python install "
+        + pin.read_text().strip()
+        + " && chmod -R a+rX /opt",
+    ]
+    lines += [f"ENV {key}={_quoted(value)}" for key, value in declared.env]
+    lines += [f"RUN {command}" for command in declared.run_commands]
+    if declared.run_commands:
+        # Only when the user's own layers exist: whatever they put in
+        # /opt needs the same readability, at the price of re-copying it.
+        lines.append("RUN chmod -R a+rX /opt")
+    lines += [
+        # Set after `uv python install`, which needs the download the
+        # final environment then forbids. `never` makes a missing
+        # interpreter a loud error at run time instead of a silent fetch.
+        f"ENV UV_PYTHON_INSTALL_DIR={PYTHON_INSTALL_DIR} UV_PYTHON_DOWNLOADS=never",
+        f"LABEL io.lightcone.image={_quoted(identity_document(root) or '')}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def tag(root: Path) -> str:
+    """Derive the image tag from everything that goes into the image.
+
+    The rendered Containerfile *and* the identity document, framed as a
+    JSON list so a boundary between them cannot shift. The render is an
+    input so a generator change rebuilds; the document alone is what
+    ``env_version`` sees.
+
+    Args:
+        root: The project root, which must be containerized.
+
+    Returns:
+        ``lc-env-<16 hex>``.
+    """
+    framed = json.dumps([containerfile(root), identity_document(root)])
+    return "lc-env-" + hashlib.sha256(framed.encode()).hexdigest()[:16]
+
+
+def archive_path(root: Path, image_tag: str) -> Path:
+    """Locate the committed image archive for *image_tag*.
+
+    The one spelling of where an image lives in the dataset — the same
+    layout ``datalad containers-add`` uses, so the archive is versioned
+    project state that travels through the annex.
+
+    Args:
+        root: The project root.
+        image_tag: The image tag, from :func:`tag`.
+
+    Returns:
+        ``<root>/.datalad/environments/<tag>/image``.
+    """
+    return root / ".datalad" / "environments" / image_tag / "image"
+
+
+def _table(root: Path) -> dict[str, Any] | None:
+    """The raw ``[tool.lightcone.image]`` table, or ``None`` if absent.
+
+    Read from ``pyproject.toml`` only — never through the uv-config
+    reader, whose "a ``uv.toml`` replaces ``[tool.uv]``" rule is about
+    uv's own settings and must not reach this table.
+    """
+    path = root / "pyproject.toml"
+    if not path.is_file():
+        return None
+    try:
+        parsed = tomllib.loads(path.read_text())
+    except tomllib.TOMLDecodeError as e:
+        raise ProjectError(f"{path}: invalid TOML: {e}") from e
+    table = parsed.get("tool", {}).get("lightcone", {}).get("image")
+    if table is None:
+        return None
+    if not isinstance(table, dict):
+        raise ProjectError("[tool.lightcone.image] must be a table.")
+    return table
+
+
+def _strings(table: dict[str, Any], key: str) -> list[str]:
+    """A list-of-strings key, defaulting empty."""
+    value = table.get(key, [])
+    if not isinstance(value, list) or not all(isinstance(v, str) and v for v in value):
+        raise ProjectError(f"[tool.lightcone.image] `{key}` must be a list of strings.")
+    return value
+
+
+def _env(table: dict[str, Any]) -> dict[str, str]:
+    """The ``env`` key, defaulting empty."""
+    value = table.get("env", {})
+    if not isinstance(value, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in value.items()
+    ):
+        raise ProjectError("[tool.lightcone.image] `env` must be a table of strings.")
+    return value
+
+
+def _quoted(value: str) -> str:
+    """Quote a value for a Containerfile ``ENV``/``LABEL`` line."""
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'

--- a/src/lightcone/engine/image.py
+++ b/src/lightcone/engine/image.py
@@ -137,8 +137,11 @@ def identity_document(root: Path) -> str | None:
         The document, or ``None`` for a direct-mode project.
     """
     declared = declaration(root)
-    if declared is None:
-        return None
+    return None if declared is None else _document(declared)
+
+
+def _document(declared: Declaration) -> str:
+    """*declared* as its canonical JSON."""
     return json.dumps(
         {
             "apt": list(declared.apt_install),
@@ -175,6 +178,11 @@ def containerfile(root: Path) -> str:
     declared = declaration(root)
     if declared is None:
         raise ProjectError(f"{root} declares no [tool.lightcone.image] — nothing to build.")
+    return _render(root, declared)
+
+
+def _render(root: Path, declared: Declaration) -> str:
+    """The Containerfile for *declared* — one parse, however it is reached."""
     pin = root / ".python-version"
     if not pin.is_file():
         raise ProjectError(
@@ -226,7 +234,7 @@ def containerfile(root: Path) -> str:
         # final environment then forbids. `never` makes a missing
         # interpreter a loud error at run time instead of a silent fetch.
         f"ENV UV_PYTHON_INSTALL_DIR={PYTHON_INSTALL_DIR} UV_PYTHON_DOWNLOADS=never",
-        f"LABEL io.lightcone.image={_quoted(identity_document(root) or '')}",
+        f"LABEL io.lightcone.image={_quoted(_document(declared))}",
     ]
     return "\n".join(lines) + "\n"
 
@@ -245,7 +253,10 @@ def tag(root: Path) -> str:
     Returns:
         ``lc-env-<16 hex>``.
     """
-    framed = json.dumps([containerfile(root), identity_document(root)])
+    declared = declaration(root)
+    if declared is None:
+        raise ProjectError(f"{root} declares no [tool.lightcone.image] — nothing to tag.")
+    framed = json.dumps([_render(root, declared), _document(declared)])
     return "lc-env-" + hashlib.sha256(framed.encode()).hexdigest()[:16]
 
 

--- a/src/lightcone/engine/image.py
+++ b/src/lightcone/engine/image.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -108,6 +109,8 @@ def declaration(root: Path) -> Declaration | None:
             "the repository. Pin it: `base = \"<ref>@sha256:<digest>\"` "
             "(find the digest with `podman image inspect` after a pull)."
         )
+    if re.search(r"\s", base):
+        raise ProjectError(f"[tool.lightcone.image] `base` is not an image reference: `{base}`.")
     return Declaration(
         base=base,
         apt_install=tuple(sorted(_strings(table, "apt-install"))),
@@ -178,6 +181,14 @@ def containerfile(root: Path) -> str:
             f"{root}: no .python-version — the image bakes the exact interpreter, "
             "so the pin is an input to it; run `lc init` to scaffold one."
         )
+    version = pin.read_text().strip()
+    # One version token: the pin splices into the install layer's RUN
+    # line, and a multi-line or annotated file would splice instructions.
+    if not re.match(r"^[A-Za-z0-9.+@-]+$", version):
+        raise ProjectError(
+            f"{root}/.python-version: `{version!r}` is not a single interpreter "
+            "version — the image bakes exactly one; run `lc init` to repin."
+        )
 
     lines = [
         f"FROM {declared.base}",
@@ -201,7 +212,7 @@ def containerfile(root: Path) -> str:
         # copy-on-write every byte it touches, doubling the interpreter
         # in every archive.
         f"RUN UV_PYTHON_INSTALL_DIR={PYTHON_INSTALL_DIR} uv python install "
-        + pin.read_text().strip()
+        + version
         + " && chmod -R a+rX /opt",
     ]
     lines += [f"ENV {key}={_quoted(value)}" for key, value in declared.env]
@@ -277,24 +288,73 @@ def _table(root: Path) -> dict[str, Any] | None:
     return table
 
 
+#: What an apt package name may contain (Debian source/package charset).
+#: Anything else is joined verbatim into a shell line by the apt layer,
+#: so the closed charset is what keeps `apt-install` a list of *names*
+#: rather than a second `run-commands`.
+_APT_NAME = re.compile(r"^[a-z0-9][a-z0-9.+-]*$")
+
+#: A shell-safe environment variable name. Anything else hits Docker's
+#: legacy `ENV key value` parse and silently defines the wrong variable.
+_ENV_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
 def _strings(table: dict[str, Any], key: str) -> list[str]:
-    """A list-of-strings key, defaulting empty."""
+    """A list-of-strings key, defaulting empty. No control characters:
+    every value here is interpolated into a Containerfile line, and a
+    newline would splice an instruction of its own into an
+    identity-hashed surface."""
     value = table.get(key, [])
     if not isinstance(value, list) or not all(isinstance(v, str) and v for v in value):
         raise ProjectError(f"[tool.lightcone.image] `{key}` must be a list of strings.")
+    for entry in value:
+        _plain(key, entry)
+    if key == "apt-install":
+        for name in value:
+            if not _APT_NAME.match(name):
+                raise ProjectError(
+                    f"[tool.lightcone.image] apt-install: `{name}` is not an apt "
+                    "package name — names are lowercase letters, digits, `.`, `+` "
+                    "and `-`. A command belongs in `run-commands`."
+                )
     return value
 
 
 def _env(table: dict[str, Any]) -> dict[str, str]:
-    """The ``env`` key, defaulting empty."""
+    """The ``env`` key, defaulting empty. Keys must be shell-safe names
+    and values control-character-free, for the reason `_strings` gives."""
     value = table.get("env", {})
     if not isinstance(value, dict) or not all(
         isinstance(k, str) and isinstance(v, str) for k, v in value.items()
     ):
         raise ProjectError("[tool.lightcone.image] `env` must be a table of strings.")
+    for key, entry in value.items():
+        if not _ENV_KEY.match(key):
+            raise ProjectError(
+                f"[tool.lightcone.image] env: `{key}` is not an environment "
+                "variable name (letters, digits and `_`, not starting with a digit)."
+            )
+        _plain("env", entry)
     return value
 
 
+def _plain(key: str, value: str) -> None:
+    """Refuse control characters in a value bound for a Containerfile line."""
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
+        raise ProjectError(
+            f"[tool.lightcone.image] `{key}` values cannot contain control "
+            "characters — each renders into a single Containerfile line."
+        )
+
+
 def _quoted(value: str) -> str:
-    """Quote a value for a Containerfile ``ENV``/``LABEL`` line."""
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    """Quote a value for a Containerfile ``ENV``/``LABEL`` line.
+
+    ``$`` is escaped along with the quoting characters, because these
+    lines undergo build-time variable expansion — measured: an unescaped
+    ``cost$5`` bakes as ``cost``, and a ``$`` inside the identity LABEL
+    silently corrupts the document the image carries. Declared ``env``
+    values are therefore *literals*, never expansions.
+    """
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$")
+    return f'"{escaped}"'

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -191,7 +191,8 @@ def _classified(
         report.warnings.append(
             "reported as out of date because their content is not in this "
             f"clone, not because they changed: {', '.join(sorted(unfetched))}. "
-            "Fetch with `git annex get <path>`."
+            "`lc materialize` fetches declared inputs before it decides "
+            "anything, so there this resolves itself."
         )
     return classified
 
@@ -427,6 +428,7 @@ def materialize(
     graph, env_version = _graph(root, targets, report)
     if not graph.tasks:
         return report
+    _fetch_inputs(root, graph, report)
     # Materialize is one of the two verbs allowed to build the image (the
     # other is `lc build`); the probe and the rerun entry point only find
     # one. Resolved once, then handed to every task — the HEAD discipline.
@@ -595,6 +597,41 @@ def cluster_for_run() -> Iterator[Scheduler]:
     ) as cluster:
         with Client(cluster) as client:  # type: ignore[no-untyped-call]
             yield _Dask(client)
+
+
+def _fetch_inputs(root: Path, graph: Graph, report: MaterializeReport) -> None:
+    """Bring declared inputs' bytes into this clone before anything hashes.
+
+    lc fetches rather than telling anyone to — the storage invariant —
+    and only here: ``--check`` and ``status`` are read-only verbs that
+    must not start network transfers, so there an unfetched input stays a
+    reported fact. In-tree inputs only, because an absolute input outside
+    the repository has no annex to fetch it from (the recorded weaker
+    promise). Unconditional rather than probed: ``git annex get`` on
+    content already present is a fast no-op, and one batch invocation
+    beats a detection walk.
+
+    A failed fetch is a *warning*, never a refusal: independent tasks
+    still run, and the task whose input is genuinely unreachable reports
+    its own failure with the real error — per-task reporting is most of
+    what owning the loop buys.
+    """
+    declared = sorted(
+        {
+            plan.declared_path(root, path)
+            for task in graph.tasks.values()
+            for name, path in task.inputs.items()
+            if name not in task.produced_by and root in path.parents
+        }
+    )
+    if not declared:
+        return
+    got = project._run(["git", "annex", "get", "--", *declared], cwd=root)
+    if got.returncode != 0:
+        report.warnings.append(
+            "some declared inputs could not be fetched into this clone — tasks "
+            f"needing them will report it:\n{got.stderr.strip()}"
+        )
 
 
 # =============================================================================

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -344,9 +344,9 @@ def status(root: Path) -> StatusReport:
     report = MaterializeReport()
     result = StatusReport()
     result.mode = project.mode(root)
-    state, tag = container.image_state(root)
+    state, tag, archive = container.image_state(root)
     if state != "direct":
-        result.image = {"tag": tag, "state": state}
+        result.image = {"tag": tag, "state": state, "archive": archive}
     result.sandbox = _sandbox_line(result.mode)
     for key, verdict, manifest in _classified(root, [], report, refresh=False):
         result.outputs.append(
@@ -363,7 +363,13 @@ def status(root: Path) -> StatusReport:
 
 
 def _sandbox_line(mode: str) -> str:
-    """One line naming the enforcement a run on this host would get."""
+    """One line naming the enforcement a run on this host would get.
+
+    The prose restates each backend's constant attestation, because
+    `Backend.attest` needs a built policy and a status header must not
+    build one. Keep it in step with the `attest` implementations — the
+    manifests, which record the real thing, are always authoritative.
+    """
     if mode == "containerized":
         if runtime := container.runtime_hint():
             return f"{runtime} (fs: declared, network: denied)"
@@ -427,11 +433,8 @@ def materialize(
     runtime = container.runtime_for_run(root, build=True)
     # Converge the environment: workers pass `--no-sync`, so this is the
     # only place on a run's path where it is made to match the lock. (A
-    # rerun does not come through here; its entry point syncs.)
-    synced = (
-        project.sync(root) if runtime.mode == "direct" else container.sync(root, runtime)
-    )
-    report.warnings.extend(f"uv: {w}" for w in synced)
+    # rerun does not come through here; its entry point converges too.)
+    report.warnings.extend(f"uv: {w}" for w in container.converge(runtime))
 
     dsid = dataset.dataset_id(root)
     # Read once, for every task: the driver commits each output as it lands,

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -41,7 +41,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
-from lightcone.engine import assets, dataset, identity, plan, project, worker
+from lightcone.engine import assets, container, dataset, identity, plan, project, worker
 from lightcone.engine.plan import Graph, Key, Task
 from lightcone.engine.project import ProjectError
 
@@ -287,6 +287,17 @@ class StatusReport:
     outputs: list[OutputStatus] = field(default_factory=list)
     #: The lock scan's prose, and inputs this clone has not fetched.
     warnings: list[str] = field(default_factory=list)
+    #: The three header facts nothing else surfaces: which world this
+    #: project executes in, where its image stands, and what would
+    #: enforce a run on this host. This is where the denial note and the
+    #: runtime-missing refusal point.
+    mode: str = "direct"
+    #: ``{tag, state}`` for a containerized project; ``None`` in direct
+    #: mode. ``state`` is repository fact only — ``present``, ``absent``
+    #: or ``unfetched`` — so status needs no runtime and no network.
+    image: dict[str, str] | None = None
+    #: One line naming the enforcement a run here would get.
+    sandbox: str = ""
 
     @property
     def counts(self) -> dict[str, int]:
@@ -303,6 +314,9 @@ class StatusReport:
             The counts, then every output, then the warnings.
         """
         return {
+            "mode": self.mode,
+            "image": self.image,
+            "sandbox": self.sandbox,
             "counts": self.counts,
             "outputs": [output.as_dict() for output in self.outputs],
             "warnings": self.warnings,
@@ -329,6 +343,11 @@ def status(root: Path) -> StatusReport:
     """
     report = MaterializeReport()
     result = StatusReport()
+    result.mode = project.mode(root)
+    state, tag = container.image_state(root)
+    if state != "direct":
+        result.image = {"tag": tag, "state": state}
+    result.sandbox = _sandbox_line(result.mode)
     for key, verdict, manifest in _classified(root, [], report, refresh=False):
         result.outputs.append(
             OutputStatus(
@@ -341,6 +360,21 @@ def status(root: Path) -> StatusReport:
         )
     result.warnings = report.warnings
     return result
+
+
+def _sandbox_line(mode: str) -> str:
+    """One line naming the enforcement a run on this host would get."""
+    if mode == "containerized":
+        if runtime := container.runtime_hint():
+            return f"{runtime} (fs: declared, network: denied)"
+        return "no container runtime — install podman (or docker)"
+    from lightcone.engine import sandbox
+
+    found = sandbox.detect().capability
+    if found.kind == "none":
+        detail = f" — {found.detail}" if found.detail else ""
+        return f"none{detail}; runs record `fs: open`"
+    return f"{found.kind} (fs: declared, network: allowed)"
 
 
 # =============================================================================
@@ -373,13 +407,24 @@ def materialize(
     project.require_git()
     project.require_git_annex()
     dataset.require_committer(root)
-    # Before anything else: workers pass `--no-sync`, so this is the only
-    # place on a run's path where the environment is made to match the
-    # lock. (A rerun does not come through here; its entry point syncs.)
     report = MaterializeReport()
-    report.warnings.extend(f"uv: {w}" for w in project.sync(root))
+    # The dirty check comes before anything that writes: the image
+    # converge below *commits*, and `dataset.save` stages scoped but
+    # commits the whole index — on a dirty tree the user's staged edits
+    # would be swept into the image commit.
     if changes := dataset.status(root):
         raise ProjectError(_dirty(root, changes))
+    # Materialize is one of the two verbs allowed to build the image (the
+    # other is `lc build`); the probe and the rerun entry point only find
+    # one. Resolved once, then handed to every task — the HEAD discipline.
+    runtime = container.runtime_for_run(root, build=True)
+    # Converge the environment: workers pass `--no-sync`, so this is the
+    # only place on a run's path where it is made to match the lock. (A
+    # rerun does not come through here; its entry point syncs.)
+    synced = (
+        project.sync(root) if runtime.mode == "direct" else container.sync(root, runtime)
+    )
+    report.warnings.extend(f"uv: {w}" for w in synced)
 
     graph, env_version = _graph(root, targets, report)
     if not graph.tasks:
@@ -412,11 +457,12 @@ def materialize(
                     head,
                     versions,
                     refresh,
+                    runtime,
                     *[pending[dep] for dep in task.depends_on],
                     key=_name(key),
                 )
             for result in scheduler.completed(list(pending.values())):
-                _consume(root, graph.tasks[result.key], result, dsid, report)
+                _consume(root, graph.tasks[result.key], result, dsid, runtime, report)
                 outstanding.pop(result.key, None)
     finally:
         # Whatever never reported — an interrupt, a dead cluster — left a
@@ -429,7 +475,12 @@ def materialize(
 
 
 def _consume(
-    root: Path, task: Task, result: worker.TaskResult, dsid: str, report: MaterializeReport
+    root: Path,
+    task: Task,
+    result: worker.TaskResult,
+    dsid: str,
+    runtime: container.Runtime,
+    report: MaterializeReport,
 ) -> None:
     """Record one finished task, and commit or undo what it left on disk."""
     name = _name(task.key)
@@ -440,7 +491,7 @@ def _consume(
         report.notes.extend([f"{name}:", *lines])
 
     if result.status == "ok":
-        dataset.save(root, [task.output_dir], run_record(root, task, dsid))
+        dataset.save(root, [task.output_dir], run_record(root, task, dsid, runtime))
         report.made.append(name)
         return
 
@@ -545,7 +596,7 @@ def cluster_for_run() -> Iterator[Scheduler]:
 # =============================================================================
 
 
-def run_record(root: Path, task: Task, dsid: str) -> str:
+def run_record(root: Path, task: Task, dsid: str, runtime: container.Runtime) -> str:
     """Build the commit message for one materialized output.
 
     A ``[DATALAD RUNCMD]`` record — datalad's format, not ours, so all of
@@ -565,6 +616,13 @@ def run_record(root: Path, task: Task, dsid: str) -> str:
         root: The project root.
         task: The output that was made.
         dsid: The dataset's UUID, which ``rerun`` reads.
+        runtime: The run's execution world. A containerized run lists its
+            committed image archive under ``extra_inputs``, which
+            ``datalad rerun`` fetches before executing — so the worker
+            enters the exact bytes that made the output, on whatever
+            runtime the rerun host has. The ``cmd`` itself stays
+            runtime-neutral for the same reason: the worker is the
+            executor that resolves the container at rerun time.
 
     Returns:
         The full commit message, subject and record.
@@ -583,6 +641,8 @@ def run_record(root: Path, task: Task, dsid: str) -> str:
         "outputs": [plan.declared_path(root, task.output_dir)],
         "pwd": ".",
     }
+    if runtime.mode == "containerized":
+        info["extra_inputs"] = [runtime.archive]
     body = json.dumps(info, indent=1, sort_keys=True, ensure_ascii=False)
     return (
         f"[DATALAD RUNCMD] {task.output_id} [{task.universe_id}]\n\n"

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -414,6 +414,13 @@ def materialize(
     # would be swept into the image commit.
     if changes := dataset.status(root):
         raise ProjectError(_dirty(root, changes))
+    # The graph — and with it the spec validation and the lock scan —
+    # before the image: a refusal here must not cost a minutes-long
+    # build, and must not leave an archive commit behind a run that
+    # "failed" on a typo in the spec.
+    graph, env_version = _graph(root, targets, report)
+    if not graph.tasks:
+        return report
     # Materialize is one of the two verbs allowed to build the image (the
     # other is `lc build`); the probe and the rerun entry point only find
     # one. Resolved once, then handed to every task — the HEAD discipline.
@@ -425,10 +432,6 @@ def materialize(
         project.sync(root) if runtime.mode == "direct" else container.sync(root, runtime)
     )
     report.warnings.extend(f"uv: {w}" for w in synced)
-
-    graph, env_version = _graph(root, targets, report)
-    if not graph.tasks:
-        return report
 
     dsid = dataset.dataset_id(root)
     # Read once, for every task: the driver commits each output as it lands,

--- a/src/lightcone/engine/project.py
+++ b/src/lightcone/engine/project.py
@@ -7,11 +7,13 @@ import os
 import re
 import shutil
 import subprocess
+import tomllib
 import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import asdict, dataclass, field
 from functools import partial
 from pathlib import Path
+from typing import Literal
 
 from astra.scaffold import create_boilerplate
 
@@ -238,12 +240,20 @@ def converge(directory: Path, *, write: bool = True) -> ConvergenceReport:
         lambda: _uv(c, ["lock"], directory=directory),
         is_current=lambda: _lock_is_current(directory),
     )
-    c.item(
-        ".venv",
-        (directory / ".venv").exists(),
-        lambda: _uv(c, _SYNC_ARGS, directory=directory),
-        is_current=lambda: _env_is_current(directory),
-    )
+    # Locking is resolution and works on the bare host in both modes; a
+    # *sync* of a containerized project is the host-sync deadlock in
+    # miniature — the lock's system-level dependencies (the reason the
+    # project containerized at all) are not on the host, so the sync
+    # fails and `--check` would report unconverged forever. The
+    # environment converge in containerized mode belongs to the verbs,
+    # which run it inside the image.
+    if mode(directory) == "direct":
+        c.item(
+            ".venv",
+            (directory / ".venv").exists(),
+            lambda: _uv(c, _SYNC_ARGS, directory=directory),
+            is_current=lambda: _env_is_current(directory),
+        )
 
     return c.report
 
@@ -320,13 +330,16 @@ def uv_prefix(directory: Path, *, sync: bool) -> list[str]:
 
 
 def sync(directory: Path) -> list[str]:
-    """Make ``.venv`` match ``uv.lock``.
+    """Make the host ``.venv`` match ``uv.lock``. Direct mode's converge.
 
-    Both entry points that execute recipes call this before they start,
+    Both entry points that execute recipes converge before they start,
     rather than checking and refusing: workers pass ``--no-sync``, so
     nothing else would notice a lock edited without a sync, and a manifest
     recording an environment the recipe did not run under is the identity
-    model saying something untrue.
+    model saying something untrue. The containerized twin is
+    ``container.sync``, which runs the same uv command inside the image —
+    callers pick by :func:`mode`, because only they know whether an image
+    has been ensured.
 
     Args:
         directory: The project root.
@@ -475,6 +488,59 @@ def _can_ask_git(directory: Path) -> bool:
     return directory.is_dir() and _in_repository(directory)
 
 
+def mode(directory: Path) -> Literal["direct", "containerized"]:
+    """Read which execution world this project declares.
+
+    Derived, never configured: a ``[tool.lightcone.image]`` table in
+    ``pyproject.toml`` *is* the escalation to containerized mode, and
+    deleting it is the way back. Presence only — what the table means is
+    :mod:`~lightcone.engine.image`'s question, asked by the verbs that
+    consume it, so an invalid declaration refuses there with the line at
+    fault rather than here with none.
+
+    Args:
+        directory: The project root.
+
+    Returns:
+        ``"containerized"`` if the table is declared, else ``"direct"`` —
+        including for a directory with no ``pyproject.toml`` yet, which is
+        what lets convergence scaffold one.
+
+    Raises:
+        ProjectError: If ``pyproject.toml`` is not valid TOML.
+    """
+    path = directory / "pyproject.toml"
+    if not path.is_file():
+        return "direct"
+    try:
+        parsed = tomllib.loads(path.read_text())
+    except tomllib.TOMLDecodeError as e:
+        raise ProjectError(f"{path}: invalid TOML: {e}") from e
+    table = parsed.get("tool", {}).get("lightcone", {}).get("image")
+    return "direct" if table is None else "containerized"
+
+
+def env_dir(directory: Path) -> Path:
+    """Locate the project environment for this project's mode.
+
+    The one spelling of where the environment lives. Direct mode syncs
+    ``.venv`` on the host; containerized mode syncs ``.lightcone/venv``
+    *inside* the image, against the baked interpreter — so its symlinks
+    dangle on the host, deliberately, and the host ``.venv`` (if any) is
+    inert. Two directories, because sharing one means every sync flips it
+    between worlds and breaks whichever side is not looking.
+
+    Args:
+        directory: The project root.
+
+    Returns:
+        The environment prefix for the current mode.
+    """
+    if mode(directory) == "containerized":
+        return directory / ".lightcone" / "venv"
+    return directory / ".venv"
+
+
 def project_name(directory: Path) -> str:
     """Derive a project name from a directory name.
 
@@ -524,7 +590,10 @@ def current_project(directory: Path | None = None) -> Path:
 
     The question every verb that runs something asks, and the stronger of
     the two: a ``.venv`` that is not there is not something these callers
-    are going to create.
+    are going to create. In containerized mode the host ``.venv`` is
+    inert and never required — the environment those verbs enter is
+    ``.lightcone/venv``, which their own converge creates inside the
+    image, so only what the repository carries is asked for.
 
     Args:
         directory: Defaults to the working directory.
@@ -533,9 +602,12 @@ def current_project(directory: Path | None = None) -> Path:
         The resolved project root.
 
     Raises:
-        ProjectError: If any of the environment is absent.
+        ProjectError: If any of the required environment is absent.
     """
-    return _project_root(directory, _ENVIRONMENT_FILES)
+    resolved = (directory or Path.cwd()).resolve()
+    if mode(resolved) == "containerized":
+        return _project_root(resolved, _DECLARED_FILES)
+    return _project_root(resolved, _ENVIRONMENT_FILES)
 
 
 def _project_root(directory: Path | None, required: Sequence[str]) -> Path:

--- a/src/lightcone/engine/project.py
+++ b/src/lightcone/engine/project.py
@@ -7,7 +7,6 @@ import os
 import re
 import shutil
 import subprocess
-import tomllib
 import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import asdict, dataclass, field
@@ -509,15 +508,11 @@ def mode(directory: Path) -> Literal["direct", "containerized"]:
     Raises:
         ProjectError: If ``pyproject.toml`` is not valid TOML.
     """
-    path = directory / "pyproject.toml"
-    if not path.is_file():
-        return "direct"
-    try:
-        parsed = tomllib.loads(path.read_text())
-    except tomllib.TOMLDecodeError as e:
-        raise ProjectError(f"{path}: invalid TOML: {e}") from e
-    table = parsed.get("tool", {}).get("lightcone", {}).get("image")
-    return "direct" if table is None else "containerized"
+    # image.py is the table's one reader; imported lazily because it
+    # imports ProjectError from here.
+    from lightcone.engine import image
+
+    return "direct" if image._table(directory) is None else "containerized"
 
 
 def env_dir(directory: Path) -> Path:

--- a/src/lightcone/engine/run.py
+++ b/src/lightcone/engine/run.py
@@ -46,14 +46,12 @@ def probe(project: Path, command: Sequence[str]) -> sandbox.Outcome:
 
     runtime = container.runtime_for_run(project, build=False)
     if runtime.mode == "containerized":
+        # The probe's converge. Direct mode's is the syncing hop below —
+        # the deliberate exception to `container.converge`, because there
+        # the hop itself is what converges.
         container.sync(project, runtime)
 
-    built = sandbox.exec_policy(
-        project,
-        read_paths=input_paths(project, spec),
-        env_dir=runtime.env_dir,
-        containerized=runtime.mode == "containerized",
-    )
+    built = container.policy_for(runtime, input_paths(project, spec))
     with sandbox.scope(built) as policy:
         return sandbox.run(
             container.backend(runtime),

--- a/src/lightcone/engine/run.py
+++ b/src/lightcone/engine/run.py
@@ -18,12 +18,18 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
-from lightcone.engine import sandbox
+from lightcone.engine import container, sandbox
 from lightcone.engine.project import SPEC_FILENAME, child_env, require_uv, uv_prefix
 
 
 def probe(project: Path, command: Sequence[str]) -> sandbox.Outcome:
     """Run a command in the project environment, inside the boundary.
+
+    A containerized probe never builds the image — it finds one, or
+    refuses naming the exact ``lc build`` — and converges the in-image
+    environment before executing, which is the same promise the direct
+    probe makes through its syncing ``uv run`` hop: the environment a
+    probe describes is one it just converged.
 
     Args:
         project: The project root.
@@ -38,14 +44,26 @@ def probe(project: Path, command: Sequence[str]) -> sandbox.Outcome:
     require_uv()
     spec = read_spec(project)
 
-    built = sandbox.exec_policy(project, read_paths=input_paths(project, spec))
+    runtime = container.runtime_for_run(project, build=False)
+    if runtime.mode == "containerized":
+        container.sync(project, runtime)
+
+    built = sandbox.exec_policy(
+        project,
+        read_paths=input_paths(project, spec),
+        env_dir=runtime.env_dir,
+        containerized=runtime.mode == "containerized",
+    )
     with sandbox.scope(built) as policy:
         return sandbox.run(
-            sandbox.detect(),
+            container.backend(runtime),
             policy,
             list(command),
             cwd=project,
-            prefix=uv_prefix(project, sync=True),
+            # The direct hop converges; the containerized one must not —
+            # the converge above already did, and the exec runs with the
+            # network denied, where a sync cannot.
+            prefix=uv_prefix(project, sync=runtime.mode == "direct"),
             # Same reason as convergence: this uv invocation names its
             # project explicitly, so an environment activated elsewhere
             # is never what we mean — and uv says so, once per run, in

--- a/src/lightcone/engine/sandbox/boundary.py
+++ b/src/lightcone/engine/sandbox/boundary.py
@@ -45,6 +45,8 @@ class Unavailable:
     """
 
     capability: Capability = field(default_factory=lambda: Capability(kind="none"))
+    #: No mechanism, so nothing owns the prefix either.
+    contains_prefix: bool = False
 
     def wrap(self, policy: Policy, argv: Sequence[str]) -> list[str]:
         """Return *argv* unchanged — there is no mechanism to wrap with."""
@@ -143,15 +145,22 @@ def run(
         cwd: Where to run it.
         env: The environment for everything outside the rewrite. The
             policy's own overlay is applied inside it, not merged here.
-        prefix: Spawned *outside* the rewrite — how a caller says "wrap
-            the command, not this". Used for the ``uv run`` hop, since
-            uv's config and caches are trusted plumbing.
+        prefix: The ``uv run`` hop. For a host mechanism it is spawned
+            *outside* the rewrite — uv's config and caches are trusted
+            plumbing. For a backend that is itself a world
+            (``contains_prefix``), it goes *inside*: there is no trusted
+            host plumbing inside a container, and the env overlay is
+            that backend's to apply natively rather than through a
+            host-resolved ``env``.
 
     Returns:
         The exit code, what was actually enforced, and any lines the
         caller should print verbatim.
     """
-    wrapped = [*prefix, *backend.wrap(policy, [*env_argv(policy), *argv])]
+    if backend.contains_prefix:
+        wrapped = backend.wrap(policy, [*prefix, *argv])
+    else:
+        wrapped = [*prefix, *backend.wrap(policy, [*env_argv(policy), *argv])]
     attestation = backend.attest(policy)
     # `policy.env` is deliberately **not** merged here: it went inside
     # the wrap, above, via :func:`env_argv`. Everything *outside* the

--- a/src/lightcone/engine/sandbox/boundary.py
+++ b/src/lightcone/engine/sandbox/boundary.py
@@ -192,13 +192,25 @@ def run(
     # module eagerly, and the shim drags ctypes in for one integer.
     from lightcone._sandbox_exec import SETUP_FAILURE_EXIT
 
-    if returncode == SETUP_FAILURE_EXIT:
-        # The shim's reserved code: the sandbox could not be *built*. Say
-        # so plainly — the trailer would otherwise point the user at their
-        # own command's permissions for a failure that is entirely ours.
+    if returncode == SETUP_FAILURE_EXIT and attestation.mechanism == "landlock":
+        # The shim's reserved code — meaningful only where the shim ran:
+        # under any other mechanism a command legitimately exiting 97 is
+        # just a failed command, and blaming lc for it would misattribute
+        # at the one place nobody is watching. Say the real case plainly —
+        # the trailer would otherwise point the user at their own
+        # command's permissions for a failure that is entirely ours.
         notes.append(
             "lc could not set up the sandbox (see above) — this is an lc "
             "problem, not your command's"
+        )
+    elif returncode == 125 and backend.contains_prefix:
+        # The runtimes reserve 125 for their own failures (a bad flag, a
+        # vanished mount source): the command never ran, so the denial
+        # heuristics have nothing to say about it.
+        notes.append(
+            f"the container runtime failed before the command ran (see "
+            f"above, `{attestation.mechanism}` exit 125) — this is a "
+            "runtime problem, not your command's"
         )
     elif returncode != 0 and attestation.mechanism != "none":
         from lightcone.engine.sandbox import denial

--- a/src/lightcone/engine/sandbox/denial.py
+++ b/src/lightcone/engine/sandbox/denial.py
@@ -147,8 +147,15 @@ def _render_tool(path: Path) -> list[str]:
     return _message(
         f"cannot execute {path}",
         [
-            "  if this is a tool the command needs, declare it in the environment:",
+            "  if this is a Python tool, declare it in the environment:",
             f"      uv add <package providing {path.name}>",
+            "",
+            "  if this is a system tool, declare it in the system layer:",
+            "      [tool.lightcone.image]",
+            f'      apt-install = ["<apt package providing {path.name}>"]',
+            "    (apt package names — unsure? try: apt-cache search <name>)",
+            "    note: this containerizes the project — podman (or docker) required —",
+            "    and puts every materialized output behind.",
         ],
     )
 

--- a/src/lightcone/engine/sandbox/landlock.py
+++ b/src/lightcone/engine/sandbox/landlock.py
@@ -73,6 +73,8 @@ class LandlockBackend:
 
     capability: Capability = field(default_factory=capability)
     interpreter: str = sys.executable
+    #: The uv hop stays outside the wrap: trusted host plumbing.
+    contains_prefix: bool = False
 
     def wrap(self, policy: Policy, argv: Sequence[str]) -> list[str]:
         """Rewrite *argv* to run under the Landlock shim.

--- a/src/lightcone/engine/sandbox/model.py
+++ b/src/lightcone/engine/sandbox/model.py
@@ -75,7 +75,7 @@ class Policy:
 class Capability:
     """What enforcement this host can provide, as probed."""
 
-    kind: Literal["landlock", "seatbelt", "none"]
+    kind: Literal["landlock", "seatbelt", "podman", "docker", "none"]
     landlock_abi: int | None = None
     #: Why, when ``kind`` is ``none``. Reaches the user — a downgrade is
     #: never silent.
@@ -87,14 +87,15 @@ class Attestation:
     """The hermeticity record for one exec.
 
     Derived from the flags actually applied, never from the mechanism
-    matrix's expectations. ``network`` is ``allowed`` on every path here
-    by recorded decision: lc applies no network restriction, and saying
-    so is the honest value.
+    matrix's expectations. ``network`` is ``allowed`` wherever lc applied
+    no restriction — the direct-mode mechanisms — and ``denied`` only
+    where a flag actually denied it, which today is the OCI backend's
+    ``--network none``.
     """
 
-    mechanism: Literal["landlock", "seatbelt", "none"]
+    mechanism: Literal["landlock", "seatbelt", "podman", "docker", "none"]
     fs: Literal["declared", "open"]
-    network: Literal["allowed"] = "allowed"
+    network: Literal["allowed", "denied"] = "allowed"
     landlock_abi: int | None = None
     exec_allowlist_version: int | None = None
 
@@ -107,6 +108,20 @@ class Backend(Protocol):
     path below it stay mechanism-blind, and what makes a backend
     testable on a host that cannot run it.
     """
+
+    @property
+    def contains_prefix(self) -> bool:
+        """Whether the wrap owns the whole command line, prefix included.
+
+        A host mechanism restricts the command and leaves the ``uv run``
+        hop outside as trusted host plumbing; a backend that is itself a
+        *world* (a container) has no trusted host plumbing inside it —
+        uv is part of what is being entered — so the seam hands it the
+        prefix too, and the env overlay becomes the backend's to apply
+        natively. Declared on every backend rather than defaulted at the
+        call site, so a new mechanism must answer the question.
+        """
+        ...
 
     @property
     def capability(self) -> Capability:

--- a/src/lightcone/engine/sandbox/oci.py
+++ b/src/lightcone/engine/sandbox/oci.py
@@ -1,0 +1,106 @@
+"""The containerized backend: the mount table is the mechanism.
+
+One backend for podman and docker, data-parameterized — the two differ
+in spellings (how the invoking uid is kept, whether pulling must be
+forbidden), not in shape. The policy's path sets map one-to-one onto
+mounts: ``read`` becomes ``:ro``, ``write`` becomes ``:rw``, and the
+image itself is the OS baseline and the exec set — everything present in
+it was declared, which is why the containerized policy carries no
+baseline and no exec tier to translate.
+
+Unlike the host mechanisms, this wrap owns the whole command line
+(``contains_prefix``): the ``uv run`` hop executes *inside* the world
+being entered, and the env overlay is applied through the runtime's own
+``--env`` rather than a host-resolved ``env`` binary — whose path (NixOS
+keeps it under ``/run/current-system/sw``) need not exist in the image.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from lightcone.engine.sandbox.boundary import SANDBOX_ENV
+from lightcone.engine.sandbox.model import Attestation, Capability, Policy
+
+
+@dataclass(frozen=True)
+class OCIBackend:
+    """A container runtime, expressed as an argv rewrite."""
+
+    #: ``podman`` or ``docker`` — also what the attestation names.
+    runtime: Literal["podman", "docker"]
+    #: The image id (bare hex). Execution pins on the id, never a tag, so
+    #: a retagged image in the local store can never substitute.
+    image_id: str
+    #: The project root — the container's working directory.
+    root: Path
+    #: How this runtime keeps mount writes owned by the invoking user,
+    #: resolved by the caller so the wrap stays a pure function of its
+    #: fields (``--userns=keep-id`` / ``--user uid:gid``).
+    user_flags: tuple[str, ...] = ()
+    contains_prefix: bool = True
+
+    @property
+    def capability(self) -> Capability:
+        """What this backend enforces with, named by the runtime."""
+        return Capability(kind=self.runtime)
+
+    def wrap(self, policy: Policy, argv: Sequence[str]) -> list[str]:
+        """Rewrite *argv* into a container invocation of itself.
+
+        Pure: no temporary files, no file descriptors, no global state.
+        Read roots mount ``:ro`` before write roots mount ``:rw``, so a
+        writable directory nested in a read-only tree lands in the order
+        the runtimes resolve natively. ``/tmp`` is a fresh tmpfs (the
+        policy's ``tmp_home`` is a bind inside it), ``/dev/shm`` gets a
+        real size because the 64 MB default is a scientific-workload
+        footgun, and the environment is an allowlist — the policy's
+        overlay as ``--env``, never the ambient environment.
+
+        Args:
+            policy: What the command may touch, as mounts.
+            argv: The command, run prefix included.
+
+        Returns:
+            The rewritten command.
+        """
+        mounts = [f"--volume={path}:{path}:ro" for path in policy.read]
+        mounts += [f"--volume={path}:{path}:rw" for path in policy.write]
+        overlay = [f"--env={k}={v}" for k, v in sorted(policy.env.items())]
+        return [
+            self.runtime, "run", "--rm",
+            "--network", "none",
+            "--entrypoint", "",
+            *self.user_flags,
+            *mounts,
+            "--tmpfs", "/tmp:rw,exec",
+            "--shm-size", "1g",
+            "--workdir", str(self.root),
+            *overlay,
+            f"--env={SANDBOX_ENV}={self.runtime}",
+            self.image_id,
+            *argv,
+        ]  # fmt: skip
+
+    def attest(self, policy: Policy) -> Attestation:
+        """Report what the wrapped command will actually have enforced.
+
+        Every value is a flag in :meth:`wrap`'s output: the mounts bound
+        the filesystem to the declared set, and ``--network none`` is a
+        real denial — the one place in the codebase that honestly says
+        ``denied`` (loopback stays intact, which is the meaning of it).
+
+        Args:
+            policy: The policy being wrapped.
+
+        Returns:
+            The record written with every output.
+        """
+        return Attestation(
+            mechanism=self.runtime,
+            fs="declared",
+            network="denied",
+        )

--- a/src/lightcone/engine/sandbox/oci.py
+++ b/src/lightcone/engine/sandbox/oci.py
@@ -67,13 +67,31 @@ class OCIBackend:
         Returns:
             The rewritten command.
         """
-        mounts = [f"--volume={path}:{path}:ro" for path in policy.read]
-        mounts += [f"--volume={path}:{path}:rw" for path in policy.write]
+        # Resolved source, declared destination: the host bind must name
+        # the real file, while the recipe addresses the path the analysis
+        # declared — a symlinked `/data` input mounted at its target
+        # would leave the container with no `/data` at all. Residue,
+        # recorded: a declared input living under `/tmp` is shadowed by
+        # the tmpfs on runtimes that mount over it — the same class of
+        # host-layout collision `_write_roots` documents for direct mode.
+        mounts = [f"--volume={path.resolve()}:{path}:ro" for path in policy.read]
+        mounts += [f"--volume={path.resolve()}:{path}:rw" for path in policy.write]
         overlay = [f"--env={k}={v}" for k, v in sorted(policy.env.items())]
         return [
             self.runtime, "run", "--rm",
             "--network", "none",
             "--entrypoint", "",
+            # The rootfs is read-only so a write outside the declared set
+            # is a loud denial rather than bytes vanishing with the
+            # container — without this, `mkdir /output` *succeeds* into
+            # the ephemeral layer and the run attests `fs: declared`
+            # over silently lost output.
+            "--read-only",
+            # SELinux hosts (Fedora/RHEL, podman's home turf) would
+            # otherwise refuse every bind read from container_t. Label
+            # separation is disabled rather than relabeling (`:z`), which
+            # would rewrite the user's own file contexts on disk.
+            "--security-opt", "label=disable",
             *self.user_flags,
             *mounts,
             "--tmpfs", "/tmp:rw,exec",
@@ -88,10 +106,11 @@ class OCIBackend:
     def attest(self, policy: Policy) -> Attestation:
         """Report what the wrapped command will actually have enforced.
 
-        Every value is a flag in :meth:`wrap`'s output: the mounts bound
-        the filesystem to the declared set, and ``--network none`` is a
-        real denial — the one place in the codebase that honestly says
-        ``denied`` (loopback stays intact, which is the meaning of it).
+        Every value is a flag in :meth:`wrap`'s output: the mounts plus
+        the read-only rootfs bound the filesystem to the declared set,
+        and ``--network none`` is a real denial — the one place in the
+        codebase that honestly says ``denied`` (loopback stays intact,
+        which is the meaning of it).
 
         Args:
             policy: The policy being wrapped.

--- a/src/lightcone/engine/sandbox/policy.py
+++ b/src/lightcone/engine/sandbox/policy.py
@@ -54,6 +54,11 @@ EXEC_ALLOWLIST: tuple[str, ...] = (
 #: profile is listed too or nothing but `/bin/sh` ever resolves there.
 _UTILITY_PATH = "/usr/local/bin:/usr/bin:/bin:/run/current-system/sw/bin"
 
+#: The ``PATH`` tail inside a containerized exec. The image's own FHS —
+#: never :data:`_UTILITY_PATH`, whose NixOS entry names a directory no
+#: Debian-family image has.
+_IMAGE_PATH = "/usr/local/bin:/usr/bin:/bin"
+
 
 def utility(name: str) -> Path | None:
     """Resolve an allowlisted tool from the fixed search path.
@@ -169,7 +174,13 @@ _HOME_LAYOUT = {
 }
 
 
-def exec_policy(project: Path, *, read_paths: Sequence[Path] = ()) -> Policy:
+def exec_policy(
+    project: Path,
+    *,
+    read_paths: Sequence[Path] = (),
+    env_dir: Path | None = None,
+    containerized: bool = False,
+) -> Policy:
     """Build what a sandboxed command may touch.
 
     The tree is read-only apart from ``results/``, so ``lc run`` and a
@@ -183,9 +194,19 @@ def exec_policy(project: Path, *, read_paths: Sequence[Path] = ()) -> Policy:
     leaves a manifest that is self-consistent and wrong, which no checksum
     can see.
 
+    The containerized shape is the same policy with the host stripped
+    out: the *image* is the OS baseline and the exec set — everything
+    present in it was declared — so the path sets carry only the project
+    world, which is exactly what the OCI backend turns into mounts. One
+    builder for both, so a probe still gets what a recipe gets per mode.
+
     Args:
         project: The project root, granted read.
         read_paths: Declared inputs outside the tree.
+        env_dir: The project environment prefix; defaults to the host
+            ``.venv``.
+        containerized: Build the mount-shaped policy instead of the host
+            one.
 
     Returns:
         The policy. ``results/`` is granted only if it exists — a policy
@@ -193,11 +214,30 @@ def exec_policy(project: Path, *, read_paths: Sequence[Path] = ()) -> Policy:
         the caller owns removing it (see
         :func:`~lightcone.engine.sandbox.boundary.scope`).
     """
-    tmp_home = Path(tempfile.mkdtemp(prefix="lc-home-")).resolve()
+    env_dir = env_dir if env_dir is not None else project / ".venv"
+    # The containerized HOME lives under the project's own (gitignored)
+    # `.lightcone/`, not the system temp dir: it is a mount source, and
+    # on macOS the podman machine shares the project's tree while the
+    # host's /var/folders temp roots arrive empty.
+    if containerized:
+        parent = project / ".lightcone"
+        parent.mkdir(parents=True, exist_ok=True)
+        tmp_home = Path(tempfile.mkdtemp(prefix="lc-home-", dir=parent)).resolve()
+    else:
+        tmp_home = Path(tempfile.mkdtemp(prefix="lc-home-")).resolve()
     for sub in _HOME_LAYOUT.values():
         (tmp_home / sub).mkdir(parents=True, exist_ok=True)
 
-    python = _venv_python(project)
+    if containerized:
+        return Policy(
+            read=_existing([project, *read_paths]),
+            write=_existing([tmp_home, project / "results"]),
+            execute=(),
+            tmp_home=tmp_home,
+            env=home_overlay(tmp_home, env_dir, containerized=True),
+        )
+
+    python = _venv_python(env_dir)
     # EXECUTE on the interpreter *file*; READ on the install root beside
     # it, for the stdlib. See :func:`_venv_python` and :func:`_stdlib_root`.
     stdlib = _stdlib_root(python)
@@ -207,9 +247,9 @@ def exec_policy(project: Path, *, read_paths: Sequence[Path] = ()) -> Policy:
     return Policy(
         read=read,
         write=write,
-        execute=_existing(_exec_set(project, python)),
+        execute=_existing(_exec_set(env_dir, python)),
         tmp_home=tmp_home,
-        env=home_overlay(tmp_home, project),
+        env=home_overlay(tmp_home, env_dir),
     )
 
 
@@ -229,7 +269,7 @@ def _write_roots(project: Path) -> list[Path]:
     return [root for root in roots if not resolved.is_relative_to(root)]
 
 
-def home_overlay(tmp_home: Path, project: Path) -> dict[str, str]:
+def home_overlay(tmp_home: Path, env_dir: Path, *, containerized: bool = False) -> dict[str, str]:
     """Point ``HOME`` and friends at a fresh private directory.
 
     The real ``$HOME`` is neither readable nor writable inside the
@@ -245,12 +285,16 @@ def home_overlay(tmp_home: Path, project: Path) -> dict[str, str]:
 
     Args:
         tmp_home: The per-run directory to point at.
-        project: The project, whose ``.venv/bin`` fronts ``PATH``.
+        env_dir: The project environment whose ``bin`` fronts ``PATH``.
+        containerized: Use the image's own FHS as the ``PATH`` tail
+            rather than the host allowlist search path, and pin uv to the
+            in-image environment — the ``uv run`` hop executes inside the
+            container, and this is how it finds ``.lightcone/venv``.
 
     Returns:
         The environment overlay the boundary applies inside the wrap.
     """
-    return {
+    overlay = {
         "HOME": str(tmp_home),
         # The search path *is* the exec set. Without this the command
         # resolves tools through the host's ambient PATH while the policy
@@ -258,20 +302,25 @@ def home_overlay(tmp_home: Path, project: Path) -> dict[str, str]:
         # whose PATH fronts another copy (homebrew's bash on macOS, say)
         # the sandbox denies `bash` itself, and the message blames the
         # user's command for lc's own incoherence.
-        "PATH": os.pathsep.join([str(project / ".venv" / "bin"), _UTILITY_PATH]),
+        "PATH": os.pathsep.join(
+            [str(env_dir / "bin"), _IMAGE_PATH if containerized else _UTILITY_PATH]
+        ),
         **{k: str(tmp_home / v) for k, v in _HOME_LAYOUT.items()},
     }
+    if containerized:
+        overlay["UV_PROJECT_ENVIRONMENT"] = str(env_dir)
+    return overlay
 
 
-def _venv_python(project: Path) -> Path | None:
+def _venv_python(env_dir: Path) -> Path | None:
     """The realpath of the venv's interpreter, if there is one.
 
-    Resolved, because ``.venv/bin/python`` is a symlink and Landlock
-    evaluates the target. What gets granted on it is
-    :func:`_exec_set`'s decision, and its install root is separately a
-    read root (:func:`exec_policy`) for the standard library beside it.
+    Resolved, because ``bin/python`` is a symlink and Landlock evaluates
+    the target. What gets granted on it is :func:`_exec_set`'s decision,
+    and its install root is separately a read root (:func:`exec_policy`)
+    for the standard library beside it.
     """
-    python = project / ".venv" / "bin" / "python"
+    python = env_dir / "bin" / "python"
     return python.resolve() if python.exists() else None
 
 
@@ -297,7 +346,7 @@ def _stdlib_root(python: Path | None) -> list[Path]:
     return [] if Path.home().resolve().is_relative_to(root) else [root]
 
 
-def _exec_set(project: Path, python: Path | None) -> list[Path]:
+def _exec_set(env_dir: Path, python: Path | None) -> list[Path]:
     """The two exec tiers: the environment, and the utility allowlist.
 
     Grants are per *file* for the utilities, never per directory:
@@ -318,7 +367,7 @@ def _exec_set(project: Path, python: Path | None) -> list[Path]:
     runnable and silently outrank this whole allowlist.
     """
     paths: list[Path] = []
-    bin_dir = project / ".venv" / "bin"
+    bin_dir = env_dir / "bin"
     if bin_dir.is_dir():
         # Per *file*, never the directory, for the same reason `/usr/bin`
         # is: a directory grant is a grant on whatever the directory holds

--- a/src/lightcone/engine/sandbox/policy.py
+++ b/src/lightcone/engine/sandbox/policy.py
@@ -229,9 +229,15 @@ def exec_policy(
         (tmp_home / sub).mkdir(parents=True, exist_ok=True)
 
     if containerized:
+        # Declared spellings, not realpaths — the one shape that keeps
+        # its paths unresolved. These become mount *destinations*, and a
+        # recipe addresses the declared path: resolving here would mount
+        # a symlinked `/data/catalog.h5` at its target and leave the
+        # container with no `/data` at all. (The backend resolves the
+        # *source* side itself.)
         return Policy(
-            read=_existing([project, *read_paths]),
-            write=_existing([tmp_home, project / "results"]),
+            read=_declared([project, *read_paths]),
+            write=_declared([tmp_home, project / "results"]),
             execute=(),
             tmp_home=tmp_home,
             env=home_overlay(tmp_home, env_dir, containerized=True),
@@ -434,6 +440,15 @@ def _loader_patterns() -> dict[str, set[str]]:
         directory, _, name = pattern.rpartition("/")
         grouped.setdefault(os.path.realpath(directory), set()).add(name)
     return grouped
+
+
+def _declared(paths: Iterable[Path]) -> tuple[Path, ...]:
+    """Drop what is not there, de-duplicate, keep the declared spelling."""
+    found: dict[Path, None] = {}
+    for path in paths:
+        if Path(path).exists():
+            found.setdefault(Path(path), None)
+    return tuple(found)
 
 
 def _existing(paths: Iterable[Path]) -> tuple[Path, ...]:

--- a/src/lightcone/engine/sandbox/seatbelt.py
+++ b/src/lightcone/engine/sandbox/seatbelt.py
@@ -106,6 +106,8 @@ class SeatbeltBackend:
     """Seatbelt, expressed as an argv rewrite."""
 
     capability: Capability = field(default_factory=lambda: Capability(kind="seatbelt"))
+    #: The uv hop stays outside the wrap: trusted host plumbing.
+    contains_prefix: bool = False
 
     def wrap(self, policy: Policy, argv: Sequence[str]) -> list[str]:
         """Rewrite *argv* to run under ``sandbox-exec``.

--- a/src/lightcone/engine/templates/files/gitattributes.tmpl
+++ b/src/lightcone/engine/templates/files/gitattributes.tmpl
@@ -11,4 +11,5 @@
 * filter=annex
 results/** annex.largefiles=anything
 data/** annex.largefiles=anything
+.datalad/environments/*/image annex.largefiles=anything
 **/.lightcone-manifest.json annex.largefiles=nothing

--- a/src/lightcone/engine/templates/files/gitattributes.tmpl
+++ b/src/lightcone/engine/templates/files/gitattributes.tmpl
@@ -11,5 +11,5 @@
 * filter=annex
 results/** annex.largefiles=anything
 data/** annex.largefiles=anything
-.datalad/environments/*/image annex.largefiles=anything
 **/.lightcone-manifest.json annex.largefiles=nothing
+.datalad/environments/*/image annex.largefiles=anything

--- a/src/lightcone/engine/templates/files/gitignore.tmpl
+++ b/src/lightcone/engine/templates/files/gitignore.tmpl
@@ -4,4 +4,5 @@ __pycache__/
 .ipynb_checkpoints/
 .DS_Store
 .venv/
+.lightcone/
 _build/

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -41,7 +41,6 @@ from lightcone.engine.project import (
     ProjectError,
     child_env,
     declared_project,
-    sync,
     uv_prefix,
 )
 
@@ -223,12 +222,7 @@ def execute(
     task.output_dir.mkdir(parents=True)
 
     read_paths = [p for p in task.inputs.values() if p.exists()]
-    policy = sandbox.exec_policy(
-        root,
-        read_paths=read_paths,
-        env_dir=runtime.env_dir,
-        containerized=runtime.mode == "containerized",
-    )
+    policy = container.policy_for(runtime, read_paths)
     with sandbox.scope(policy):
         outcome = sandbox.run(
             container.backend(runtime),
@@ -270,14 +264,7 @@ def execute(
                 git_remote=remote,
                 lc_version=lc_version(),
                 hermeticity=asdict(outcome.attestation),
-                image=None
-                if runtime.mode == "direct"
-                else {
-                    "tag": runtime.image_tag,
-                    "id": runtime.image_id,
-                    "archive": runtime.archive,
-                    "arch": runtime.arch,
-                },
+                image=runtime.manifest_image(),
             ),
         )
     except (OSError, ProjectError) as e:
@@ -371,10 +358,7 @@ def main(argv: list[str]) -> int:
         # *is* the driver here — the rule is that each is read once by
         # whoever owns the run, not that a worker never reads them.
         runtime = container.runtime_for_run(root, build=False)
-        if runtime.mode == "direct":
-            sync(root)
-        else:
-            container.sync(root, runtime)
+        container.converge(runtime)
         result = execute(
             root,
             task,

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -360,6 +360,13 @@ def main(argv: list[str]) -> int:
     universe_id, _, output_id = argv[0].partition("/")
     try:
         root = declared_project()
+        # The graph — and with it the task lookup — before any converge:
+        # a typo'd target must cost nothing and mask nothing, and a
+        # failing sync must not bury "no output `x`" under its own error.
+        graph = plan.build(root)
+        if (task := graph.tasks.get((universe_id, output_id))) is None:
+            print(f"no output `{argv[0]}` in this project", file=sys.stderr)
+            return 2
         # This one-task run resolves its own runtime and HEAD, because it
         # *is* the driver here — the rule is that each is read once by
         # whoever owns the run, not that a worker never reads them.
@@ -368,13 +375,13 @@ def main(argv: list[str]) -> int:
             sync(root)
         else:
             container.sync(root, runtime)
-        env_version = identity.env_version(root)
-        graph = plan.build(root)
-        if (task := graph.tasks.get((universe_id, output_id))) is None:
-            print(f"no output `{argv[0]}` in this project", file=sys.stderr)
-            return 2
         result = execute(
-            root, task, env_version, _from_disk(task), head=dataset.head(root), runtime=runtime
+            root,
+            task,
+            identity.env_version(root),
+            _from_disk(task),
+            head=dataset.head(root),
+            runtime=runtime,
         )
     except ProjectError as e:
         print(f"error: {e}", file=sys.stderr)

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -35,7 +35,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Literal
 
-from lightcone.engine import assets, dataset, identity, plan, sandbox
+from lightcone.engine import assets, container, dataset, identity, plan, sandbox
 from lightcone.engine.plan import Key, Task
 from lightcone.engine.project import (
     ProjectError,
@@ -97,6 +97,7 @@ def materialize(
     head: Head,
     versions: assets.Versions,
     refresh: bool,
+    runtime: container.Runtime,
     *upstream: TaskResult,
 ) -> TaskResult:
     """Make *task* if it needs making. What Dask submits, once per task.
@@ -115,6 +116,9 @@ def materialize(
             driver because it commits as outputs land and HEAD moves.
         versions: The run's content-hash memo for declared inputs.
         refresh: Whether to remake an output that is merely behind.
+        runtime: The execution world, resolved once by the driver — the
+            same discipline as *head*, because resolving per task could
+            answer differently mid-run.
         *upstream: The results of this task's dependencies, arriving as
             the futures it was given — which is what makes Dask the
             scheduler rather than a loop here.
@@ -123,7 +127,7 @@ def materialize(
         What happened. Never raises.
     """
     try:
-        return _materialize(root, task, env_version, head, versions, refresh, upstream)
+        return _materialize(root, task, env_version, head, versions, refresh, runtime, upstream)
     except Exception as e:  # the contract is that this function returns
         return TaskResult(task.key, "failed", reason=f"{type(e).__name__}: {e}")
 
@@ -135,6 +139,7 @@ def _materialize(
     head: Head,
     versions: assets.Versions,
     refresh: bool,
+    runtime: container.Runtime,
     upstream: tuple[TaskResult, ...],
 ) -> TaskResult:
     reported = {u.key: u for u in upstream if u.usable}
@@ -155,7 +160,7 @@ def _materialize(
         inputs=inputs,
     )
     if verdict.calls_for_a_remake(refresh=refresh):
-        return execute(root, task, env_version, inputs, head=head)
+        return execute(root, task, env_version, inputs, head=head, runtime=runtime)
 
     # Left alone, so the bytes on disk stand. Their *recorded* digest,
     # never a recomputed one: on a clone that has fetched no annex content
@@ -179,6 +184,7 @@ def execute(
     input_versions: Mapping[str, str],
     *,
     head: Head,
+    runtime: container.Runtime,
 ) -> TaskResult:
     """Run *task*'s recipe and record what it produced.
 
@@ -195,6 +201,9 @@ def execute(
         input_versions: Each declared input's content identity, recorded
             in the manifest as the chain.
         head: The run's ``(commit sha, origin URL)``.
+        runtime: The execution world the recipe enters — the host under
+            the platform's mechanism, or the project image behind its
+            mount table.
 
     Returns:
         ``ok`` with the output's ``data_version``, or ``failed``. Commits
@@ -214,10 +223,15 @@ def execute(
     task.output_dir.mkdir(parents=True)
 
     read_paths = [p for p in task.inputs.values() if p.exists()]
-    policy = sandbox.exec_policy(root, read_paths=read_paths)
+    policy = sandbox.exec_policy(
+        root,
+        read_paths=read_paths,
+        env_dir=runtime.env_dir,
+        containerized=runtime.mode == "containerized",
+    )
     with sandbox.scope(policy):
         outcome = sandbox.run(
-            sandbox.detect(),
+            container.backend(runtime),
             policy,
             [_SHELL, "-c", task.recipe],
             cwd=root,
@@ -256,6 +270,14 @@ def execute(
                 git_remote=remote,
                 lc_version=lc_version(),
                 hermeticity=asdict(outcome.attestation),
+                image=None
+                if runtime.mode == "direct"
+                else {
+                    "tag": runtime.image_tag,
+                    "id": runtime.image_id,
+                    "archive": runtime.archive,
+                    "arch": runtime.arch,
+                },
             ),
         )
     except (OSError, ProjectError) as e:
@@ -319,6 +341,11 @@ def main(argv: list[str]) -> int:
     ``--locked``, so a lock that no longer matches ``pyproject.toml`` is a
     loud refusal rather than a quiet relock.
 
+    The image, by contrast, is *found*, never built: the run record lists
+    the committed archive in ``extra_inputs``, so ``datalad rerun`` has
+    fetched the exact bytes before this runs — and a build would be a
+    commit, which nothing here makes.
+
     Args:
         argv: One argument, ``<universe>/<output_id>``.
 
@@ -333,17 +360,21 @@ def main(argv: list[str]) -> int:
     universe_id, _, output_id = argv[0].partition("/")
     try:
         root = declared_project()
-        sync(root)
+        # This one-task run resolves its own runtime and HEAD, because it
+        # *is* the driver here — the rule is that each is read once by
+        # whoever owns the run, not that a worker never reads them.
+        runtime = container.runtime_for_run(root, build=False)
+        if runtime.mode == "direct":
+            sync(root)
+        else:
+            container.sync(root, runtime)
         env_version = identity.env_version(root)
         graph = plan.build(root)
         if (task := graph.tasks.get((universe_id, output_id))) is None:
             print(f"no output `{argv[0]}` in this project", file=sys.stderr)
             return 2
-        # This one-task run reads HEAD for itself, because it *is* the
-        # driver here — the rule is that the run's commit is read once by
-        # whoever owns the run, not that a worker never reads it.
         result = execute(
-            root, task, env_version, _from_disk(task), head=dataset.head(root)
+            root, task, env_version, _from_disk(task), head=dataset.head(root), runtime=runtime
         )
     except ProjectError as e:
         print(f"error: {e}", file=sys.stderr)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import subprocess
 import textwrap
 from collections.abc import Callable
 from pathlib import Path
@@ -200,3 +201,27 @@ def uv_calls(calls: list[list[str]]) -> list[list[str]]:
 def probes(calls: list[list[str]]) -> list[list[str]]:
     """Just the read-only ``--check`` probes."""
     return [c for c in uv_calls(calls) if "--check" in c]
+
+
+@pytest.fixture(scope="session")
+def engine_dist(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, Path]:
+    """Build the engine under test into a wheel the pinned record can find.
+
+    The record pins ``lightcone-cli==<v>`` and the suite's build is not
+    published, so the rerun's ephemeral environment is pointed here via
+    ``UV_FIND_LINKS`` — which is what lets the suite execute the same
+    record shape every real commit carries, rather than a test-only one.
+
+    Returns:
+        The wheel's exact version, and the directory serving it.
+    """
+    dist = tmp_path_factory.mktemp("engine-dist")
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(dist)],
+        cwd=Path(__file__).parent.parent,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    wheel = next(dist.glob("*.whl"))
+    return wheel.name.split("-")[1], dist

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,9 +27,9 @@ def test_help_advertises_exactly_the_verbs_that_work(runner: CliRunner) -> None:
     """`lc --help` advertises only verbs that work — advertising others
     before they do would be a lie."""
     result = runner.invoke(main, ["--help"])
-    for verb in ("init", "materialize", "run", "status"):
+    for verb in ("init", "build", "materialize", "run", "status"):
         assert f"  {verb}" in result.output
-    for verb in ("verify", "build", "export"):
+    for verb in ("verify", "export"):
         assert f"  {verb}" not in result.output
 
 
@@ -515,6 +515,40 @@ def test_status_shows_each_output_its_state_and_its_commit(
         assert fragment in result.output
 
 
+def test_status_headers_answer_mode_image_and_sandbox(
+    runner: CliRunner, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The three facts nothing else surfaces — where the denial note and
+    the runtime-missing refusal both point."""
+    from lightcone.engine.materialize import StatusReport
+
+    report = _report()
+    assert isinstance(report, StatusReport)
+    report.mode = "containerized"
+    report.image = {"tag": "lc-env-0123456789abcdef", "state": "absent"}
+    report.sandbox = "podman (fs: declared, network: denied)"
+    _status_stub(monkeypatch, report)
+
+    output = runner.invoke(main, ["status"]).output
+
+    assert "mode:    containerized" in output
+    assert "lc-env-0123456789abcdef" in output
+    assert "needs build" in output and "lc build" in output
+    assert "podman" in output
+
+
+def test_build_on_a_direct_project_is_an_explanatory_no_op(
+    runner: CliRunner, project: Path
+) -> None:
+    """Not an error: `lc build` answers "what would building do here",
+    and for a direct project the answer names the escalation."""
+    result = runner.invoke(main, ["build"])
+
+    assert result.exit_code == 0
+    assert "direct mode" in result.output
+    assert "[tool.lightcone.image]" in result.output
+
+
 def test_status_exits_zero_even_with_stale_outputs(
     runner: CliRunner, project: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -534,6 +568,9 @@ def test_status_json_is_machine_readable(
     result = runner.invoke(main, ["status", "--json"])
 
     assert json.loads(result.output) == {
+        "mode": "direct",
+        "image": None,
+        "sandbox": "",
         "counts": {"current": 1, "behind": 1, "stale": 1},
         "outputs": [
             {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -525,7 +525,11 @@ def test_status_headers_answer_mode_image_and_sandbox(
     report = _report()
     assert isinstance(report, StatusReport)
     report.mode = "containerized"
-    report.image = {"tag": "lc-env-0123456789abcdef", "state": "absent"}
+    report.image = {
+        "tag": "lc-env-0123456789abcdef",
+        "state": "absent",
+        "archive": ".datalad/environments/lc-env-0123456789abcdef/image",
+    }
     report.sandbox = "podman (fs: declared, network: denied)"
     _status_stub(monkeypatch, report)
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,380 @@
+"""Tests for `lightcone.engine.container` — the image lifecycle, stubbed.
+
+Every runtime command goes through `project._run`, so these tests hand it
+a fake that models each command's observable effect and records every
+argv — the same discipline as convergence's `tools` fixture. What a real
+runtime does with the argv is `test_container_smoke.py`'s question.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lightcone.engine import assets, container, image, project
+from lightcone.engine.project import ProjectError
+
+_TABLE = '[tool.lightcone.image]\napt-install = ["bc"]\n'
+_CONFIG = b'{"architecture":"amd64","os":"linux"}'
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    project_dir = tmp_path / "analysis"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "analysis"\nversion = "0.1.0"\n'
+        'requires-python = ">=3.11"\ndependencies = []\n' + _TABLE
+    )
+    (project_dir / ".python-version").write_text("3.12.11\n")
+    (project_dir / "uv.lock").write_text("version = 1\n")
+    return project_dir
+
+
+def _write_archive(path: Path, config: bytes = _CONFIG) -> str:
+    """Write a minimal but structurally real docker-archive at *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(path, "w") as tar:
+        for name, data in (
+            ("abc.json", config),
+            ("manifest.json", json.dumps([{"Config": "abc.json", "RepoTags": []}]).encode()),
+        ):
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    import hashlib
+
+    return hashlib.sha256(config).hexdigest()
+
+
+@pytest.fixture
+def fake(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    """A podman-having host: records argv, models each command's effect."""
+    calls: list[list[str]] = []
+    loaded: set[str] = set()
+
+    def run(argv: list[str], *, cwd: Path) -> MagicMock:
+        calls.append(list(argv))
+        if argv[0] in ("podman", "docker"):
+            if argv[1] == "image":  # the loaded probe, both spellings
+                return MagicMock(returncode=0 if argv[3] in loaded else 1)
+            if argv[1] == "load":
+                loaded.add(container.archive_identity(Path(argv[3]))[0])
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if argv[1] == "save":
+                _write_archive(Path(argv[argv.index("-o") + 1]))
+                return MagicMock(returncode=0, stdout="", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+        if argv[:2] == ["uv", "cache"]:
+            return MagicMock(returncode=0, stdout="/home/user/.cache/uv\n", stderr="")
+        if argv[:3] == ["git", "diff", "--cached"]:
+            return MagicMock(returncode=1)  # something staged: commits proceed
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(project, "_run", run)
+    monkeypatch.setattr(shutil, "which", lambda name, path=None: f"/usr/bin/{name}")
+    return calls
+
+
+def _argvs(calls: list[list[str]], *head: str) -> list[list[str]]:
+    return [c for c in calls if c[: len(head)] == list(head)]
+
+
+# ---- runtime detection ------------------------------------------------------
+
+
+def test_podman_is_preferred(root: Path, fake: list[list[str]]) -> None:
+    assert container.runtime_name(root) == "podman"
+
+
+def test_docker_without_its_daemon_is_a_refusal(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`docker` on PATH with the daemon down is the common broken state;
+    'cannot connect to the socket' mid-run is a worse message."""
+    monkeypatch.setattr(
+        shutil, "which", lambda name, path=None: f"/usr/bin/{name}" if name == "docker" else None
+    )
+    monkeypatch.setattr(
+        project, "_run", lambda argv, *, cwd: MagicMock(returncode=1, stdout="", stderr="")
+    )
+    with pytest.raises(ProjectError, match="daemon"):
+        container.runtime_name(root)
+
+
+def test_no_runtime_is_a_refusal_naming_both(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(shutil, "which", lambda name, path=None: None)
+    with pytest.raises(ProjectError, match="podman"):
+        container.runtime_name(root)
+
+
+# ---- the three strictnesses -------------------------------------------------
+
+
+def test_a_direct_project_resolves_without_touching_a_runtime(
+    tmp_path: Path, fake: list[list[str]]
+) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "pyproject.toml").write_text('[project]\nname = "p"\nversion = "0"\n')
+
+    runtime = container.runtime_for_run(plain, build=False)
+
+    assert runtime.mode == "direct"
+    assert runtime.env_dir == plain / ".venv"
+    assert fake == []
+
+
+def test_a_missing_archive_refuses_unless_the_caller_may_build(
+    root: Path, fake: list[list[str]]
+) -> None:
+    """`lc run` never builds and the worker never writes git — and the
+    mutation check: the same state under a build-allowed caller succeeds."""
+    with pytest.raises(ProjectError, match="lc build"):
+        container.runtime_for_run(root, build=False)
+    assert _argvs(fake, "podman", "build") == []
+    assert _argvs(fake, "git", "commit") == []
+
+    runtime = container.runtime_for_run(root, build=True)
+
+    assert runtime.mode == "containerized"
+    assert runtime.image_tag == image.tag(root)
+    assert container.runtime_for_run(root, build=False).image_id == runtime.image_id
+
+
+def test_unfetched_archive_content_names_git_annex_get(
+    root: Path, fake: list[list[str]]
+) -> None:
+    archive = image.archive_path(root, image.tag(root))
+    archive.parent.mkdir(parents=True)
+    archive.write_bytes(b"/annex/objects/SHA256E-s323--abc\n")  # the pointer shape
+
+    with pytest.raises(assets.ContentNotFetchedError, match="git annex get"):
+        container.runtime_for_run(root, build=False)
+
+
+def test_a_present_archive_is_loaded_once_and_reused(
+    root: Path, fake: list[list[str]]
+) -> None:
+    expected = _write_archive(image.archive_path(root, image.tag(root)))
+
+    first = container.runtime_for_run(root, build=False)
+    second = container.runtime_for_run(root, build=False)
+
+    assert first.image_id == expected and second.image_id == expected
+    assert first.arch == "amd64"
+    assert first.archive == f".datalad/environments/{image.tag(root)}/image"
+    assert len(_argvs(fake, "podman", "load")) == 1  # the second run hit the store
+
+
+# ---- building ---------------------------------------------------------------
+
+
+def test_the_build_context_holds_only_the_containerfile(
+    root: Path, fake: list[list[str]]
+) -> None:
+    """No project file ever enters the context — what makes 'code edits
+    never trigger a build' structural rather than observed."""
+    container.runtime_for_run(root, build=True)
+
+    (build,) = _argvs(fake, "podman", "build")
+    context = Path(build[-1])
+    assert not context.is_relative_to(root)
+    containerfile = Path(build[build.index("-f") + 1])
+    assert containerfile.name == "Containerfile"
+    assert build[build.index("-t") + 1] == image.tag(root)
+
+
+def test_the_build_saves_and_commits_the_archive(root: Path, fake: list[list[str]]) -> None:
+    """The dataset is the image store: the archive and the datalad
+    containers config land in one scoped commit."""
+    runtime = container.runtime_for_run(root, build=True)
+
+    (save,) = _argvs(fake, "podman", "save")
+    assert save[save.index("-o") + 1] == str(image.archive_path(root, runtime.image_tag))
+    assert "--format" in save and save[save.index("--format") + 1] == "docker-archive"
+    configured = {c[-2] for c in _argvs(fake, "git", "config", "-f", ".datalad/config")}
+    assert f"datalad.containers.{runtime.image_tag}.image" in configured
+    assert f"datalad.containers.{runtime.image_tag}.cmdexec" in configured
+    (add,) = [c for c in fake if c[0] == "git" and "add" in c]
+    assert f".datalad/environments/{runtime.image_tag}" in " ".join(add)
+    # The dot-path routing: without it the archive is a full blob in git.
+    assert "annex.dotfiles=true" in add
+    assert len(_argvs(fake, "git", "commit")) == 1
+
+
+def test_a_bad_apt_name_is_parsed_out_of_the_build_log(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def failing(argv: list[str], *, cwd: Path) -> MagicMock:
+        if argv[:2] == ["podman", "build"]:
+            return MagicMock(
+                returncode=1, stdout="", stderr="E: Unable to locate package texlive-latex-bass"
+            )
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(project, "_run", failing)
+    with pytest.raises(ProjectError, match="texlive-latex-bass"):
+        container.runtime_for_run(root, build=True)
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [("43", "glibc"), ("44", "bash"), ("45", "apt")],
+)
+def test_a_contract_violation_names_the_base_not_the_log(
+    root: Path,
+    fake: list[list[str]],
+    monkeypatch: pytest.MonkeyPatch,
+    code: str,
+    expected: str,
+) -> None:
+    def failing(argv: list[str], *, cwd: Path) -> MagicMock:
+        if argv[:2] == ["podman", "build"]:
+            return MagicMock(
+                returncode=1, stdout="", stderr=f'Error: building at STEP: exit status {code}'
+            )
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(project, "_run", failing)
+    with pytest.raises(ProjectError, match=expected):
+        container.runtime_for_run(root, build=True)
+
+
+def test_lc_build_refuses_a_dirty_tree(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The archive commit takes the whole index with it, and the tag
+    derives from pyproject.toml — the declaration commits first."""
+
+    def dirty(argv: list[str], *, cwd: Path) -> MagicMock:
+        if argv[:2] == ["git", "status"]:
+            return MagicMock(returncode=0, stdout=" M pyproject.toml\n", stderr="")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(project, "_run", dirty)
+    with pytest.raises(ProjectError, match="[Cc]ommit"):
+        container.build(root)
+
+
+def test_lc_build_is_idempotent(root: Path, fake: list[list[str]]) -> None:
+    _, first = container.build(root)
+    _, second = container.build(root)
+    assert (first, second) == ("built", "present")
+    assert len(_argvs(fake, "podman", "build")) == 1
+
+
+def test_lc_build_on_a_direct_project_says_so(tmp_path: Path, fake: list[list[str]]) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "pyproject.toml").write_text('[project]\nname = "p"\nversion = "0"\n')
+    with pytest.raises(ProjectError, match="direct mode"):
+        container.build(plain)
+
+
+# ---- the containerized converge ---------------------------------------------
+
+
+def test_sync_runs_uv_inside_the_image_with_the_host_cache(
+    root: Path, fake: list[list[str]]
+) -> None:
+    runtime = container.runtime_for_run(root, build=True)
+    fake.clear()
+
+    container.sync(root, runtime)
+
+    (sync,) = _argvs(fake, "podman", "run")
+    assert f"{root}:{root}:rw" in " ".join(sync)
+    assert "/home/user/.cache/uv:/home/user/.cache/uv:rw" in " ".join(sync)
+    assert f"UV_PROJECT_ENVIRONMENT={root / '.lightcone' / 'venv'}" in " ".join(sync)
+    assert "--userns=keep-id" in sync
+    assert runtime.image_id in sync
+    tail = sync[sync.index(runtime.image_id) + 1 :]
+    assert tail[:2] == ["uv", "sync"]
+    assert "--locked" in tail and "--exact" in tail and "--compile-bytecode" in tail
+
+
+# ---- the podman machine (macOS) ---------------------------------------------
+
+
+def _darwin(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    monkeypatch.setattr(container.sys, "platform", "darwin")
+    assert sys.platform  # the global module object is patched; reverted after
+
+
+def test_no_podman_machine_is_a_refusal_naming_the_setup(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _darwin(monkeypatch)
+    monkeypatch.setattr(
+        project, "_run", lambda argv, *, cwd: MagicMock(returncode=1, stdout="", stderr="")
+    )
+    with pytest.raises(ProjectError, match="podman machine init"):
+        container.runtime_name(root)
+
+
+def test_a_project_outside_the_machine_shares_is_a_refusal(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bind mount from outside the VM's shared directories arrives
+    *empty* — no error, just a project with nothing in it — so the
+    preflight names the exact `podman machine set`. The mutation check:
+    a share that covers the project passes."""
+    _darwin(monkeypatch)
+
+    def machine(shares: list[str]) -> None:
+        inspect = json.dumps([{"Mounts": [{"Source": s} for s in shares]}])
+        monkeypatch.setattr(
+            project,
+            "_run",
+            lambda argv, *, cwd: MagicMock(returncode=0, stdout=inspect, stderr=""),
+        )
+
+    machine(["/Users"])
+    with pytest.raises(ProjectError, match="podman machine set"):
+        container.runtime_name(root)
+
+    machine([str(root.parent)])
+    assert container.runtime_name(root) == "podman"
+
+
+# ---- state for status and the CLI -------------------------------------------
+
+
+def test_image_state_reports_repository_facts_only(root: Path, fake: list[list[str]]) -> None:
+    assert container.image_state(root) == ("absent", image.tag(root))
+
+    archive = image.archive_path(root, image.tag(root))
+    archive.parent.mkdir(parents=True)
+    archive.write_bytes(b"/annex/objects/SHA256E-s1--abc\n")
+    assert container.image_state(root)[0] == "unfetched"
+
+    _write_archive(archive)
+    assert container.image_state(root)[0] == "present"
+    assert not any(c[0] in ("podman", "docker") for c in fake)
+
+
+def test_archive_identity_matches_the_runtime_id_computation(tmp_path: Path) -> None:
+    """The same sha256-of-the-config-blob podman and docker report, and
+    the value the smoke test compares against a real `podman inspect`."""
+    config = b'{"architecture":"arm64"}'
+    expected = _write_archive(tmp_path / "image", config)
+    found, arch = container.archive_identity(tmp_path / "image")
+    assert found == expected
+    assert arch == "arm64"
+
+
+def test_a_garbled_archive_is_a_pointed_refusal(tmp_path: Path) -> None:
+    (tmp_path / "image").write_bytes(b"not a tar at all" * 4096)
+    with pytest.raises(ProjectError, match="lc build"):
+        container.archive_identity(tmp_path / "image")

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from lightcone.engine import assets, container, image, project
+from lightcone.engine import container, image, project
 from lightcone.engine.project import ProjectError
 
 _TABLE = '[tool.lightcone.image]\napt-install = ["bc"]\n'
@@ -78,6 +78,9 @@ def fake(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
             return MagicMock(
                 returncode=0, stdout=f"{argv[-1]}: annex.largefiles: anything\n", stderr=""
             )
+        if argv[:3] == ["git", "annex", "get"]:
+            _write_archive(cwd / argv[-1])  # the fetch's observable effect
+            return MagicMock(returncode=0, stdout="", stderr="")
         return MagicMock(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(project, "_run", run)
@@ -153,14 +156,32 @@ def test_a_missing_archive_refuses_unless_the_caller_may_build(
     assert container.runtime_for_run(root, build=False).image_id == runtime.image_id
 
 
-def test_unfetched_archive_content_names_git_annex_get(
-    root: Path, fake: list[list[str]]
+def test_unfetched_archive_content_is_fetched_by_lc_itself(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Nobody is ever asked to run a git-annex command by hand — the
+    storage invariant. lc gets its own artifact; the refusal is reserved
+    for a fetch with no reachable copy, which is the second half."""
     archive = image.archive_path(root, image.tag(root))
     archive.parent.mkdir(parents=True)
     archive.write_bytes(b"/annex/objects/SHA256E-s323--abc\n")  # the pointer shape
 
-    with pytest.raises(assets.ContentNotFetchedError, match="git annex get"):
+    runtime = container.runtime_for_run(root, build=False)
+
+    assert runtime.image_id
+    (got,) = [c for c in fake if c[:3] == ["git", "annex", "get"]]
+    assert got[-1] == f".datalad/environments/{image.tag(root)}/image"
+
+    archive.write_bytes(b"/annex/objects/SHA256E-s323--abc\n")  # unfetched again
+    inner = project._run
+
+    def failing(argv: list[str], *, cwd: Path) -> MagicMock:
+        if argv[:3] == ["git", "annex", "get"]:
+            return MagicMock(returncode=1, stdout="", stderr="no reachable copy")
+        return inner(argv, cwd=cwd)
+
+    monkeypatch.setattr(project, "_run", failing)
+    with pytest.raises(ProjectError, match="fetching it failed"):
         container.runtime_for_run(root, build=False)
 
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -75,6 +75,10 @@ def fake(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
             return MagicMock(returncode=0, stdout="/home/user/.cache/uv\n", stderr="")
         if argv[:3] == ["git", "diff", "--cached"]:
             return MagicMock(returncode=1)  # something staged: commits proceed
+        if argv[:2] == ["git", "check-attr"]:
+            return MagicMock(
+                returncode=0, stdout=f"{argv[-1]}: annex.largefiles: anything\n", stderr=""
+            )
         return MagicMock(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(project, "_run", run)
@@ -199,7 +203,12 @@ def test_the_build_saves_and_commits_the_archive(root: Path, fake: list[list[str
     runtime = container.runtime_for_run(root, build=True)
 
     (save,) = _argvs(fake, "podman", "save")
-    assert save[save.index("-o") + 1] == str(image.archive_path(root, runtime.image_tag))
+    # Saved beside its final name and renamed into place, so a save that
+    # dies midway leaves no partial archive for the dirty refusal to
+    # tell the user to commit.
+    archive = image.archive_path(root, runtime.image_tag)
+    assert save[save.index("-o") + 1] == str(archive.parent / "image.partial")
+    assert archive.is_file() and not (archive.parent / "image.partial").exists()
     assert "--format" in save and save[save.index("--format") + 1] == "docker-archive"
     configured = {c[-2] for c in _argvs(fake, "git", "config", "-f", ".datalad/config")}
     assert f"datalad.containers.{runtime.image_tag}.image" in configured
@@ -211,42 +220,91 @@ def test_the_build_saves_and_commits_the_archive(root: Path, fake: list[list[str
     assert len(_argvs(fake, "git", "commit")) == 1
 
 
+def test_an_unrouted_archive_refuses_before_building(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The archive is committed, and `.gitattributes` is a user-authored
+    file lc only appends to — so an archive it does not route to the
+    annex would land in git as a several-hundred-MB blob, silently. The
+    probe fires before any build is paid for. Mutation check: the `fake`
+    fixture's routed answer is what every other build test passes with."""
+    original = project._run
+
+    def unrouted(argv: list[str], *, cwd: Path) -> MagicMock:
+        if argv[:2] == ["git", "check-attr"]:
+            return MagicMock(
+                returncode=0, stdout=f"{argv[-1]}: annex.largefiles: unspecified\n", stderr=""
+            )
+        return original(argv, cwd=cwd)
+
+    monkeypatch.setattr(project, "_run", unrouted)
+    with pytest.raises(ProjectError, match="annex.largefiles=anything"):
+        container.runtime_for_run(root, build=True)
+    assert _argvs(fake, "podman", "build") == []
+
+
 def test_a_bad_apt_name_is_parsed_out_of_the_build_log(
     root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    def failing(argv: list[str], *, cwd: Path) -> MagicMock:
-        if argv[:2] == ["podman", "build"]:
-            return MagicMock(
-                returncode=1, stdout="", stderr="E: Unable to locate package texlive-latex-bass"
-            )
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr(project, "_run", failing)
+    _failing_build("E: Unable to locate package texlive-latex-bass", monkeypatch)
     with pytest.raises(ProjectError, match="texlive-latex-bass"):
         container.runtime_for_run(root, build=True)
 
 
+def _failing_build(stderr: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route only the build through failure; everything else keeps the
+    `fake` fixture's modelled answers (the routing probe included)."""
+    from lightcone.engine import project as project_module
+
+    inner = project_module._run
+
+    def failing(argv: list[str], *, cwd: Path) -> MagicMock:
+        if argv[:2] == ["podman", "build"]:
+            return MagicMock(returncode=1, stdout="", stderr=stderr)
+        return inner(argv, cwd=cwd)
+
+    monkeypatch.setattr(project_module, "_run", failing)
+
+
 @pytest.mark.parametrize(
-    ("code", "expected"),
-    [("43", "glibc"), ("44", "bash"), ("45", "apt")],
+    ("code", "instruction", "expected"),
+    [
+        ("43", "RUN if ldd --version 2>&1 | grep -qi musl", "glibc"),
+        ("44", "RUN command -v bash >/dev/null", "bash"),
+        ("45", "RUN command -v apt-get >/dev/null", "apt"),
+    ],
 )
 def test_a_contract_violation_names_the_base_not_the_log(
     root: Path,
     fake: list[list[str]],
     monkeypatch: pytest.MonkeyPatch,
     code: str,
+    instruction: str,
     expected: str,
 ) -> None:
-    def failing(argv: list[str], *, cwd: Path) -> MagicMock:
-        if argv[:2] == ["podman", "build"]:
-            return MagicMock(
-                returncode=1, stdout="", stderr=f'Error: building at STEP: exit status {code}'
-            )
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr(project, "_run", failing)
+    _failing_build(
+        f'Error: building at STEP "{instruction}": while running runtime: '
+        f"exit status {code}",
+        monkeypatch,
+    )
     with pytest.raises(ProjectError, match=expected):
         container.runtime_for_run(root, build=True)
+
+
+def test_a_run_command_exiting_a_contract_code_is_not_misdiagnosed(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """curl exits 43 for its own reasons; blaming the base for it would
+    point the user away from their own failing command. The anchor is
+    the failing instruction, not the code alone."""
+    _failing_build(
+        'Error: building at STEP "RUN curl -fsSL https://example.org/tool.tar": '
+        "exit status 43",
+        monkeypatch,
+    )
+    with pytest.raises(ProjectError, match="curl") as raised:
+        container.runtime_for_run(root, build=True)
+    assert "musl" not in str(raised.value)
 
 
 def test_lc_build_refuses_a_dirty_tree(
@@ -333,7 +391,9 @@ def test_a_project_outside_the_machine_shares_is_a_refusal(
     _darwin(monkeypatch)
 
     def machine(shares: list[str]) -> None:
-        inspect = json.dumps([{"Mounts": [{"Source": s} for s in shares]}])
+        inspect = json.dumps(
+            [{"State": "running", "Mounts": [{"Source": s} for s in shares]}]
+        )
         monkeypatch.setattr(
             project,
             "_run",
@@ -344,8 +404,30 @@ def test_a_project_outside_the_machine_shares_is_a_refusal(
     with pytest.raises(ProjectError, match="podman machine set"):
         container.runtime_name(root)
 
+    # A machine sharing nothing at all is the same refusal, not a pass.
+    machine([])
+    with pytest.raises(ProjectError, match="podman machine set"):
+        container.runtime_name(root)
+
     machine([str(root.parent)])
     assert container.runtime_name(root) == "podman"
+
+
+def test_a_stopped_machine_is_a_refusal_naming_start(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`podman machine inspect` succeeds on a stopped machine — without
+    the state check the preflight passes and the run dies later on a raw
+    connection error, far from the one-command fix."""
+    _darwin(monkeypatch)
+    inspect = json.dumps([{"State": "stopped", "Mounts": [{"Source": "/Users"}]}])
+    monkeypatch.setattr(
+        project,
+        "_run",
+        lambda argv, *, cwd: MagicMock(returncode=0, stdout=inspect, stderr=""),
+    )
+    with pytest.raises(ProjectError, match="podman machine start"):
+        container.runtime_name(root)
 
 
 # ---- state for status and the CLI -------------------------------------------

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -33,7 +33,6 @@ def root(tmp_path: Path) -> Path:
         'requires-python = ">=3.11"\ndependencies = []\n' + _TABLE
     )
     (project_dir / ".python-version").write_text("3.12.11\n")
-    (project_dir / "uv.lock").write_text("version = 1\n")
     return project_dir
 
 
@@ -434,9 +433,11 @@ def test_a_stopped_machine_is_a_refusal_naming_start(
 
 
 def test_image_state_reports_repository_facts_only(root: Path, fake: list[list[str]]) -> None:
-    assert container.image_state(root) == ("absent", image.tag(root))
+    tag = image.tag(root)
+    relative = f".datalad/environments/{tag}/image"
+    assert container.image_state(root) == ("absent", tag, relative)
 
-    archive = image.archive_path(root, image.tag(root))
+    archive = image.archive_path(root, tag)
     archive.parent.mkdir(parents=True)
     archive.write_bytes(b"/annex/objects/SHA256E-s1--abc\n")
     assert container.image_state(root)[0] == "unfetched"

--- a/tests/test_container_smoke.py
+++ b/tests/test_container_smoke.py
@@ -52,11 +52,17 @@ def _available() -> list[str]:
     found = []
     if shutil.which("podman"):
         found.append("podman")
-    if (
-        shutil.which("docker")
-        and subprocess.run(["docker", "info"], capture_output=True).returncode == 0
-    ):
-        found.append("docker")
+    try:
+        if (
+            shutil.which("docker")
+            and subprocess.run(
+                ["docker", "info"], capture_output=True, timeout=10
+            ).returncode
+            == 0
+        ):
+            found.append("docker")
+    except subprocess.TimeoutExpired:
+        pass  # a hung daemon at collection time must not hang the suite
     return found
 
 
@@ -177,6 +183,15 @@ def test_the_probe_and_its_boundary(runtime: str, cproject: Path) -> None:
     finally:
         outside.unlink()
 
+    # The rootfs is read-only: a write outside the declared set is a
+    # loud denial, not bytes vanishing with the container. The mutation
+    # check is the same write into results/, which must succeed.
+    rootfs = engine_run.probe(cproject, ["bash", "-c", "mkdir /output"])
+    assert rootfs.returncode != 0
+    results = engine_run.probe(cproject, ["bash", "-c", "touch results/probe-write"])
+    assert results.returncode == 0
+    (cproject / "results" / "probe-write").unlink()
+
     loopback = engine_run.probe(
         cproject,
         ["python", "-c", 'import socket; socket.socket().bind(("127.0.0.1", 0))'],
@@ -238,6 +253,11 @@ def test_a_rerun_on_a_clone_fetches_the_archive_and_reproduces(
     archive through the annex (it is in `extra_inputs`), the worker loads
     it and syncs `.lightcone/venv` in-image, and the output reproduces."""
     pytest.importorskip("datalad")
+    if runtime != _RUNTIMES[0]:
+        # The rerun is a subprocess and detects the host's preferred
+        # runtime for itself — a monkeypatch cannot reach it, so running
+        # this under any other parameter would silently retest the first.
+        pytest.skip("the rerun subprocess always uses the host's preferred runtime")
     version, dist = engine_dist
     monkeypatch.setattr(engine, "_engine_requirement", lambda: f"lightcone-cli=={version}")
     report = engine.materialize(cproject, [])

--- a/tests/test_container_smoke.py
+++ b/tests/test_container_smoke.py
@@ -1,0 +1,289 @@
+"""The runtime's answer — the one file that can say the container layer works.
+
+Everything here builds a real image, saves a real archive into a real
+annexed repository, and runs real commands through a real runtime's mount
+table. Gated exactly like the sandbox enforcement suite: hosts without a
+runtime skip, and ``LC_CONTAINER_TESTS_REQUIRED=1`` (set in Linux CI)
+turns that skip into a hard failure, with two tests covering the guard
+itself — an unfailing guard is worse than none.
+
+Parameterized over the runtimes actually present, because a leak or an
+asymmetry only docker catches is still a bug.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from lightcone.engine import assets, container, dataset, image
+from lightcone.engine import materialize as engine
+from lightcone.engine import run as engine_run
+from lightcone.engine.project import ProjectError, child_env
+
+REQUIRED_ENV = "LC_CONTAINER_TESTS_REQUIRED"
+
+_SPEC = """
+version: "0.0.13"
+name: analysis
+
+inputs:
+  - id: catalog
+    type: data
+    source: data/catalog.fits
+
+outputs:
+  - id: sums
+    type: metric
+    recipe:
+      command: echo "2+2" | bc > {output}/sum.txt
+"""
+
+
+def _available() -> list[str]:
+    """The runtimes this host can actually run, probed once at collection."""
+    found = []
+    if shutil.which("podman"):
+        found.append("podman")
+    if (
+        shutil.which("docker")
+        and subprocess.run(["docker", "info"], capture_output=True).returncode == 0
+    ):
+        found.append("docker")
+    return found
+
+
+_RUNTIMES = _available()
+
+
+def _gate(available: list[str]) -> None:
+    if available:
+        return
+    if os.environ.get(REQUIRED_ENV):
+        pytest.fail(
+            f"{REQUIRED_ENV} is set but this host has no container runtime. "
+            "Container tests must not be skipped on CI."
+        )
+    pytest.skip("no container runtime here")
+
+
+@pytest.fixture(params=_RUNTIMES or [""])
+def runtime(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> str:
+    """One available runtime, with the others hidden from detection."""
+    _gate(_RUNTIMES)
+    name = str(request.param)
+    real_which = shutil.which
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda tool, path=None: None
+        if tool in ("podman", "docker") and tool != name
+        else real_which(tool, path=path),
+    )
+    return name
+
+
+@pytest.fixture
+def cproject(analysis: Callable[..., Path]) -> Path:
+    """A real committed project, containerized after its scaffold commit —
+    the way a real project escalates: edit pyproject, commit, build."""
+    root = analysis(_SPEC, files={"data/catalog.fits": "stars\n"})
+    text = (root / "pyproject.toml").read_text()
+    (root / "pyproject.toml").write_text(
+        text + '\n[tool.lightcone.image]\napt-install = ["bc"]\n'
+    )
+    dataset.save(root, [root], "containerize")
+    return root
+
+
+def _inspect_id(runtime: str, image_id: str) -> str:
+    argv = {
+        "podman": ["podman", "image", "inspect", "--format", "{{.Id}}", image_id],
+        "docker": ["docker", "image", "inspect", "--format", "{{.Id}}", image_id],
+    }[runtime]
+    out = subprocess.run(argv, capture_output=True, text=True, check=True).stdout.strip()
+    return out.removeprefix("sha256:")
+
+
+# ---- lc build ---------------------------------------------------------------
+
+
+def test_build_commits_the_exact_bytes_and_leaves_the_tree_clean(
+    runtime: str, cproject: Path
+) -> None:
+    resolved, action = container.build(cproject)
+
+    assert action == "built"
+    archive = image.archive_path(cproject, resolved.image_tag)
+    assert archive.is_file()
+    assert not dataset.status(cproject), "the archive commit left the tree dirty"
+    # The user never sees a Containerfile — not in the tree, not beside
+    # the archive.
+    assert not list(cproject.rglob("Containerfile"))
+    # The id read from the archive is the id the runtime computed.
+    assert resolved.image_id == _inspect_id(runtime, resolved.image_id)
+    # And the image carries its own identity.
+    label = subprocess.run(
+        [
+            runtime, "image", "inspect",
+            "--format", '{{index .Config.Labels "io.lightcone.image"}}',
+            resolved.image_id,
+        ],  # fmt: skip
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert json.loads(label) == json.loads(image.identity_document(cproject) or "")
+
+    _, again = container.build(cproject)
+    assert again == "present"
+
+
+# ---- lc run: the probe ------------------------------------------------------
+
+
+def test_the_probe_and_its_boundary(runtime: str, cproject: Path) -> None:
+    """One image, the probe's whole contract — each denial beside the
+    mutation check that proves the same reach works where it should.
+
+    `lc run` never builds: the first probe refuses naming `lc build`, and
+    succeeding after one is the mutation check. The mounts are the
+    mechanism: an undeclared host file simply is not there (while the
+    host itself reads it fine). And `--network none` is a real denial
+    with loopback intact — the meaning of `network: denied`."""
+    with pytest.raises(ProjectError, match="lc build"):
+        engine_run.probe(cproject, ["bc", "--version"])
+
+    container.build(cproject)
+    outcome = engine_run.probe(cproject, ["bc", "--version"])
+    assert outcome.returncode == 0
+    assert outcome.attestation.mechanism == runtime
+    assert outcome.attestation.network == "denied"
+    assert outcome.attestation.fs == "declared"
+
+    outside = Path.home() / ".lc-smoke-outside.txt"
+    outside.write_text("host secret\n")
+    try:
+        denied = engine_run.probe(cproject, ["cat", str(outside)])
+        assert denied.returncode != 0
+        assert outside.read_text() == "host secret\n"  # the host itself can
+    finally:
+        outside.unlink()
+
+    loopback = engine_run.probe(
+        cproject,
+        ["python", "-c", 'import socket; socket.socket().bind(("127.0.0.1", 0))'],
+    )
+    assert loopback.returncode == 0
+
+    egress = engine_run.probe(
+        cproject,
+        [
+            "python", "-c",
+            "import socket, urllib.request; socket.setdefaulttimeout(3); "
+            'urllib.request.urlopen("http://1.1.1.1")',
+        ],  # fmt: skip
+    )
+    assert egress.returncode != 0
+
+
+# ---- lc materialize ---------------------------------------------------------
+
+
+def test_materialize_end_to_end_in_the_image(runtime: str, cproject: Path) -> None:
+    """The whole layer at once: the driver builds and commits the image,
+    converges the in-image environment, runs the recipe behind the mount
+    table, records the runtime facts, and leaves the tree clean — through
+    the real Dask cluster, not a stub."""
+    report = engine.materialize(cproject, [])
+
+    assert report.ok, report.warnings
+    assert report.made == ["baseline/sums"]
+    assert (cproject / "results/baseline/sums/sum.txt").read_text() == "4\n"
+    assert not dataset.status(cproject)
+
+    manifest = assets.read(cproject / "results/baseline/sums")
+    assert manifest is not None
+    assert manifest.hermeticity["mechanism"] == runtime
+    assert manifest.hermeticity["network"] == "denied"
+    assert manifest.hermeticity["fs"] == "declared"
+    assert manifest.image is not None
+    assert manifest.image["id"] == _inspect_id(runtime, manifest.image["id"])
+    assert manifest.image["archive"] == f".datalad/environments/{manifest.image['tag']}/image"
+
+    # The record lists the archive, so a rerun's `datalad get` fetches
+    # the exact bytes before the worker runs. Parsed rather than matched
+    # as text, because the record is datalad's format, not ours.
+    record = dataset._git(["log", "-1", "--format=%B"], cwd=cproject)
+    body = record.partition("=== Do not change lines below ===")[2].partition("^^^")[0]
+    assert json.loads(body)["extra_inputs"] == [manifest.image["archive"]]
+
+
+def test_a_rerun_on_a_clone_fetches_the_archive_and_reproduces(
+    runtime: str,
+    cproject: Path,
+    tmp_path: Path,
+    engine_dist: tuple[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The record's whole claim, on the machine that matters: a clone with
+    no annex content and no local image. `datalad rerun` fetches the
+    archive through the annex (it is in `extra_inputs`), the worker loads
+    it and syncs `.lightcone/venv` in-image, and the output reproduces."""
+    pytest.importorskip("datalad")
+    version, dist = engine_dist
+    monkeypatch.setattr(engine, "_engine_requirement", lambda: f"lightcone-cli=={version}")
+    report = engine.materialize(cproject, [])
+    assert report.ok, report.warnings
+    original = assets.read(cproject / "results/baseline/sums")
+    assert original is not None
+
+    clone = tmp_path / "clone"
+    dataset._git(["clone", "-q", str(cproject), str(clone)], cwd=tmp_path)
+    for key, value in (("user.email", "t@example.com"), ("user.name", "Test")):
+        dataset._git(["config", key, value], cwd=clone)
+    dataset._git(["annex", "init", "-q", "clone"], cwd=clone)
+    # No annex content: the archive here is a pointer until rerun gets it.
+    with pytest.raises(assets.ContentNotFetchedError):
+        assets.require_fetched(clone / str(original.image["archive"]))  # type: ignore[index]
+
+    proc = subprocess.run(
+        [sys.executable, "-c", "from datalad.api import rerun; rerun('HEAD')"],
+        cwd=clone,
+        capture_output=True,
+        text=True,
+        env={**child_env(), "UV_FIND_LINKS": str(dist)},
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    rerun = assets.read(clone / "results/baseline/sums")
+    assert rerun is not None
+    assert rerun.data_version == original.data_version
+    assert not dataset.status(clone)
+
+
+# ---- the guard on this file itself -----------------------------------------
+
+
+def test_the_ci_guard_fails_rather_than_skipping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The one test here that must pass everywhere: CI cannot go green by
+    skipping the rest. Without this, `LC_CONTAINER_TESTS_REQUIRED` is a
+    comment."""
+    monkeypatch.setenv(REQUIRED_ENV, "1")
+    with pytest.raises(pytest.fail.Exception, match="must not be skipped"):
+        _gate([])
+
+
+def test_without_the_guard_a_runtimeless_host_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+    """And off CI it stays a skip — a laptop without podman should run the
+    rest of the suite, not fail it."""
+    monkeypatch.delenv(REQUIRED_ENV, raising=False)
+    with pytest.raises(pytest.skip.Exception):
+        _gate([])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -94,23 +94,35 @@ def test_a_plain_git_add_annexes_content_by_itself(repo: Path) -> None:
     assert _annexed(repo, output / "fit.csv")
 
 
-def test_the_image_archive_reaches_the_annex_despite_its_dot_path(repo: Path) -> None:
-    """git-annex routes dotfile paths to git whatever `annex.largefiles`
-    says, unless the add opts in — so without `dotfiles=True` the image
-    archive under `.datalad/environments/` lands as a full blob in git,
-    silently, and every clone carries the bytes forever. The mutation
-    check is the plain save: same file, same attributes, git's blob."""
+def test_dot_paths_follow_the_storage_policy_not_annex_defaults(repo: Path) -> None:
+    """git-annex routes any file under a dot-directory to git whatever
+    `annex.largefiles` says, unless the add opts in — so the image
+    archive under `.datalad/environments/`, or a `.cache.h5` a recipe
+    writes into results/, would land as a full blob in git, silently,
+    and every clone would carry the bytes forever. `save` opts in
+    unconditionally, so the attributes alone decide: archives and dot
+    outputs reach the annex, dot-named manifests keep their exemption.
+    The mutation check is a *plain* `git add` of the same shape, which
+    keeps git-annex's stock dotfile behavior."""
     archive = repo / ".datalad" / "environments" / "lc-env-abc" / "image"
     archive.parent.mkdir(parents=True)
     archive.write_bytes(b"pretend image bytes\n" * 64)
+    output = repo / "results" / "baseline" / "fit"
+    output.mkdir(parents=True)
+    (output / ".cache.h5").write_bytes(b"intermediate\n" * 64)
+    (output / ".lightcone-manifest.json").write_text("{}\n")
 
-    dataset.save(repo, [archive.parent], "with routing", dotfiles=True)
+    dataset.save(repo, [archive.parent, output], "routed")
+
     assert _annexed(repo, archive)
+    assert _annexed(repo, output / ".cache.h5")
+    assert not _annexed(repo, output / ".lightcone-manifest.json")
 
     plain = repo / ".datalad" / "environments" / "lc-env-def" / "image"
     plain.parent.mkdir(parents=True)
     plain.write_bytes(b"pretend image bytes\n" * 64)
-    dataset.save(repo, [plain.parent], "without routing")
+    dataset._git(["add", "-A", "--", ".datalad/environments/lc-env-def"], cwd=repo)
+    dataset._git(["commit", "-q", "-m", "plain add"], cwd=repo)
     assert not _annexed(repo, plain)
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -94,6 +94,26 @@ def test_a_plain_git_add_annexes_content_by_itself(repo: Path) -> None:
     assert _annexed(repo, output / "fit.csv")
 
 
+def test_the_image_archive_reaches_the_annex_despite_its_dot_path(repo: Path) -> None:
+    """git-annex routes dotfile paths to git whatever `annex.largefiles`
+    says, unless the add opts in — so without `dotfiles=True` the image
+    archive under `.datalad/environments/` lands as a full blob in git,
+    silently, and every clone carries the bytes forever. The mutation
+    check is the plain save: same file, same attributes, git's blob."""
+    archive = repo / ".datalad" / "environments" / "lc-env-abc" / "image"
+    archive.parent.mkdir(parents=True)
+    archive.write_bytes(b"pretend image bytes\n" * 64)
+
+    dataset.save(repo, [archive.parent], "with routing", dotfiles=True)
+    assert _annexed(repo, archive)
+
+    plain = repo / ".datalad" / "environments" / "lc-env-def" / "image"
+    plain.parent.mkdir(parents=True)
+    plain.write_bytes(b"pretend image bytes\n" * 64)
+    dataset.save(repo, [plain.parent], "without routing")
+    assert not _annexed(repo, plain)
+
+
 def test_analysis_code_stays_in_git_and_stays_writable(repo: Path) -> None:
     """The default `annex.largefiles=nothing` is what keeps `filter=annex`
     from routing source files into the annex along with the data."""

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,249 @@
+"""Tests for `lightcone.engine.image` — the declaration and the identity.
+
+Containerfile assertions are about structure and ordering, never bytes:
+this repo keeps no golden fixtures, and a byte-level test would pin the
+render's prose rather than the properties that matter — what layers
+exist, in what order, derived from which declaration.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lightcone.engine import identity, image, project
+from lightcone.engine.project import ProjectError
+
+_PIN = "3.12.11\n"
+
+
+def _project(root: Path, table: str = "") -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "analysis"\nversion = "0.1.0"\n'
+        'requires-python = ">=3.11"\ndependencies = []\n' + table
+    )
+    (root / ".python-version").write_text(_PIN)
+    (root / "uv.lock").write_text("version = 1\n")
+    return root
+
+
+_DECLARED = """
+[tool.lightcone.image]
+apt-install = ["r-base-core", "bc"]
+run-commands = ["curl -fsSL https://example.org/tool.tar | tar x -C /opt/tool"]
+env = { R_LIBS_SITE = "/opt/rlibs" }
+"""
+
+
+# ---- the declaration --------------------------------------------------------
+
+
+def test_no_table_is_direct_mode(tmp_path: Path) -> None:
+    root = _project(tmp_path / "p")
+    assert image.declaration(root) is None
+    assert image.identity_document(root) is None
+    assert project.mode(root) == "direct"
+
+
+def test_an_empty_table_is_the_escalation(tmp_path: Path) -> None:
+    """The table's presence is the whole trigger — a project may
+    containerize purely for the default system layer."""
+    root = _project(tmp_path / "p", "[tool.lightcone.image]\n")
+    declared = image.declaration(root)
+    assert declared is not None
+    assert declared.base == image.DEFAULT_BASE
+    assert declared.apt_install == ()
+    assert project.mode(root) == "containerized"
+
+
+def test_the_key_surface_is_closed(tmp_path: Path) -> None:
+    """Every key is hashed, so a key nothing implements cannot ride along."""
+    root = _project(tmp_path / "p", "[tool.lightcone.image]\npip-install = [\"numpy\"]\n")
+    with pytest.raises(ProjectError, match="pip-install"):
+        image.declaration(root)
+
+
+def test_a_tag_only_base_is_refused(tmp_path: Path) -> None:
+    root = _project(tmp_path / "p", '[tool.lightcone.image]\nbase = "debian:bookworm-slim"\n')
+    with pytest.raises(ProjectError, match="digest"):
+        image.declaration(root)
+
+
+@pytest.mark.parametrize(
+    "table",
+    [
+        '[tool.lightcone.image]\napt-install = "bc"\n',
+        "[tool.lightcone.image]\nrun-commands = [1]\n",
+        "[tool.lightcone.image]\nenv = { K = 1 }\n",
+        "[tool.lightcone.image]\nbase = 3\n",
+    ],
+)
+def test_a_wrong_type_is_refused(tmp_path: Path, table: str) -> None:
+    with pytest.raises(ProjectError):
+        image.declaration(_project(tmp_path / "p", table))
+
+
+def test_reads_pyproject_only_never_the_uv_config(tmp_path: Path) -> None:
+    """A `uv.toml` replaces `[tool.uv]` — uv's rule about uv's own
+    settings, which must not reach this table."""
+    root = _project(tmp_path / "p", _DECLARED)
+    (root / "uv.toml").write_text("no-build = true\n")
+    declared = image.declaration(root)
+    assert declared is not None and declared.apt_install == ("bc", "r-base-core")
+
+
+# ---- the identity document --------------------------------------------------
+
+
+def test_the_document_is_canonical(tmp_path: Path) -> None:
+    root = _project(tmp_path / "p", _DECLARED)
+    document = image.identity_document(root)
+    assert document is not None
+    parsed = json.loads(document)
+    assert parsed["apt"] == ["bc", "r-base-core"]  # sorted into the identity
+    assert parsed["base"] == image.DEFAULT_BASE
+    assert parsed["env"] == {"R_LIBS_SITE": "/opt/rlibs"}
+    assert parsed["uv"] == image.UV_IMAGE
+    # One spelling: re-serializing canonically reproduces the text.
+    assert document == json.dumps(parsed, sort_keys=True, separators=(",", ":"))
+
+
+def test_absent_keys_hash_as_their_empty_shape(tmp_path: Path) -> None:
+    """A project relying on a default and one spelling it out are the same
+    environment only until the default changes — so the keys are always
+    emitted, the install-settings discipline."""
+    spelled = _project(
+        tmp_path / "a",
+        f'[tool.lightcone.image]\nbase = "{image.DEFAULT_BASE}"\n'
+        "apt-install = []\nrun-commands = []\nenv = {}\n",
+    )
+    bare = _project(tmp_path / "b", "[tool.lightcone.image]\n")
+    assert image.identity_document(spelled) == image.identity_document(bare)
+
+
+# ---- the Containerfile ------------------------------------------------------
+
+
+def test_the_render_layers_in_the_generator_order(tmp_path: Path) -> None:
+    root = _project(tmp_path / "p", _DECLARED)
+    lines = image.containerfile(root).splitlines()
+
+    assert lines[0] == f"FROM {image.DEFAULT_BASE}"
+    order = [
+        next(i for i, line in enumerate(lines) if marker in line)
+        for marker in (
+            "exit 43",  # the glibc contract
+            "exit 44",  # the bash contract
+            "exit 45",  # the apt contract, present because apt-install is
+            "apt-get install",
+            f"COPY --from={image.UV_IMAGE}",
+            "uv python install 3.12.11",
+            "ENV R_LIBS_SITE=",
+            "RUN curl -fsSL",
+            "UV_PYTHON_DOWNLOADS=never",
+            "LABEL io.lightcone.image=",
+        )
+    ]
+    assert order == sorted(order), "the fixed layering moved"
+    # The readability chmod rides inside the layers that write /opt — a
+    # layer of its own would copy-on-write the whole interpreter tree
+    # into every archive.
+    assert "uv python install 3.12.11 && chmod -R a+rX /opt" in image.containerfile(root)
+
+
+def test_apt_layers_exist_only_when_packages_are_declared(tmp_path: Path) -> None:
+    """apt is required iff `apt-install` is nonempty — the engine and the
+    dataset stay on the host, so lc itself needs nothing from apt."""
+    root = _project(tmp_path / "p", "[tool.lightcone.image]\n")
+    text = image.containerfile(root)
+    assert "apt-get" not in text
+    assert "exit 45" not in text
+
+
+def test_the_render_needs_the_interpreter_pin(tmp_path: Path) -> None:
+    root = _project(tmp_path / "p", _DECLARED)
+    (root / ".python-version").unlink()
+    with pytest.raises(ProjectError, match=".python-version"):
+        image.containerfile(root)
+
+
+def test_the_render_refuses_a_direct_project(tmp_path: Path) -> None:
+    with pytest.raises(ProjectError, match="lightcone.image"):
+        image.containerfile(_project(tmp_path / "p"))
+
+
+def test_env_values_are_quoted(tmp_path: Path) -> None:
+    """The label is JSON full of double quotes and an env value may hold
+    spaces — both must survive the Containerfile's own parsing."""
+    root = _project(
+        tmp_path / "p", '[tool.lightcone.image]\nenv = { OPTS = "-a \\"b\\" c" }\n'
+    )
+    text = image.containerfile(root)
+    assert 'ENV OPTS="-a \\"b\\" c"' in text
+    assert 'LABEL io.lightcone.image="{' in text
+
+
+# ---- the tag ----------------------------------------------------------------
+
+
+def test_every_declared_key_moves_the_tag(tmp_path: Path) -> None:
+    tags = {
+        name: image.tag(_project(tmp_path / name, table))
+        for name, table in {
+            "bare": "[tool.lightcone.image]\n",
+            "apt": '[tool.lightcone.image]\napt-install = ["bc"]\n',
+            "run": '[tool.lightcone.image]\nrun-commands = ["true"]\n',
+            "env": '[tool.lightcone.image]\nenv = { K = "v" }\n',
+        }.items()
+    }
+    assert len(set(tags.values())) == len(tags)
+
+
+def test_the_interpreter_pin_moves_the_tag(tmp_path: Path) -> None:
+    """The pin is baked into the image, so it is an input to the tag even
+    though the identity document deliberately omits it."""
+    a = _project(tmp_path / "a", "[tool.lightcone.image]\n")
+    b = _project(tmp_path / "b", "[tool.lightcone.image]\n")
+    (b / ".python-version").write_text("3.13.1\n")
+    assert image.tag(a) != image.tag(b)
+
+
+def test_identical_declarations_are_one_tag_wherever_they_live(tmp_path: Path) -> None:
+    a = _project(tmp_path / "somewhere" / "a", _DECLARED)
+    b = _project(tmp_path / "elsewhere" / "b", _DECLARED)
+    assert image.tag(a) == image.tag(b)
+    assert image.archive_path(a, image.tag(a)) == (
+        a / ".datalad" / "environments" / image.tag(a) / "image"
+    )
+
+
+# ---- env_version integration ------------------------------------------------
+
+
+def test_declaring_an_image_moves_env_version(tmp_path: Path) -> None:
+    """The system layer is part of what a recipe ran under, so declaring
+    one puts every output behind — the model working, not a bug."""
+    direct = _project(tmp_path / "a")
+    containerized = _project(tmp_path / "b", "[tool.lightcone.image]\n")
+    assert identity.env_version(direct) != identity.env_version(containerized)
+
+
+def test_every_image_key_moves_env_version(tmp_path: Path) -> None:
+    bare = identity.env_version(_project(tmp_path / "a", "[tool.lightcone.image]\n"))
+    with_apt = identity.env_version(
+        _project(tmp_path / "b", '[tool.lightcone.image]\napt-install = ["bc"]\n')
+    )
+    assert bare != with_apt
+
+
+def test_other_lightcone_tables_do_not_move_env_version(tmp_path: Path) -> None:
+    """Only the image table is the environment; a sibling table under
+    `[tool.lightcone]` is somebody else's future."""
+    plain = identity.env_version(_project(tmp_path / "a"))
+    with_sibling = identity.env_version(
+        _project(tmp_path / "b", '[tool.lightcone.something-else]\nkey = "v"\n')
+    )
+    assert plain == with_sibling

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -86,6 +86,37 @@ def test_a_wrong_type_is_refused(tmp_path: Path, table: str) -> None:
         image.declaration(_project(tmp_path / "p", table))
 
 
+@pytest.mark.parametrize(
+    "table",
+    [
+        # An apt "name" that is really a command reaches a raw RUN line.
+        '[tool.lightcone.image]\napt-install = ["foo; rm -rf /"]\n',
+        # A key with a space hits Docker's legacy `ENV key value` parse
+        # and silently defines the wrong variable.
+        '[tool.lightcone.image]\nenv = { "A B" = "v" }\n',
+        # A newline in a value splices a Containerfile instruction of its
+        # own into an identity-hashed surface.
+        '[tool.lightcone.image]\nenv = { K = "a\\nUSER root" }\n',
+        '[tool.lightcone.image]\nrun-commands = ["true\\nUSER root"]\n',
+        '[tool.lightcone.image]\nbase = "a b@sha256:0000"\n',
+    ],
+)
+def test_values_that_cannot_render_as_one_line_are_refused(tmp_path: Path, table: str) -> None:
+    """Everything in the declaration is interpolated into Containerfile
+    lines, so structural validation is what keeps the closed surface
+    closed — a value that smuggles an instruction is not a value."""
+    with pytest.raises(ProjectError):
+        image.declaration(_project(tmp_path / "p", table))
+
+
+def test_a_multiline_interpreter_pin_is_refused(tmp_path: Path) -> None:
+    """The pin splices into the install layer's RUN line."""
+    root = _project(tmp_path / "p", "[tool.lightcone.image]\n")
+    (root / ".python-version").write_text("3.12.11\nUSER root\n")
+    with pytest.raises(ProjectError, match="single interpreter"):
+        image.containerfile(root)
+
+
 def test_reads_pyproject_only_never_the_uv_config(tmp_path: Path) -> None:
     """A `uv.toml` replaces `[tool.uv]` — uv's rule about uv's own
     settings, which must not reach this table."""
@@ -175,14 +206,17 @@ def test_the_render_refuses_a_direct_project(tmp_path: Path) -> None:
         image.containerfile(_project(tmp_path / "p"))
 
 
-def test_env_values_are_quoted(tmp_path: Path) -> None:
-    """The label is JSON full of double quotes and an env value may hold
-    spaces — both must survive the Containerfile's own parsing."""
+def test_env_values_are_quoted_and_dollar_is_literal(tmp_path: Path) -> None:
+    """The label is JSON full of double quotes, an env value may hold
+    spaces, and `$` undergoes build-time expansion — measured, an
+    unescaped `cost$5` bakes as `cost`. Declared values are literals."""
     root = _project(
-        tmp_path / "p", '[tool.lightcone.image]\nenv = { OPTS = "-a \\"b\\" c" }\n'
+        tmp_path / "p",
+        '[tool.lightcone.image]\nenv = { OPTS = "-a \\"b\\" c", PRICE = "cost$5" }\n',
     )
     text = image.containerfile(root)
     assert 'ENV OPTS="-a \\"b\\" c"' in text
+    assert 'ENV PRICE="cost\\$5"' in text
     assert 'LABEL io.lightcone.image="{' in text
 
 

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -687,6 +687,76 @@ def _clone(root: Path, into: Path) -> Path:
     return clone
 
 
+_FETCH_SPEC = """
+version: "0.0.13"
+name: analysis
+
+inputs:
+  - id: catalog
+    type: data
+    source: data/catalog.fits
+
+outputs:
+  - id: copy
+    type: metric
+    inputs: [catalog]
+    recipe:
+      command: cat {inputs.catalog} > {output}/copy.txt
+"""
+
+
+def test_a_bytes_free_clone_fetches_its_inputs_and_is_up_to_date(
+    analysis: Callable[..., Path], inline: None, tmp_path: Path
+) -> None:
+    """lc fetches declared inputs rather than telling anyone to — a clone
+    holding only pointers materializes straight to up-to-date, hashing
+    the same bytes the origin recorded. Without the fetch this run
+    *failed*: the worker's hash refused the pointer file."""
+    root = analysis(_FETCH_SPEC, files={"data/catalog.fits": "stars\n"})
+    assert engine.materialize(root, []).ok
+
+    clone = _clone(root, tmp_path)
+    with pytest.raises(assets.ContentNotFetchedError):
+        assets.data_version(clone / "data" / "catalog.fits")
+
+    again = engine.materialize(clone, [])
+
+    assert again.up_to_date, (again.failed, again.warnings)
+    assert assets.data_version(clone / "data" / "catalog.fits")  # the bytes came
+    assert not dataset.status(clone)
+
+
+def test_an_unreachable_input_is_a_warning_and_a_per_task_failure(
+    analysis: Callable[..., Path], inline: None, tmp_path: Path
+) -> None:
+    """A failed fetch must not refuse the whole run — independent tasks
+    still run, and the task whose input is unreachable reports its own
+    failure. Reaching the state honestly: clone, then delete the origin
+    the annex would fetch from."""
+    root = analysis(_FETCH_SPEC, files={"data/catalog.fits": "stars\n"})
+    assert engine.materialize(root, []).ok
+    clone = _clone(root, tmp_path)
+    dataset._git(["remote", "remove", "origin"], cwd=clone)
+
+    report = engine.materialize(clone, [])
+
+    assert not report.ok
+    assert report.failed == ["baseline/copy"]
+    assert any("could not be fetched" in w for w in report.warnings)
+
+
+def test_check_mode_never_fetches(root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--check` and `status` are read-only verbs: an unfetched input is a
+    reported fact there, never a network transfer."""
+
+    def refuse(*args: Any) -> None:
+        raise AssertionError("check mode fetched")
+
+    monkeypatch.setattr(engine, "_fetch_inputs", refuse)
+    engine.check(root, [])
+    engine.status(root)
+
+
 def test_a_drifted_environment_is_made_to_match_before_anything_runs(
     root: Path, inline: None
 ) -> None:

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -712,30 +712,6 @@ def test_a_drifted_environment_is_made_to_match_before_anything_runs(
     assert project_mod._env_is_current(root)
 
 
-@pytest.fixture(scope="session")
-def engine_dist(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, Path]:
-    """Build the engine under test into a wheel the pinned record can find.
-
-    The record pins ``lightcone-cli==<v>`` and the suite's build is not
-    published, so the rerun's ephemeral environment is pointed here via
-    ``UV_FIND_LINKS`` — which is what lets the suite execute the same
-    record shape every real commit carries, rather than a test-only one.
-
-    Returns:
-        The wheel's exact version, and the directory serving it.
-    """
-    dist = tmp_path_factory.mktemp("engine-dist")
-    subprocess.run(
-        ["uv", "build", "--wheel", "--out-dir", str(dist)],
-        cwd=Path(__file__).parent.parent,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    wheel = next(dist.glob("*.whl"))
-    return wheel.name.split("-")[1], dist
-
-
 def test_the_recorded_command_reproduces_the_output(
     root: Path,
     inline: None,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -122,6 +122,32 @@ def test_converge_scaffolds_no_environment_escalation(tmp_path: Path) -> None:
     assert "[tool.lightcone.image]" not in (project / "pyproject.toml").read_text()
 
 
+def test_a_containerized_project_converges_no_host_venv(
+    tmp_path: Path, tools: list[list[str]]
+) -> None:
+    """The host sync is the host-sync deadlock in miniature: the lock's
+    system-level dependencies — the reason the project containerized at
+    all — are not on the host, so a host `uv sync` fails and `--check`
+    would report unconverged forever. The verbs converge the environment
+    inside the image instead; init owes neither podman nor minutes."""
+    project = tmp_path / "proj"
+    converge(project)
+    text = (project / "pyproject.toml").read_text()
+    (project / "pyproject.toml").write_text(
+        text + '\n[tool.lightcone.image]\napt-install = ["bc"]\n'
+    )
+    shutil.rmtree(project / ".venv")
+
+    report = converge(project)
+
+    assert ".venv" not in [*report.created, *report.repaired, *report.unchanged]
+    assert report.converged
+    assert not (project / ".venv").exists()
+    # The lock still converges: locking is resolution, which the bare
+    # host can do in both modes.
+    assert "uv.lock" in report.unchanged
+
+
 def test_converge_scaffolds_no_src_directory(tmp_path: Path) -> None:
     """astra stopped creating it (astra-tools#100) and so do we: the
     boilerplate's `python src/main.py` is a TODO placeholder, and git drops

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -78,6 +78,17 @@ def test_an_unbuilt_project_is_told_to_build_it(project: Path) -> None:
     assert "lc init" in str(raised.value)
 
 
+def test_a_containerized_project_needs_no_host_venv(project: Path) -> None:
+    """The host `.venv` is inert in containerized mode — the environment
+    the verbs enter is `.lightcone/venv`, created by their own converge
+    inside the image — so a clone is runnable without it."""
+    (project / ".venv").rmdir()
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "proj"\n\n[tool.lightcone.image]\napt-install = ["bc"]\n'
+    )
+    assert current_project(project) == project.resolve()
+
+
 def test_the_wrong_directory_is_told_to_move_not_to_scaffold(tmp_path: Path) -> None:
     """The complaint that produced this split: standing in `$HOME`, being
     told to run `lc init` is advice to scaffold a project in your home

--- a/tests/test_sandbox_denial.py
+++ b/tests/test_sandbox_denial.py
@@ -69,6 +69,11 @@ def test_an_undeclared_tool_is_named_with_its_remedy(policy: Policy, project: Pa
     joined = "\n".join(lines)
     assert f"cannot execute {tool}" in joined
     assert "uv add" in joined
+    # The system-layer remedy is real now — `lc build` exists — so the
+    # standing cap on remedies makes naming it mandatory, not optional.
+    assert "[tool.lightcone.image]" in joined
+    assert "apt-install" in joined
+    assert "behind" in joined
 
 
 def test_an_undeclared_data_file_gets_the_astra_snippet(

--- a/tests/test_sandbox_oci.py
+++ b/tests/test_sandbox_oci.py
@@ -1,0 +1,236 @@
+"""Tests for the OCI backend — the mount table as the mechanism.
+
+Pure, and run on every OS: the wrap is a function of the policy and the
+backend's fields, so the argv a containerized recipe would get is checked
+here with nothing spawned and no runtime installed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lightcone.engine.sandbox import boundary, exec_policy
+from lightcone.engine.sandbox.boundary import Unavailable
+from lightcone.engine.sandbox.model import Policy
+from lightcone.engine.sandbox.oci import OCIBackend
+
+_IMAGE_ID = "956ea01f6c5b94522bedc346c9646f81d0707b2a00b2a9ed8b4e5b6a8d2d00d1"
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    project = tmp_path / "analysis"
+    (project / "results").mkdir(parents=True)
+    (project / "data").mkdir()
+    (project / "data" / "catalog.fits").write_text("stars\n")
+    return project
+
+
+@pytest.fixture
+def policy(root: Path) -> Policy:
+    built = exec_policy(
+        root,
+        read_paths=[root / "data" / "catalog.fits"],
+        env_dir=root / ".lightcone" / "venv",
+        containerized=True,
+    )
+    yield built
+    import shutil
+
+    shutil.rmtree(built.tmp_home, ignore_errors=True)
+
+
+def _backend(runtime: str = "podman", **kwargs: Any) -> OCIBackend:
+    flags = ("--userns=keep-id", "--pull=never") if runtime == "podman" else ("--user", "1000:1000")
+    return OCIBackend(
+        runtime=runtime,  # type: ignore[arg-type]
+        image_id=_IMAGE_ID,
+        root=kwargs.pop("root"),
+        user_flags=flags,
+    )
+
+
+# ---- the containerized policy shape ----------------------------------------
+
+
+def test_the_containerized_policy_is_the_project_world_only(root: Path, policy: Policy) -> None:
+    """The image is the OS baseline and the exec set — everything present
+    in it was declared — so the path sets carry only what becomes mounts."""
+    assert all(str(p).startswith(str(root)) for p in policy.read)
+    assert policy.execute == ()
+    assert root.resolve() in policy.read
+    assert (root / "results").resolve() in policy.write
+    assert policy.tmp_home in policy.write
+
+
+def test_the_containerized_home_lives_under_the_project(root: Path, policy: Policy) -> None:
+    """It is a mount source, and on macOS the podman machine shares the
+    project's tree while the host's temp roots arrive empty."""
+    assert policy.tmp_home.is_relative_to((root / ".lightcone").resolve())
+
+
+def test_the_overlay_points_uv_at_the_image_environment(root: Path, policy: Policy) -> None:
+    """The `uv run` hop executes inside the container; this is how it
+    finds `.lightcone/venv` instead of inventing a `.venv`."""
+    env_dir = root / ".lightcone" / "venv"
+    assert policy.env["UV_PROJECT_ENVIRONMENT"] == str(env_dir)
+    assert policy.env["PATH"].startswith(str(env_dir / "bin"))
+    # The PATH tail is the image's own FHS, never the host allowlist
+    # search path — whose NixOS entry no Debian-family image has.
+    assert "/run/current-system" not in policy.env["PATH"]
+
+
+# ---- the wrap ---------------------------------------------------------------
+
+
+def test_wrap_is_pure(root: Path, policy: Policy, tmp_path: Path) -> None:
+    before = set(tmp_path.rglob("*"))
+    backend = _backend(root=root)
+    assert backend.wrap(policy, ["true"]) == backend.wrap(policy, ["true"])
+    assert set(tmp_path.rglob("*")) == before
+
+
+def test_reads_mount_ro_and_writes_mount_rw(root: Path, policy: Policy) -> None:
+    argv = _backend(root=root).wrap(policy, ["true"])
+    assert f"--volume={root.resolve()}:{root.resolve()}:ro" in argv
+    results = (root / "results").resolve()
+    assert f"--volume={results}:{results}:rw" in argv
+    catalog = (root / "data" / "catalog.fits").resolve()
+    assert f"--volume={catalog}:{catalog}:ro" in argv
+    # Read mounts land before write mounts, so the writable results
+    # directory nests over the read-only tree the way the runtimes
+    # resolve natively.
+    assert argv.index(f"--volume={root.resolve()}:{root.resolve()}:ro") < argv.index(
+        f"--volume={results}:{results}:rw"
+    )
+
+
+def test_execution_pins_the_image_by_id_never_a_tag(root: Path, policy: Policy) -> None:
+    argv = _backend(root=root).wrap(policy, ["bash", "-c", "true"])
+    assert _IMAGE_ID in argv
+    assert argv[argv.index(_IMAGE_ID) + 1 :] == ["bash", "-c", "true"]
+    assert not any("lc-env-" in part for part in argv)
+
+
+def test_the_network_is_denied_by_flag(root: Path, policy: Policy) -> None:
+    argv = _backend(root=root).wrap(policy, ["true"])
+    assert "--network" in argv and argv[argv.index("--network") + 1] == "none"
+
+
+def test_runtimes_differ_only_in_their_spellings(root: Path, policy: Policy) -> None:
+    podman = _backend("podman", root=root).wrap(policy, ["true"])
+    docker = _backend("docker", root=root).wrap(policy, ["true"])
+    assert "--userns=keep-id" in podman and "--pull=never" in podman
+    assert "--user" in docker and "1000:1000" in docker
+    strip = {
+        "--userns=keep-id", "--pull=never", "--user", "1000:1000", "podman", "docker",
+        "--env=LC_SANDBOX=podman", "--env=LC_SANDBOX=docker",
+    }  # fmt: skip
+    assert [a for a in podman if a not in strip] == [a for a in docker if a not in strip]
+
+
+def test_the_environment_is_an_allowlist_never_ambient(
+    root: Path, policy: Policy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A secret in the invoking shell must never reach the container."""
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "hunter2")
+    argv = _backend(root=root).wrap(policy, ["true"])
+    assert not any("hunter2" in part or "AWS_SECRET" in part for part in argv)
+    for key, value in policy.env.items():
+        assert f"--env={key}={value}" in argv
+    assert "--env=LC_SANDBOX=podman" in argv
+
+
+def test_no_host_resolved_env_binary_in_the_argv(root: Path, policy: Policy) -> None:
+    """The overlay travels as `--env` flags: a host path for `env` (NixOS
+    keeps it under /run/current-system/sw) need not exist in the image,
+    and argv[0] dying there would blame the user's command."""
+    argv = _backend(root=root).wrap(policy, ["true"])
+    assert not any(part.endswith("/env") for part in argv)
+
+
+# ---- the attestation --------------------------------------------------------
+
+
+def test_the_attestation_is_derived_from_the_flags(root: Path, policy: Policy) -> None:
+    for runtime in ("podman", "docker"):
+        attested = _backend(runtime, root=root).attest(policy)
+        assert attested.mechanism == runtime
+        assert attested.fs == "declared"
+        assert attested.network == "denied"
+        assert attested.landlock_abi is None
+
+
+# ---- the seam's composition -------------------------------------------------
+
+
+class _Recorder:
+    """A Popen stand-in that records the argv and exits cleanly."""
+
+    def __init__(self) -> None:
+        self.argv: list[str] | None = None
+
+    def __call__(self, argv: list[str], **kwargs: Any) -> Any:
+        self.argv = list(argv)
+
+        class _Proc:
+            import io
+
+            stderr = io.StringIO("")
+            returncode = 0
+
+            def wait(self) -> int:
+                return 0
+
+        return _Proc()
+
+
+def test_a_world_backend_takes_the_prefix_inside(
+    root: Path, policy: Policy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In a container there is no trusted host plumbing: the `uv run` hop
+    is part of the world being entered, so it lands after the image in
+    the argv rather than in front of the runtime."""
+    recorder = _Recorder()
+    monkeypatch.setattr(subprocess, "Popen", recorder)
+
+    boundary.run(
+        _backend(root=root),
+        policy,
+        ["bash", "-c", "true"],
+        cwd=root,
+        env={},
+        prefix=["uv", "run", "--locked", "--no-sync", "--project", str(root), "--"],
+    )
+
+    assert recorder.argv is not None
+    assert recorder.argv[0] == "podman"
+    assert recorder.argv[recorder.argv.index(_IMAGE_ID) + 1 :] == [
+        "uv", "run", "--locked", "--no-sync", "--project", str(root), "--",
+        "bash", "-c", "true",
+    ]  # fmt: skip
+
+
+def test_a_host_backend_keeps_the_prefix_outside(
+    root: Path, policy: Policy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The existing composition, pinned: uv's config and caches are
+    trusted plumbing outside a host mechanism's rewrite."""
+    recorder = _Recorder()
+    monkeypatch.setattr(subprocess, "Popen", recorder)
+
+    boundary.run(
+        Unavailable(),
+        policy,
+        ["bash", "-c", "true"],
+        cwd=root,
+        env={},
+        prefix=["uv", "run", "--"],
+    )
+
+    assert recorder.argv is not None
+    assert recorder.argv[:3] == ["uv", "run", "--"]

--- a/tests/test_sandbox_oci.py
+++ b/tests/test_sandbox_oci.py
@@ -44,12 +44,12 @@ def policy(root: Path) -> Policy:
     shutil.rmtree(built.tmp_home, ignore_errors=True)
 
 
-def _backend(runtime: str = "podman", **kwargs: Any) -> OCIBackend:
+def _backend(root: Path, runtime: str = "podman") -> OCIBackend:
     flags = ("--userns=keep-id", "--pull=never") if runtime == "podman" else ("--user", "1000:1000")
     return OCIBackend(
         runtime=runtime,  # type: ignore[arg-type]
         image_id=_IMAGE_ID,
-        root=kwargs.pop("root"),
+        root=root,
         user_flags=flags,
     )
 
@@ -91,13 +91,13 @@ def test_the_overlay_points_uv_at_the_image_environment(root: Path, policy: Poli
 
 def test_wrap_is_pure(root: Path, policy: Policy, tmp_path: Path) -> None:
     before = set(tmp_path.rglob("*"))
-    backend = _backend(root=root)
+    backend = _backend(root)
     assert backend.wrap(policy, ["true"]) == backend.wrap(policy, ["true"])
     assert set(tmp_path.rglob("*")) == before
 
 
 def test_reads_mount_ro_and_writes_mount_rw(root: Path, policy: Policy) -> None:
-    argv = _backend(root=root).wrap(policy, ["true"])
+    argv = _backend(root).wrap(policy, ["true"])
     assert f"--volume={root.resolve()}:{root}:ro" in argv
     results = root / "results"
     assert f"--volume={results.resolve()}:{results}:rw" in argv
@@ -130,7 +130,7 @@ def test_a_symlinked_input_mounts_at_its_declared_path(root: Path, tmp_path: Pat
         containerized=True,
     )
     try:
-        argv = _backend(root=root).wrap(built, ["true"])
+        argv = _backend(root).wrap(built, ["true"])
         assert f"--volume={store / 'catalog.h5'}:{declared}:ro" in argv
     finally:
         import shutil
@@ -143,27 +143,27 @@ def test_the_rootfs_is_read_only_and_labels_are_disabled(root: Path, policy: Pol
     *succeeds* into the container's ephemeral layer and vanishes, while
     the run attests `fs: declared` — the silent-loss path. And
     `label=disable`: SELinux hosts otherwise refuse every bind read."""
-    argv = _backend(root=root).wrap(policy, ["true"])
+    argv = _backend(root).wrap(policy, ["true"])
     assert "--read-only" in argv
     assert "--security-opt" in argv
     assert argv[argv.index("--security-opt") + 1] == "label=disable"
 
 
 def test_execution_pins_the_image_by_id_never_a_tag(root: Path, policy: Policy) -> None:
-    argv = _backend(root=root).wrap(policy, ["bash", "-c", "true"])
+    argv = _backend(root).wrap(policy, ["bash", "-c", "true"])
     assert _IMAGE_ID in argv
     assert argv[argv.index(_IMAGE_ID) + 1 :] == ["bash", "-c", "true"]
     assert not any("lc-env-" in part for part in argv)
 
 
 def test_the_network_is_denied_by_flag(root: Path, policy: Policy) -> None:
-    argv = _backend(root=root).wrap(policy, ["true"])
+    argv = _backend(root).wrap(policy, ["true"])
     assert "--network" in argv and argv[argv.index("--network") + 1] == "none"
 
 
 def test_runtimes_differ_only_in_their_spellings(root: Path, policy: Policy) -> None:
-    podman = _backend("podman", root=root).wrap(policy, ["true"])
-    docker = _backend("docker", root=root).wrap(policy, ["true"])
+    podman = _backend(root, "podman").wrap(policy, ["true"])
+    docker = _backend(root, "docker").wrap(policy, ["true"])
     assert "--userns=keep-id" in podman and "--pull=never" in podman
     assert "--user" in docker and "1000:1000" in docker
     strip = {
@@ -178,7 +178,7 @@ def test_the_environment_is_an_allowlist_never_ambient(
 ) -> None:
     """A secret in the invoking shell must never reach the container."""
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "hunter2")
-    argv = _backend(root=root).wrap(policy, ["true"])
+    argv = _backend(root).wrap(policy, ["true"])
     assert not any("hunter2" in part or "AWS_SECRET" in part for part in argv)
     for key, value in policy.env.items():
         assert f"--env={key}={value}" in argv
@@ -189,7 +189,7 @@ def test_no_host_resolved_env_binary_in_the_argv(root: Path, policy: Policy) -> 
     """The overlay travels as `--env` flags: a host path for `env` (NixOS
     keeps it under /run/current-system/sw) need not exist in the image,
     and argv[0] dying there would blame the user's command."""
-    argv = _backend(root=root).wrap(policy, ["true"])
+    argv = _backend(root).wrap(policy, ["true"])
     assert not any(part.endswith("/env") for part in argv)
 
 
@@ -198,7 +198,7 @@ def test_no_host_resolved_env_binary_in_the_argv(root: Path, policy: Policy) -> 
 
 def test_the_attestation_is_derived_from_the_flags(root: Path, policy: Policy) -> None:
     for runtime in ("podman", "docker"):
-        attested = _backend(runtime, root=root).attest(policy)
+        attested = _backend(root, runtime).attest(policy)
         assert attested.mechanism == runtime
         assert attested.fs == "declared"
         assert attested.network == "denied"
@@ -241,7 +241,7 @@ def test_a_world_backend_takes_the_prefix_inside(
     monkeypatch.setattr(subprocess, "Popen", recorder)
 
     boundary.run(
-        _backend(root=root),
+        _backend(root),
         policy,
         ["bash", "-c", "true"],
         cwd=root,
@@ -285,7 +285,7 @@ def test_exit_97_is_the_shims_only_under_landlock(
     container — a recipe legitimately exiting 97 must not be told lc
     could not set up the sandbox."""
     monkeypatch.setattr(subprocess, "Popen", _Recorder(returncode=97))
-    outcome = boundary.run(_backend(root=root), policy, ["true"], cwd=root, env={})
+    outcome = boundary.run(_backend(root), policy, ["true"], cwd=root, env={})
     assert not any("could not set up" in note for note in outcome.notes)
 
 
@@ -296,6 +296,6 @@ def test_exit_125_names_the_runtime_not_the_command(
     never ran, so neither the denial heuristics nor the trailer should
     point at it."""
     monkeypatch.setattr(subprocess, "Popen", _Recorder(returncode=125))
-    outcome = boundary.run(_backend(root=root), policy, ["true"], cwd=root, env={})
+    outcome = boundary.run(_backend(root), policy, ["true"], cwd=root, env={})
     assert any("runtime failed before the command ran" in note for note in outcome.notes)
     assert not any("ran under the lc sandbox" in note for note in outcome.notes)

--- a/tests/test_sandbox_oci.py
+++ b/tests/test_sandbox_oci.py
@@ -59,11 +59,13 @@ def _backend(runtime: str = "podman", **kwargs: Any) -> OCIBackend:
 
 def test_the_containerized_policy_is_the_project_world_only(root: Path, policy: Policy) -> None:
     """The image is the OS baseline and the exec set — everything present
-    in it was declared — so the path sets carry only what becomes mounts."""
+    in it was declared — so the path sets carry only what becomes mounts.
+    Declared spellings, deliberately unresolved: they become mount
+    *destinations*, and the recipe addresses the declared path."""
     assert all(str(p).startswith(str(root)) for p in policy.read)
     assert policy.execute == ()
-    assert root.resolve() in policy.read
-    assert (root / "results").resolve() in policy.write
+    assert root in policy.read
+    assert root / "results" in policy.write
     assert policy.tmp_home in policy.write
 
 
@@ -96,17 +98,55 @@ def test_wrap_is_pure(root: Path, policy: Policy, tmp_path: Path) -> None:
 
 def test_reads_mount_ro_and_writes_mount_rw(root: Path, policy: Policy) -> None:
     argv = _backend(root=root).wrap(policy, ["true"])
-    assert f"--volume={root.resolve()}:{root.resolve()}:ro" in argv
-    results = (root / "results").resolve()
-    assert f"--volume={results}:{results}:rw" in argv
-    catalog = (root / "data" / "catalog.fits").resolve()
-    assert f"--volume={catalog}:{catalog}:ro" in argv
+    assert f"--volume={root.resolve()}:{root}:ro" in argv
+    results = root / "results"
+    assert f"--volume={results.resolve()}:{results}:rw" in argv
+    catalog = root / "data" / "catalog.fits"
+    assert f"--volume={catalog.resolve()}:{catalog}:ro" in argv
     # Read mounts land before write mounts, so the writable results
     # directory nests over the read-only tree the way the runtimes
     # resolve natively.
-    assert argv.index(f"--volume={root.resolve()}:{root.resolve()}:ro") < argv.index(
-        f"--volume={results}:{results}:rw"
+    assert argv.index(f"--volume={root.resolve()}:{root}:ro") < argv.index(
+        f"--volume={results.resolve()}:{results}:rw"
     )
+
+
+def test_a_symlinked_input_mounts_at_its_declared_path(root: Path, tmp_path: Path) -> None:
+    """The HPC case: `/data` is a symlink into a shared store. The bind's
+    source must be the real file, but the destination is the path the
+    analysis declared — resolving both would leave the container with no
+    `/data` at all and the recipe's literal path ENOENT."""
+    store = tmp_path / "store"
+    store.mkdir()
+    (store / "catalog.h5").write_text("stars\n")
+    link = tmp_path / "data-link"
+    link.symlink_to(store)
+    declared = link / "catalog.h5"
+
+    built = exec_policy(
+        root,
+        read_paths=[declared],
+        env_dir=root / ".lightcone" / "venv",
+        containerized=True,
+    )
+    try:
+        argv = _backend(root=root).wrap(built, ["true"])
+        assert f"--volume={store / 'catalog.h5'}:{declared}:ro" in argv
+    finally:
+        import shutil
+
+        shutil.rmtree(built.tmp_home, ignore_errors=True)
+
+
+def test_the_rootfs_is_read_only_and_labels_are_disabled(root: Path, policy: Policy) -> None:
+    """`--read-only`: without it a write outside the declared set
+    *succeeds* into the container's ephemeral layer and vanishes, while
+    the run attests `fs: declared` — the silent-loss path. And
+    `label=disable`: SELinux hosts otherwise refuse every bind read."""
+    argv = _backend(root=root).wrap(policy, ["true"])
+    assert "--read-only" in argv
+    assert "--security-opt" in argv
+    assert argv[argv.index("--security-opt") + 1] == "label=disable"
 
 
 def test_execution_pins_the_image_by_id_never_a_tag(root: Path, policy: Policy) -> None:
@@ -169,22 +209,24 @@ def test_the_attestation_is_derived_from_the_flags(root: Path, policy: Policy) -
 
 
 class _Recorder:
-    """A Popen stand-in that records the argv and exits cleanly."""
+    """A Popen stand-in that records the argv and exits as told."""
 
-    def __init__(self) -> None:
+    def __init__(self, returncode: int = 0) -> None:
         self.argv: list[str] | None = None
+        self.returncode = returncode
 
     def __call__(self, argv: list[str], **kwargs: Any) -> Any:
         self.argv = list(argv)
+        code = self.returncode
 
         class _Proc:
             import io
 
             stderr = io.StringIO("")
-            returncode = 0
+            returncode = code
 
             def wait(self) -> int:
-                return 0
+                return code
 
         return _Proc()
 
@@ -234,3 +276,26 @@ def test_a_host_backend_keeps_the_prefix_outside(
 
     assert recorder.argv is not None
     assert recorder.argv[:3] == ["uv", "run", "--"]
+
+
+def test_exit_97_is_the_shims_only_under_landlock(
+    root: Path, policy: Policy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """97 is the shim's reserved code, and there is no shim in a
+    container — a recipe legitimately exiting 97 must not be told lc
+    could not set up the sandbox."""
+    monkeypatch.setattr(subprocess, "Popen", _Recorder(returncode=97))
+    outcome = boundary.run(_backend(root=root), policy, ["true"], cwd=root, env={})
+    assert not any("could not set up" in note for note in outcome.notes)
+
+
+def test_exit_125_names_the_runtime_not_the_command(
+    root: Path, policy: Policy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The runtimes reserve 125 for their own failures — the command
+    never ran, so neither the denial heuristics nor the trailer should
+    point at it."""
+    monkeypatch.setattr(subprocess, "Popen", _Recorder(returncode=125))
+    outcome = boundary.run(_backend(root=root), policy, ["true"], cwd=root, env={})
+    assert any("runtime failed before the command ran" in note for note in outcome.notes)
+    assert not any("ran under the lc sandbox" in note for note in outcome.notes)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from lightcone.engine import assets, identity, plan, worker
+from lightcone.engine import assets, container, identity, plan, worker
 from lightcone.engine.sandbox import Unavailable
 from lightcone.engine.worker import TaskResult
 
@@ -62,13 +62,25 @@ def _task(root: Path, output_id: str) -> plan.Task:
 _HEAD = ("0123456789abcdef", "https://example/analysis.git")
 
 
+def _runtime(root: Path) -> container.Runtime:
+    """The direct-mode runtime the driver would resolve for these projects."""
+    return container.runtime_for_run(root, build=False)
+
+
 def _make(
     root: Path, output_id: str, *upstream: TaskResult, refresh: bool = False
 ) -> TaskResult:
     """Run one task the way Dask would, handed its upstream results."""
     task = _task(root, output_id)
     return worker.materialize(
-        root, task, identity.env_version(root), _HEAD, assets.Versions(), refresh, *upstream
+        root,
+        task,
+        identity.env_version(root),
+        _HEAD,
+        assets.Versions(),
+        refresh,
+        _runtime(root),
+        *upstream,
     )
 
 
@@ -236,7 +248,10 @@ def test_a_stale_file_does_not_survive_a_rebuild(root: Path) -> None:
     output = root / "results/baseline/first"
     (output / "leftover.txt").write_text("from a previous run\n")
 
-    worker.execute(root, _task(root, "first"), identity.env_version(root), {}, head=_HEAD)
+    worker.execute(
+        root, _task(root, "first"), identity.env_version(root), {}, head=_HEAD,
+        runtime=_runtime(root),
+    )
 
     assert not (output / "leftover.txt").exists()
     assert (output / "value.txt").exists()
@@ -295,7 +310,8 @@ def test_an_environment_that_moved_under_the_run_is_refused(root: Path) -> None:
     """A manifest may not claim an environment that had already been edited
     by the time the recipe ran."""
     result = worker.execute(
-        root, _task(root, "first"), "sha256:from-another-run", {}, head=_HEAD
+        root, _task(root, "first"), "sha256:from-another-run", {}, head=_HEAD,
+        runtime=_runtime(root),
     )
 
     assert result.status == "failed"


### PR DESCRIPTION
## What this is

The container hatch, landed whole: declaration, identity, `lc build`, containerized `lc run` and `lc materialize`, manifest v2, and the `lc status` headers. The design decisions were taken interactively and are recorded in CLAUDE.md; the load-bearing ones:

- **Engine on host.** The container is the *recipe's* execution world, never the engine's — driver, git, annex, dask and classification all stay the invoked `lc`. This deviates from spec v6.1's full-stack-in-image rule, recorded: v6.1's reason (the host-sync deadlock) is solved by converging `.lightcone/venv` *inside* the image, and the spec's own Perlmutter row ("recipe wrap, step 3 only") is this exact shape. No delegation machinery, no git through a `--userns=keep-id` bind mount, no engine version in the image tag.
- **The user never sees a Containerfile.** The whole surface is Modal-shaped TOML — `base` / `apt-install` / `run-commands` / `env`, a closed, fully-hashed key set (`pip_install` deliberately has no equivalent; the lock owns Python). The render exists only in a transient build context; `LABEL io.lightcone.image` keeps the image self-describing.
- **The dataset is the image store; runtime stores are caches.** `lc build` saves the image as a docker-archive at `.datalad/environments/<tag>/image` (the `datalad containers-add` layout), annexed and committed — exact bytes to every clone via `git annex get`, no registry. Execution pins the id read from the archive itself. A dropped archive never substitutes; a rebuild is a new commit under a new id.
- **The mount table is the mechanism.** One `OCIBackend` (podman recommended, docker accepted — data-parameterized spellings, one shape) maps the same `Policy` to `:ro`/`:rw` mounts with `--network none`; the attestation (`fs: declared`, `network: denied`) is derived flag-for-flag. No in-container Landlock, no seccomp probe: the engine container never gets the tree `:rw`, so mounts alone express the whole policy. The archive format is chosen so apptainer/singularity become thin layer-7 backends.
- **The record stays runtime-neutral through the worker.** Verified against datalad-container's source: templates expand at *record* time and `rerun` executes the literal string, so a bare-recipe `cmd` was rejected. The containerized record adds `extra_inputs: [<archive>]`, which stock `datalad rerun` fetches through the annex before executing.

## Notable traps found on the way

- git-annex routes dotfiles to git regardless of `annex.largefiles` — without a per-add `annex.dotfiles=true` the archive lands as a full git blob, silently. Pinned both ways in `test_dataset.py`.
- A standalone `chmod -R /opt` layer copy-on-writes the whole interpreter into every archive, doubling it; the chmod rides inside the layers that write `/opt`.
- `boundary.env_argv`'s host-resolved `env` binary need not exist in the image (NixOS), so world-backends apply the overlay natively via `--env` (`contains_prefix`, declared on every backend).
- The dirty check now runs *before* the converge in materialize: the image commit would otherwise sweep the user's staged edits.

## Testing

- `tests/test_image.py`, `test_sandbox_oci.py` — pure (declaration, document, render ordering, tag sensitivity, mounts, attestation, seam composition).
- `tests/test_container.py` — the lifecycle against a stubbed `project._run` (three `ensure_image` strictnesses, refusals mutation-checked, build/save/commit argv).
- `tests/test_container_smoke.py` — real podman end to end, gated (`skipif` + `LC_CONTAINER_TESTS_REQUIRED=1` on Linux CI + two guard tests): build → id/label verification → probe (refusal → success → mount denial → loopback/egress) → full materialize with manifest assertions → **`datalad rerun` on a bytes-free clone fetching the archive through the annex and reproducing the output**.
- 483 tests pass; ruff and mypy clean; `lc --help` still 65 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oVCfc4eZdyKqT1zY95Xi2