### PR TITLE
Layer 7: venues — SLURM in-allocation execution and podman-hpc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1578,11 +1578,18 @@ count refuses naming the variable (`venue._int_env`), and a
 the bind rather than the raw `socket.gaierror` (distributed wraps it in
 a `RuntimeError`, so the constructor catches both).
 
-**The login guard is materialize-scoped and comes first.**
-`venue.require_compute_node()` refuses iff `NERSC_HOST` is set and
-`SLURM_JOB_ID` is not (NERSC_HOST is set on compute nodes too; the
-allocation is what distinguishes them), naming copy-pasteable `salloc`
-and `sbatch --wrap 'lc materialize'` commands. It is the first line of
+**The login guard is materialize-scoped, table-driven, and comes
+first.** `venue.require_compute_node()` refuses iff a known center's
+marker is in the environment and `SLURM_JOB_ID` is not (a marker is set
+on compute nodes too; the allocation is what distinguishes them),
+naming that center's copy-pasteable `salloc` and `sbatch --wrap 'lc
+materialize'` commands. The centers live in `venue._SITES` — one row
+each: name, marker variable, and the center's own allocation spellings,
+**verified against the center's documentation, never guessed** (the
+remedies rule). NERSC is the seeded row; supporting another center is
+one row, and nothing else moves — the conftest scrub derives its marker
+list from the table, and `test_a_new_center_is_one_table_row` pins that
+the row alone drives the message. The guard is the first line of
 `materialize()`, before even the tool checks: the allocation is the
 remedy with queue latency, so the user submits it first and fixes
 whatever later refusals name while waiting. The rerun entry point

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1593,13 +1593,17 @@ node is exactly where "where does this project stand" gets asked.
 
 **Containerized runs assume a homogeneous allocation**, and the one
 part of that lc can check is *enforced*: a multi-node allocation with a
-containerized project **refuses** unless the runtime is podman-hpc,
-because podman's and docker's stores are node-local — the image loads on
-the driver's node only, and every task scheduled elsewhere would fail at
-`run <id>` with `--pull=never` forbidding the fetch. The check sits in
-`materialize()` before the runtime resolves (a refusal must not cost an
-image build) and not in `runtime_for_run` (the rerun entry point shares
-that, and a rerun is a one-node run wherever it sits). The rest stays a
+containerized project **refuses** unless the runtime's image store spans
+nodes — `container._SHARED_STORE_RUNTIMES`, a positively-stated fact
+like `_PODMAN_FAMILY`, holding podman-hpc alone — because podman's and
+docker's stores are node-local: the image loads on the driver's node
+only, and every task scheduled elsewhere would fail at `run <id>` with
+`--pull=never` forbidding the fetch. The check sits in `materialize()`
+before the runtime resolves (a refusal must not cost an image build, so
+it asks `runtime_hint()`, letting a wholly missing runtime reach
+`runtime_for_run`'s own refusal) and not in `runtime_for_run` (the rerun
+entry point shares that, and a rerun is a one-node run wherever it
+sits). The rest stays a
 recorded assumption: every node offers the same runtime binary and sees
 the shared-filesystem project tree. podman-hpc is what makes multi-node
 true on NERSC — `migrate` squashes the image to the shared filesystem,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ speculatively.
 | 4 | **Fabric** — `lc materialize`, worker sequence, mid-run relock gate | ✅ **done** |
 | 5 | **Sandbox layer** — Landlock / Seatbelt, exec-shim, denial UX, `lc run` | ✅ **done** |
 | 6 | **Container hatch** — `[tool.lightcone.image]`, `lc build`, OCI runtimes as the exec boundary, the image archived in the dataset | ✅ **done** |
-| 7 | Venues — Perlmutter, hub/GKE, Cloud Build | ⬜ |
+| 7 | **Venues** — SLURM in-allocation execution, login guard, podman-hpc | 🔶 **landed; Perlmutter spike pending** — hub/GKE and Cloud Build deferred to their own layer |
 | 8 | `lc verify`, WRROC export | ⬜ |
 
 `lc status` landed with the invalidation model rather than at layer 8:
@@ -1415,7 +1415,8 @@ layer-7 item, as is apptainer/singularity — which is *why* the format is
 `docker-archive`: all four runtimes consume it, and HPC hosts that
 cannot build obtain images through the repository.
 
-**`ensure_image` is one function with three strictnesses**, and the split
+**`runtime_for_run(root, *, build)` is one function with two
+strictnesses**, and the split
 is load-bearing: `lc build` and the materialize preflight may **build +
 save + commit** (announced by the CLI, which owns the console — the
 engine never prints); the probe and the worker entry point only ever
@@ -1431,7 +1432,7 @@ cannot substitute. **A dropped archive never substitutes**: a rebuild is
 a new archive commit under a new id; old manifests keep naming what ran.
 
 **Builds and the archive commit happen only on a clean tree, and only
-after the graph.** The dirty check runs before `ensure_image` in
+after the graph.** The dirty check runs before `runtime_for_run` in
 materialize, and `lc build` refuses dirt itself: `dataset.save` stages
 scoped but commits the whole index, so a build on a dirty tree would
 sweep the user's staged edits into the image commit — and the tag
@@ -1520,6 +1521,136 @@ state, sandbox) — repository facts only, no runtime and no network
 required, which is where the denial note and the runtime-missing
 refusal point.
 
+## Key Invariants (layer 7)
+
+**The venue is detected, never configured, and only in one place.**
+`cluster_for_run()` is the whole ladder — a SLURM allocation
+(`SLURM_JOB_ID` set) spans every node it was granted, anything else is
+the local machine — and nothing outside that function asks where a run
+executes. The allocation *is* the resource declaration: the user already
+answered every sizing question at `salloc`/`sbatch`, so lc adds no venue
+config surface, no report field, and no status line (a venue is host
+state, and the status header is repository facts). The venue speaks only
+when it refuses, and those refusals carry the job facts (nodes expected
+vs connected, srun's exit code). A future submission-model venue
+(dask-jobqueue) is one more branch in this ladder plus the config table
+it genuinely needs — nothing else changes.
+
+**The allocation branch is `venue.slurm_client()`**: a scheduler in the
+driver process bound to `SLURMD_NODENAME` (the default loopback bind is
+unreachable from peer nodes), one `srun --overlap --ntasks=<nodes>
+--ntasks-per-node=1` launching `sys.executable -m
+distributed.cli.dask_worker` — the driver's own interpreter, the tool
+env on the shared filesystem, so driver and workers are the identical
+installation and `-m` cannot resolve to a different install the way a
+PATH-found `dask` can. One worker process per node with
+`--nthreads=<cpus>` (tasks block in `subprocess.wait()` with the GIL
+released — the local branch's own rationale), `--no-nanny` (srun won't
+relaunch either; the nanny logs a spurious death on every clean
+retirement), `--memory-limit 0` (the real work is in subprocesses behind
+the exec boundary, so Dask's memory manager could only pause workers
+over phantom numbers), `--death-timeout 60` (a worker whose driver died
+exits instead of holding its node to walltime), and `--local-directory`
+on node-local tmp — never the project tree, and explicit so ambient
+`DASK_TEMPORARY_DIRECTORY` cannot point it there. The driver's node
+hosts a worker too, and a single-node allocation takes the same srun
+path — one path means the venue is exercised on the cheapest allocation.
+
+**The srun child is the one documented exception to `project._run`.**
+That seam is run-to-completion capture; this child lives as long as the
+run, and its stderr must reach the terminal live (srun's own errors are
+the user's to see as they happen). It is a `subprocess.Popen` with the
+rationale at the call site, and the fake-srun tests keep the argv
+inspectable. Worker connection is a poll loop rather than
+`wait_for_workers`, so a dead srun is reported as *its exit code*
+immediately, not as a timeout two minutes later; teardown retires
+workers first (they exit 0, srun ends silently — killing srun prints
+"srun: forcing job termination" on every clean run) and escalates
+wait → terminate → kill, bounded, never a hang. A leaked `SLURM_JOB_ID`
+with no srun on PATH is a loud refusal, never a silent local fallback.
+
+**The login guard is materialize-scoped and comes first.**
+`venue.require_compute_node()` refuses iff `NERSC_HOST` is set and
+`SLURM_JOB_ID` is not (NERSC_HOST is set on compute nodes too; the
+allocation is what distinguishes them), naming copy-pasteable `salloc`
+and `sbatch --wrap 'lc materialize'` commands. It is the first line of
+`materialize()`, before even the tool checks: the allocation is the
+remedy with queue latency, so the user submits it first and fixes
+whatever later refusals name while waiting. `check()`, `status()` and
+`lc run` never call it — a login node is exactly where "where does this
+project stand" gets asked.
+
+**Containerized runs assume a homogeneous allocation**, recorded: the
+runtime resolves driver-side once (the HEAD discipline) and workers exec
+that runtime's CLI on their own node, so every node must offer the same
+runtime and see the shared-filesystem project tree. podman-hpc is what
+makes this true multi-node on NERSC — `migrate` squashes the image to
+the shared filesystem, where every compute node runs it; plain
+podman/docker multi-node would need per-node stores and is out of scope.
+
+**podman-hpc is a spelling, not a shape.** It rides the existing
+`OCIBackend` (standard podman flags, `--userns=keep-id`,
+`--pull=never`), joins the podman family in `uid_flags`, `_loaded`
+(`image exists`) and `_build` (`save --format docker-archive`), and adds
+exactly one step: `podman-hpc migrate <image-id>` in `runtime_for_run`,
+**outside the load branch** — after a fresh `lc build` the image is
+already in the store and the load never runs, but compute nodes only see
+migrated images. Migrate runs driver-side wherever `runtime_for_run`
+runs (login node at `lc build`, materialize preflight, the rerun entry
+point); one migrate serves all nodes. Detection order is
+**podman-hpc → podman → docker**: a site installs the wrapper precisely
+because plain podman's node-local overlay store is invisible to compute
+nodes, so where both are on PATH the bare sibling is the broken one.
+Presence-only detection (no daemon, no machine); the no-runtime refusal
+still names only podman/docker — podman-hpc is site-installed, never a
+user remedy. It is build-capable (it wraps `podman build`; NERSC login
+nodes are where a matching-arch archive comes from), so all three
+runtimes are both build- and run-capable and a capability predicate
+would be dead code — it lands with the first run-only runtime.
+
+**The architecture gate refuses before the load.** A wrong-arch
+`load` *succeeds* and then dies as `exec format error` deep inside a
+recipe — so `_require_arch` compares the archive's recorded arch against
+`platform.machine()` (via the closed `_OCI_ARCH` map) before anything is
+loaded, naming both arches and the fix: build on a matching host (on
+NERSC, a login node), commit, push, pull. Ignorance is not a mismatch —
+an archive that does not say, or an unmapped host machine, passes.
+Recorded residue: an arm64 mac that *could* emulate an amd64 archive is
+refused too (emulation is unattested ten-times-slower execution), and
+full multi-arch (arch-suffixed archive paths, `--platform` cross-builds)
+remains open, with the venue that makes it real.
+
+**Design headroom for a daemonless runtime (apptainer/singularity),
+deferred but load-bearing**: `Runtime` stays facts (root/mode/name/
+tag/id/arch), never mechanism — the committed→fetched→loaded ladder
+stays name-branched inside `runtime_for_run`, and a store-less runtime's
+analogue is a one-time archive→SIF conversion into gitignored
+`.lightcone/` cache keyed by the same runtime-independent config-blob
+id (the reason `docker-archive` stays the store format).
+`container.backend()` stays the single construction point; a future
+world-backend is one dataclass in `sandbox/` plus one branch there. A
+runtime that cannot deny network must attest `network: allowed` with no
+denial flag emitted — no consumer may assume containerized ⇒ denied,
+and `_sandbox_line`'s containerized prose is the one place that
+assumption lives today. `boundary.run`'s exit-125 note is a
+podman/docker-family fact, not a `contains_prefix` fact — it becomes
+mechanism-keyed when a non-OCI backend lands.
+
+**Pending the one-time Perlmutter spike** (run `tests/
+test_container_smoke.py` on a login node, then one materialize through
+`sbatch`; record findings here): `--overlap` and `--cpus-per-task`
+behavior inside salloc/sbatch steps; `nidXXXXXX` resolution from peer
+nodes (else `--interface hsn0`); `SLURM_CPUS_ON_NODE` on a CPU node
+(128 vs 256 hyperthreads); cold-Lustre `distributed` import vs the
+120 s worker wait; `podman-hpc migrate` accepting a bare image id and
+re-running cheaply; `--network none` on compute nodes (the
+`network: denied` attestation hangs on it); podman-hpc `--module`
+site-injected mounts vs the honesty of `fs: declared` (the one item
+that could add a flag); whether Landlock is in the SLES boot LSM list
+(either answer is handled — a host without it attests `fs: open` with
+the downgrade note); `git annex add`/`get` timings on `$SCRATCH` and
+`$CFS` (the recorded Lustre residue).
+
 ### Recorded decisions
 
 - **The engine is the host's uv tool, never a project dependency**
@@ -1543,12 +1674,12 @@ refusal point.
     worker process actually needs is `lightcone.engine` importable at a
     matching version — pickle serializes `worker.materialize` by
     reference and `Task`/`Versions`/`TaskResult` by class reference.
-    Verified by hand (2026-08-20), not pinned by the suite — a full
-    materialization through a `LocalCluster(processes=True)`: the
-    current code works unchanged across process boundaries, and workers
+    Pinned by the suite since layer 7
+    (`test_a_processes_cluster_fits_through_the_seam`, a full
+    materialization through a `LocalCluster(processes=True)`): the
+    code works unchanged across process boundaries, and workers
     need **no git and no git-annex** (the driver owns git alone;
-    `data_version` is pure file hashing). The shipped cluster is
-    threads; re-verify when layer 7 makes processes real. So per venue: on HPC the tool env lives on the shared
+    `data_version` is pure file hashing). So per venue: on HPC the tool env lives on the shared
     filesystem and the venue launches workers on the driver's own
     interpreter (`sys.executable` — dask-jobqueue's `python=`), which
     makes driver and workers the identical installation; in containerized
@@ -1766,11 +1897,12 @@ refusal point.
 | Change how a project stores bytes | `src/lightcone/engine/dataset.py` + `templates/files/gitattributes.tmpl` | Every command through `project._run`; test it against a real annex (`real_tools`) |
 | Change how an output is identified | `src/lightcone/engine/identity.py` + `tests/test_identity.py` | Sensitivity tests both ways: what must move the hash, and what must not |
 | Change what the image is made of | `src/lightcone/engine/image.py` + `tests/test_image.py` | Pure; structure-and-ordering tests, never byte goldens; every declaration key is hashed |
-| Change how images are built, stored or entered | `src/lightcone/engine/container.py` (+ `sandbox/oci.py` for the exec argv) + `tests/test_container.py` | Everything through `project._run`; keep the three `ensure_image` strictnesses; runtime differences are spellings inside `OCIBackend`, never new shapes |
+| Change how images are built, stored or entered | `src/lightcone/engine/container.py` (+ `sandbox/oci.py` for the exec argv) + `tests/test_container.py` | Everything through `project._run`; keep `runtime_for_run`'s two strictnesses; runtime differences are spellings inside `OCIBackend`, never new shapes |
 | Change when an output is remade | `src/lightcone/engine/assets.py` + `tests/test_assets.py` | One `classify()`, two callers; `--check` differs by one input value, never by logic. Ask first whether the thing that moved *contradicts* the project or is a *circumstance* — the second is `behind`, not `stale` |
 | Change how the spec becomes a graph | `src/lightcone/engine/plan.py` + `tests/test_plan.py` | Ask `astra.resolve`; if the answer is missing, the fix is a PR to astra-tools. Anything ambiguous is a `ProjectError`, never a guess |
 | Change how a recipe runs | `src/lightcone/engine/worker.py` + `tests/test_worker.py` | Never raises, never writes git; mutation-check every denial test |
 | Change what a run commits | `src/lightcone/engine/materialize.py` + `tests/test_materialize.py` | The driver owns git alone; the tree ends as clean as it started |
+| Change where a run executes | `src/lightcone/engine/venue.py` + `materialize.cluster_for_run` + `tests/test_venue.py` | One detection ladder, in `cluster_for_run` alone; venues are detected, never configured; test by faking the host (env vars + a stub srun), never the code |
 | Add a CLI verb | `src/lightcone/cli/commands.py` | `@main.command()`; keep logic in the engine, raise `ProjectError`, render here |
 | Add a sandbox mechanism | `src/lightcone/engine/sandbox/` | One module with a `Backend` (`wrap` pure, `attest` honest) + one line in `detect()`. Nothing above the seam changes |
 | Change what a sandboxed command may touch | `sandbox/policy.py` + `tests/test_sandbox_policy.py` | Path sets only — no mechanism ever leaks in here |
@@ -1841,6 +1973,17 @@ The sandbox suite splits along the seam, which is what makes it cheap:
 - `tests/test_run.py` — what `lc run` decides *before* it execs: the
   current-directory project check, declared inputs, the uv hop. Nothing
   spawns.
+- `tests/test_venue.py` — the venue's surface is ambient (env vars, an
+  srun on PATH), so the suite fakes the *host*, never the code: SLURM
+  variables set deliberately, a bash stub standing in for srun, and the
+  end-to-end tests run a real graph through the real detection, bind,
+  launch and teardown path on any machine — real worker processes, no
+  SLURM anywhere. `SLURMD_NODENAME=127.0.0.1` keeps the scheduler bind
+  hermetic against CI DNS. No required-vs-skip gating: nothing depends
+  on host capability. The `venue_env` autouse fixture in conftest scrubs
+  the venue variables suite-wide — without it the whole suite fails on a
+  NERSC login node (the guard) and the real-cluster test would srun
+  across a live allocation.
 - `tests/test_image.py` — **pure**: the declaration, the document, the
   render's structure and ordering, tag sensitivity both ways, and the
   `env_version` integration. `tests/test_sandbox_oci.py` — **pure**: the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1551,8 +1551,12 @@ retirement), `--memory-limit 0` (the real work is in subprocesses behind
 the exec boundary, so Dask's memory manager could only pause workers
 over phantom numbers), `--death-timeout 60` (a worker whose driver died
 exits instead of holding its node to walltime), and `--local-directory`
-on node-local tmp — never the project tree, and explicit so ambient
-`DASK_TEMPORARY_DIRECTORY` cannot point it there. The driver's node
+on a **literal `/tmp`** — never the project tree, explicit so ambient
+`DASK_TEMPORARY_DIRECTORY` cannot point it there, and literal rather
+than the driver's `tempfile.gettempdir()` because a site prolog can
+scope `TMPDIR` to the node or job step that set it, leaving a
+driver-resolved path absent on the allocation's other nodes. The
+driver's node
 hosts a worker too, and a single-node allocation takes the same srun
 path — one path means the venue is exercised on the cheapest allocation.
 
@@ -1567,7 +1571,12 @@ immediately, not as a timeout two minutes later; teardown retires
 workers first (they exit 0, srun ends silently — killing srun prints
 "srun: forcing job termination" on every clean run) and escalates
 wait → terminate → kill, bounded, never a hang. A leaked `SLURM_JOB_ID`
-with no srun on PATH is a loud refusal, never a silent local fallback.
+with no srun on PATH is a loud refusal, never a silent local fallback —
+and the other leak shapes get the same treatment: a non-integer SLURM
+count refuses naming the variable (`venue._int_env`), and a
+`SLURMD_NODENAME` that does not resolve becomes a `ProjectError` naming
+the bind rather than the raw `socket.gaierror` (distributed wraps it in
+a `RuntimeError`, so the constructor catches both).
 
 **The login guard is materialize-scoped and comes first.**
 `venue.require_compute_node()` refuses iff `NERSC_HOST` is set and
@@ -1576,22 +1585,34 @@ allocation is what distinguishes them), naming copy-pasteable `salloc`
 and `sbatch --wrap 'lc materialize'` commands. It is the first line of
 `materialize()`, before even the tool checks: the allocation is the
 remedy with queue latency, so the user submits it first and fixes
-whatever later refusals name while waiting. `check()`, `status()` and
-`lc run` never call it — a login node is exactly where "where does this
-project stand" gets asked.
+whatever later refusals name while waiting. The rerun entry point
+(`worker.main`) is guarded too — a rerun executes a recipe, and the
+record's `cmd` is how recipes reach a login node without `lc` in the
+command line. `check()`, `status()` and `lc run` never call it — a login
+node is exactly where "where does this project stand" gets asked.
 
-**Containerized runs assume a homogeneous allocation**, recorded: the
-runtime resolves driver-side once (the HEAD discipline) and workers exec
-that runtime's CLI on their own node, so every node must offer the same
-runtime and see the shared-filesystem project tree. podman-hpc is what
-makes this true multi-node on NERSC — `migrate` squashes the image to
-the shared filesystem, where every compute node runs it; plain
-podman/docker multi-node would need per-node stores and is out of scope.
+**Containerized runs assume a homogeneous allocation**, and the one
+part of that lc can check is *enforced*: a multi-node allocation with a
+containerized project **refuses** unless the runtime is podman-hpc,
+because podman's and docker's stores are node-local — the image loads on
+the driver's node only, and every task scheduled elsewhere would fail at
+`run <id>` with `--pull=never` forbidding the fetch. The check sits in
+`materialize()` before the runtime resolves (a refusal must not cost an
+image build) and not in `runtime_for_run` (the rerun entry point shares
+that, and a rerun is a one-node run wherever it sits). The rest stays a
+recorded assumption: every node offers the same runtime binary and sees
+the shared-filesystem project tree. podman-hpc is what makes multi-node
+true on NERSC — `migrate` squashes the image to the shared filesystem,
+where every compute node runs it.
 
 **podman-hpc is a spelling, not a shape.** It rides the existing
 `OCIBackend` (standard podman flags, `--userns=keep-id`,
 `--pull=never`), joins the podman family in `uid_flags`, `_loaded`
-(`image exists`) and `_build` (`save --format docker-archive`), and adds
+(`image exists`) and `_build` (`save --format docker-archive`) — the
+set stated once as `container._PODMAN_FAMILY` and asked positively at
+every site, so a future runtime falls *outside* it by default instead
+of inheriting podman behavior through a `!= "docker"` back door — and
+adds
 exactly one step: `podman-hpc migrate <image-id>` in `runtime_for_run`,
 **outside the load branch** — after a fresh `lc build` the image is
 already in the store and the load never runs, but compute nodes only see

--- a/src/lightcone/engine/container.py
+++ b/src/lightcone/engine/container.py
@@ -42,6 +42,12 @@ from lightcone.engine.project import ProjectError, _check_call
 #: inheriting podman behavior through a `!= "docker"` back door.
 _PODMAN_FAMILY = ("podman", "podman-hpc")
 
+#: The runtimes whose image store every node of an allocation can see —
+#: podman-hpc's migrate squashes the image to the shared filesystem.
+#: podman's and docker's overlay stores are node-local, which is what
+#: the multi-node materialize refusal stands on.
+_SHARED_STORE_RUNTIMES = ("podman-hpc",)
+
 
 @dataclass(frozen=True)
 class Runtime:
@@ -127,9 +133,7 @@ def runtime_for_run(root: Path, *, build: bool) -> Runtime:
         _build(root, name, tag, archive)
     _fetch(root, archive)
     image_id, arch = archive_identity(archive)
-    # Before the load: a wrong-arch load *succeeds*, and the failure then
-    # surfaces as `exec format error` deep inside a recipe.
-    _require_arch(root, archive, arch)
+    _require_arch(root, archive, arch)  # before the load — see its docstring
     if not _loaded(root, name, image_id):
         _check_call([name, "load", "-i", str(archive)], cwd=root)
     if name == "podman-hpc":
@@ -248,7 +252,7 @@ def backend(runtime: Runtime) -> sandbox.Backend:
     """
     if runtime.mode == "direct":
         return sandbox.detect()
-    from lightcone.engine.sandbox.oci import OCIBackend
+    from lightcone.engine.sandbox.oci import OCIBackend, OCIRuntime
 
     # `--pull=never` beside the uid flags rather than inside them: it is
     # a pull policy (a typo'd reference must fail, not fetch), the podman
@@ -256,7 +260,7 @@ def backend(runtime: Runtime) -> sandbox.Backend:
     # the next reader would not look.
     pull = ("--pull=never",) if runtime.runtime in _PODMAN_FAMILY else ()
     return OCIBackend(
-        runtime=cast(Literal["podman", "docker", "podman-hpc"], runtime.runtime),
+        runtime=cast(OCIRuntime, runtime.runtime),
         image_id=runtime.image_id,
         root=runtime.root,
         user_flags=(*uid_flags(runtime.runtime), *pull),

--- a/src/lightcone/engine/container.py
+++ b/src/lightcone/engine/container.py
@@ -10,10 +10,9 @@ name-pinned apt notwithstanding. A dropped archive never substitutes: a
 rebuild is a new archive under a new id, never the old reference.
 
 Runtime is host capability, not project state — podman-hpc where a site
-provides it, podman preferred, docker accepted — and the archive format
-is the one all of podman, docker, and (later) apptainer/singularity
-consume, which is why build-capable and run-capable are separate
-questions.
+provides it, podman preferred, docker accepted — and every one of them
+consumes the same ``docker-archive``, which is what lets the repository
+stay the one store.
 
 Every command goes through :func:`~lightcone.engine.project._run`, the
 seam the whole engine shares, so the suite never spawns a runtime.
@@ -36,6 +35,12 @@ from typing import Literal, cast
 
 from lightcone.engine import assets, dataset, image, project, sandbox
 from lightcone.engine.project import ProjectError, _check_call
+
+#: The runtimes that are podman underneath and share its spellings —
+#: the one statement of the set, spelled positively everywhere it is
+#: asked, so a future runtime falls outside it by default rather than
+#: inheriting podman behavior through a `!= "docker"` back door.
+_PODMAN_FAMILY = ("podman", "podman-hpc")
 
 
 @dataclass(frozen=True)
@@ -131,8 +136,9 @@ def runtime_for_run(root: Path, *, build: bool) -> Runtime:
         # Compute nodes run only migrated images — the squashed copy on
         # the shared filesystem — never the login node's overlay store.
         # Outside the load branch, because after a fresh `lc build` the
-        # image is already in the store and the load never runs; on an
-        # already-migrated image this is a cheap no-op.
+        # image is already in the store and the load never runs.
+        # Unconditional: nothing here can ask whether the squashed copy
+        # already exists, so re-migrate cost is podman-hpc's to bound.
         _check_call([name, "migrate", image_id], cwd=root)
     return Runtime(
         root=root,
@@ -248,7 +254,7 @@ def backend(runtime: Runtime) -> sandbox.Backend:
     # a pull policy (a typo'd reference must fail, not fetch), the podman
     # family's spelling only, and filing it under uid mapping is where
     # the next reader would not look.
-    pull = ("--pull=never",) if runtime.runtime in ("podman", "podman-hpc") else ()
+    pull = ("--pull=never",) if runtime.runtime in _PODMAN_FAMILY else ()
     return OCIBackend(
         runtime=cast(Literal["podman", "docker", "podman-hpc"], runtime.runtime),
         image_id=runtime.image_id,
@@ -514,7 +520,7 @@ def uid_flags(runtime: str) -> list[str]:
     Returns:
         The argv fragment.
     """
-    if runtime in ("podman", "podman-hpc"):
+    if runtime in _PODMAN_FAMILY:
         return ["--userns=keep-id"]
     return ["--user", f"{os.getuid()}:{os.getgid()}"]
 
@@ -564,7 +570,7 @@ def _build(root: Path, runtime: str, tag: str, archive: Path) -> None:
     # dies midway must not leave a partial archive that the dirty-tree
     # refusal would then tell the user to commit.
     partial = archive.parent / "image.partial"
-    save_format = [] if runtime == "docker" else ["--format", "docker-archive"]
+    save_format = ["--format", "docker-archive"] if runtime in _PODMAN_FAMILY else []
     try:
         _check_call([runtime, "save", *save_format, "-o", str(partial), tag], cwd=root)
     except ProjectError:
@@ -630,7 +636,7 @@ def _build_failure(tag: str, stderr: str) -> str:
 
 def _loaded(root: Path, runtime: str, image_id: str) -> bool:
     """Whether the runtime's local store already holds *image_id*."""
-    probe = ["image", "inspect" if runtime == "docker" else "exists", image_id]
+    probe = ["image", "exists" if runtime in _PODMAN_FAMILY else "inspect", image_id]
     return project._run([runtime, *probe], cwd=root).returncode == 0
 
 

--- a/src/lightcone/engine/container.py
+++ b/src/lightcone/engine/container.py
@@ -9,10 +9,11 @@ it has, so the bytes that made an output are the bytes a rerun enters,
 name-pinned apt notwithstanding. A dropped archive never substitutes: a
 rebuild is a new archive under a new id, never the old reference.
 
-Runtime is host capability, not project state — podman is preferred,
-docker accepted — and the archive format is the one all of podman,
-docker, and (later, on HPC) apptainer/singularity consume, which is why
-build-capable and run-capable are separate questions.
+Runtime is host capability, not project state — podman-hpc where a site
+provides it, podman preferred, docker accepted — and the archive format
+is the one all of podman, docker, and (later) apptainer/singularity
+consume, which is why build-capable and run-capable are separate
+questions.
 
 Every command goes through :func:`~lightcone.engine.project._run`, the
 seam the whole engine shares, so the suite never spawns a runtime.
@@ -23,6 +24,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import platform
 import re
 import shutil
 import sys
@@ -51,7 +53,7 @@ class Runtime:
     #: Where the project environment lives: ``.venv``, or the in-image
     #: ``.lightcone/venv``.
     env_dir: Path
-    #: ``podman`` or ``docker``; empty in direct mode.
+    #: ``podman``, ``podman-hpc`` or ``docker``; empty in direct mode.
     runtime: str = ""
     image_tag: str = ""
     #: The image id (bare hex of its config blob) — execution pins on
@@ -120,8 +122,18 @@ def runtime_for_run(root: Path, *, build: bool) -> Runtime:
         _build(root, name, tag, archive)
     _fetch(root, archive)
     image_id, arch = archive_identity(archive)
+    # Before the load: a wrong-arch load *succeeds*, and the failure then
+    # surfaces as `exec format error` deep inside a recipe.
+    _require_arch(root, archive, arch)
     if not _loaded(root, name, image_id):
         _check_call([name, "load", "-i", str(archive)], cwd=root)
+    if name == "podman-hpc":
+        # Compute nodes run only migrated images — the squashed copy on
+        # the shared filesystem — never the login node's overlay store.
+        # Outside the load branch, because after a fresh `lc build` the
+        # image is already in the store and the load never runs; on an
+        # already-migrated image this is a cheap no-op.
+        _check_call([name, "migrate", image_id], cwd=root)
     return Runtime(
         root=root,
         mode="containerized",
@@ -175,20 +187,25 @@ def _committed(archive: Path) -> bool:
 def runtime_name(root: Path) -> str:
     """Detect which container runtime this host offers.
 
-    podman first — rootless podman needs no daemon and no group — then
-    docker, whose CLI without a reachable daemon is probed rather than
-    trusted, because `docker` on PATH with the daemon down is the common
-    broken state and "cannot connect to the socket" mid-run is a worse
-    message than this one.
+    podman-hpc first: a site installs the wrapper precisely because plain
+    podman does not work on its compute nodes — the node-local overlay
+    store is invisible there, only the wrapper's migrated copies run — so
+    where both are on PATH, the bare sibling is the broken one. Then
+    podman — rootless, no daemon, no group — then docker, whose CLI
+    without a reachable daemon is probed rather than trusted, because
+    `docker` on PATH with the daemon down is the common broken state and
+    "cannot connect to the socket" mid-run is a worse message than this
+    one. podman-hpc is presence-only: no daemon to probe, and no machine
+    (it is a Linux-site tool).
 
     Args:
         root: The project root, for the probe's working directory.
 
     Returns:
-        ``"podman"`` or ``"docker"``.
+        ``"podman-hpc"``, ``"podman"`` or ``"docker"``.
 
     Raises:
-        ProjectError: If neither is usable.
+        ProjectError: If none is usable.
     """
     name = runtime_hint()
     if name == "podman":
@@ -200,7 +217,7 @@ def runtime_name(root: Path) -> str:
                 "(or install podman, which needs no daemon), then retry. "
                 "`lc status` shows what this project needs."
             )
-    else:
+    elif not name:
         raise ProjectError(
             "this project is containerized and needs a container runtime: install "
             "podman (recommended: https://podman.io/docs/installation) or docker. "
@@ -228,12 +245,12 @@ def backend(runtime: Runtime) -> sandbox.Backend:
     from lightcone.engine.sandbox.oci import OCIBackend
 
     # `--pull=never` beside the uid flags rather than inside them: it is
-    # a pull policy (a typo'd reference must fail, not fetch), podman's
-    # spelling only, and filing it under uid mapping is where the next
-    # reader would not look.
-    pull = ("--pull=never",) if runtime.runtime == "podman" else ()
+    # a pull policy (a typo'd reference must fail, not fetch), the podman
+    # family's spelling only, and filing it under uid mapping is where
+    # the next reader would not look.
+    pull = ("--pull=never",) if runtime.runtime in ("podman", "podman-hpc") else ()
     return OCIBackend(
-        runtime=cast(Literal["podman", "docker"], runtime.runtime),
+        runtime=cast(Literal["podman", "docker", "podman-hpc"], runtime.runtime),
         image_id=runtime.image_id,
         root=runtime.root,
         user_flags=(*uid_flags(runtime.runtime), *pull),
@@ -287,9 +304,9 @@ def runtime_hint() -> str:
     is skipped because a header must not cost a subprocess.
 
     Returns:
-        ``"podman"``, ``"docker"``, or ``""``.
+        ``"podman-hpc"``, ``"podman"``, ``"docker"``, or ``""``.
     """
-    for name in ("podman", "docker"):
+    for name in ("podman-hpc", "podman", "docker"):
         if shutil.which(name):
             return name
     return ""
@@ -446,23 +463,58 @@ def archive_identity(path: Path) -> tuple[str, str]:
     )
 
 
+#: `platform.machine()` spellings mapped onto the OCI architecture names
+#: an archive's config records. Closed deliberately: an unmapped host
+#: cannot be refused on ignorance.
+_OCI_ARCH = {"x86_64": "amd64", "amd64": "amd64", "aarch64": "arm64", "arm64": "arm64"}
+
+
+def _require_arch(root: Path, archive: Path, arch: str) -> None:
+    """Refuse an archive built for another architecture.
+
+    The archive is single-arch — it is the exact bytes that ran, which is
+    the point of committing it — so a host on the other architecture gets
+    a refusal naming the fix, not an emulated run ten times slower than
+    the attestation implies, and not an `exec format error` deep inside
+    a recipe. Skipped when either side is unknown.
+
+    Args:
+        root: The project root, for naming the archive.
+        archive: The committed archive.
+        arch: Its recorded architecture; empty means unknown.
+
+    Raises:
+        ProjectError: On a mismatch.
+    """
+    host = _OCI_ARCH.get(platform.machine().lower(), "")
+    if not host or not arch or host == arch:
+        return
+    relative = archive.relative_to(root).as_posix()
+    raise ProjectError(
+        f"the committed image archive `{relative}` was built for {arch} and this "
+        f"host is {host} — it cannot run here. Run `lc build` on a host whose "
+        "architecture matches (on NERSC, a login node), commit and push; then "
+        "`git pull` here."
+    )
+
+
 def uid_flags(runtime: str) -> list[str]:
     """The flags that keep files written through a mount owned by the user.
 
-    podman maps the invoking uid into the container (``--userns=keep-id``);
-    docker has no equivalent spelling, so the container simply runs as the
-    invoking uid — without which a rootful docker writes root-owned files
-    into ``results/`` that the host's git cannot manage. The missing
-    passwd entry that leaves behind is covered by the private-HOME
-    overlay every exec already gets.
+    The podman family maps the invoking uid into the container
+    (``--userns=keep-id``); docker has no equivalent spelling, so the
+    container simply runs as the invoking uid — without which a rootful
+    docker writes root-owned files into ``results/`` that the host's git
+    cannot manage. The missing passwd entry that leaves behind is covered
+    by the private-HOME overlay every exec already gets.
 
     Args:
-        runtime: ``"podman"`` or ``"docker"``.
+        runtime: ``"podman"``, ``"podman-hpc"`` or ``"docker"``.
 
     Returns:
         The argv fragment.
     """
-    if runtime == "podman":
+    if runtime in ("podman", "podman-hpc"):
         return ["--userns=keep-id"]
     return ["--user", f"{os.getuid()}:{os.getgid()}"]
 
@@ -512,7 +564,7 @@ def _build(root: Path, runtime: str, tag: str, archive: Path) -> None:
     # dies midway must not leave a partial archive that the dirty-tree
     # refusal would then tell the user to commit.
     partial = archive.parent / "image.partial"
-    save_format = ["--format", "docker-archive"] if runtime == "podman" else []
+    save_format = [] if runtime == "docker" else ["--format", "docker-archive"]
     try:
         _check_call([runtime, "save", *save_format, "-o", str(partial), tag], cwd=root)
     except ProjectError:
@@ -578,7 +630,7 @@ def _build_failure(tag: str, stderr: str) -> str:
 
 def _loaded(root: Path, runtime: str, image_id: str) -> bool:
     """Whether the runtime's local store already holds *image_id*."""
-    probe = ["image", "exists" if runtime == "podman" else "inspect", image_id]
+    probe = ["image", "inspect" if runtime == "docker" else "exists", image_id]
     return project._run([runtime, *probe], cwd=root).returncode == 0
 
 

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -433,6 +433,21 @@ def materialize(
     if not graph.tasks:
         return report
     _fetch_inputs(root, graph, report)
+    # Before the runtime resolves, because the refusal must not cost an
+    # image build: a containerized graph can span an allocation only if
+    # every node can see the image, and of the shipped runtimes only
+    # podman-hpc (whose migrate squashes to the shared filesystem)
+    # provides that — podman's and docker's stores are node-local, so
+    # every task scheduled off the driver's node would fail to find an
+    # image `--pull=never` forbids it to fetch.
+    if (nodes := venue.allocation_nodes()) > 1 and project.mode(root) == "containerized":
+        if (name := container.runtime_name(root)) != "podman-hpc":
+            raise ProjectError(
+                f"this allocation spans {nodes} nodes and `{name}`'s image store is "
+                "node-local, so recipes scheduled on the other nodes would not find "
+                "the image. Use a single-node allocation, or a system whose runtime "
+                "shares images across nodes (NERSC's podman-hpc)."
+            )
     # Materialize is one of the two verbs allowed to build the image (the
     # other is `lc build`); the probe and the rerun entry point only find
     # one. Resolved once, then handed to every task — the HEAD discipline.

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -435,19 +435,23 @@ def materialize(
     _fetch_inputs(root, graph, report)
     # Before the runtime resolves, because the refusal must not cost an
     # image build: a containerized graph can span an allocation only if
-    # every node can see the image, and of the shipped runtimes only
-    # podman-hpc (whose migrate squashes to the shared filesystem)
-    # provides that — podman's and docker's stores are node-local, so
-    # every task scheduled off the driver's node would fail to find an
-    # image `--pull=never` forbids it to fetch.
-    if (nodes := venue.allocation_nodes()) > 1 and project.mode(root) == "containerized":
-        if (name := container.runtime_name(root)) != "podman-hpc":
-            raise ProjectError(
-                f"this allocation spans {nodes} nodes and `{name}`'s image store is "
-                "node-local, so recipes scheduled on the other nodes would not find "
-                "the image. Use a single-node allocation, or a system whose runtime "
-                "shares images across nodes (NERSC's podman-hpc)."
-            )
+    # every node can see the image — the hint suffices, since which
+    # stores span nodes is `container._SHARED_STORE_RUNTIMES`'s fact and
+    # a wholly missing runtime gets `runtime_for_run`'s own refusal. Off
+    # the driver's node a task would otherwise fail to find an image
+    # `--pull=never` forbids it to fetch.
+    if (
+        (nodes := venue.allocation_nodes()) > 1
+        and project.mode(root) == "containerized"
+        and (name := container.runtime_hint())
+        and name not in container._SHARED_STORE_RUNTIMES
+    ):
+        raise ProjectError(
+            f"this allocation spans {nodes} nodes and `{name}`'s image store is "
+            "node-local, so recipes scheduled on the other nodes would not find "
+            "the image. Use a single-node allocation, or a system whose runtime "
+            "shares images across nodes (NERSC's podman-hpc)."
+        )
     # Materialize is one of the two verbs allowed to build the image (the
     # other is `lc build`); the probe and the rerun entry point only find
     # one. Resolved once, then handed to every task — the HEAD discipline.
@@ -609,7 +613,7 @@ def cluster_for_run() -> Iterator[Scheduler]:
     Yields:
         A scheduler bound to a Dask cluster, closed on exit.
     """
-    if "SLURM_JOB_ID" in os.environ:
+    if venue.allocation_nodes():
         with venue.slurm_client() as client:
             yield _Dask(client)
         return

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -41,7 +41,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
-from lightcone.engine import assets, container, dataset, identity, plan, project, worker
+from lightcone.engine import assets, container, dataset, identity, plan, project, venue, worker
 from lightcone.engine.plan import Graph, Key, Task
 from lightcone.engine.project import ProjectError
 
@@ -406,10 +406,14 @@ def materialize(
         blocked, plus the boundary's notes and the lock scan's warnings.
 
     Raises:
-        ProjectError: If a required tool or git's committer identity is
-            missing, the tree has uncommitted changes, or the lock cannot
-            be audited.
+        ProjectError: If this is a login node, a required tool or git's
+            committer identity is missing, the tree has uncommitted
+            changes, or the lock cannot be audited.
     """
+    # First, because its remedy is the one with queue latency: the user
+    # can submit the allocation and fix anything the later refusals name
+    # while waiting for it.
+    venue.require_compute_node()
     project.require_uv()
     project.require_git()
     project.require_git_annex()
@@ -573,20 +577,27 @@ class _Dask:
 
 @contextmanager
 def cluster_for_run() -> Iterator[Scheduler]:
-    """Open a scheduler for one run. The seam venues will land behind.
+    """Open a scheduler for one run — the venue ladder, and nothing else.
 
     Every core, with no knob to say otherwise: how much of a machine a run
-    may use, and which machine, is one question and it belongs to the
-    declaration of an execution backend.
+    may use, and which machine, is one question, and the venue answers it —
+    a SLURM allocation spans every node it was granted, and the local
+    machine is the whole of itself. Detected, never configured, and only
+    here: nothing outside this function asks where a run executes.
 
-    Threads rather than processes — every task's real work happens in a
-    subprocess behind the exec boundary, so a worker spends its time in
-    ``wait()`` with the GIL released, and a threaded cluster costs no
-    interpreter startup and no pickling of results.
+    Threads rather than processes on the local branch — every task's real
+    work happens in a subprocess behind the exec boundary, so a worker
+    spends its time in ``wait()`` with the GIL released, and a threaded
+    cluster costs no interpreter startup and no pickling of results. The
+    allocation branch runs one such worker per node.
 
     Yields:
-        A scheduler bound to a local Dask cluster, closed on exit.
+        A scheduler bound to a Dask cluster, closed on exit.
     """
+    if "SLURM_JOB_ID" in os.environ:
+        with venue.slurm_client() as client:
+            yield _Dask(client)
+        return
     from distributed import Client, LocalCluster
 
     with LocalCluster(  # type: ignore[no-untyped-call]

--- a/src/lightcone/engine/sandbox/model.py
+++ b/src/lightcone/engine/sandbox/model.py
@@ -75,7 +75,7 @@ class Policy:
 class Capability:
     """What enforcement this host can provide, as probed."""
 
-    kind: Literal["landlock", "seatbelt", "podman", "docker", "none"]
+    kind: Literal["landlock", "seatbelt", "podman", "docker", "podman-hpc", "none"]
     landlock_abi: int | None = None
     #: Why, when ``kind`` is ``none``. Reaches the user — a downgrade is
     #: never silent.
@@ -93,7 +93,7 @@ class Attestation:
     ``--network none``.
     """
 
-    mechanism: Literal["landlock", "seatbelt", "podman", "docker", "none"]
+    mechanism: Literal["landlock", "seatbelt", "podman", "docker", "podman-hpc", "none"]
     fs: Literal["declared", "open"]
     network: Literal["allowed", "denied"] = "allowed"
     landlock_abi: int | None = None

--- a/src/lightcone/engine/sandbox/oci.py
+++ b/src/lightcone/engine/sandbox/oci.py
@@ -1,8 +1,8 @@
 """The containerized backend: the mount table is the mechanism.
 
-One backend for podman and docker, data-parameterized — the two differ
-in spellings (how the invoking uid is kept, whether pulling must be
-forbidden), not in shape. The policy's path sets map one-to-one onto
+One backend for podman, podman-hpc and docker, data-parameterized — they
+differ in spellings (how the invoking uid is kept, whether pulling must
+be forbidden), not in shape. The policy's path sets map one-to-one onto
 mounts: ``read`` becomes ``:ro``, ``write`` becomes ``:rw``, and the
 image itself is the OS baseline and the exec set — everything present in
 it was declared, which is why the containerized policy carries no
@@ -30,8 +30,9 @@ from lightcone.engine.sandbox.model import Attestation, Capability, Policy
 class OCIBackend:
     """A container runtime, expressed as an argv rewrite."""
 
-    #: ``podman`` or ``docker`` — also what the attestation names.
-    runtime: Literal["podman", "docker"]
+    #: ``podman``, ``podman-hpc`` or ``docker`` — also what the
+    #: attestation names.
+    runtime: Literal["podman", "docker", "podman-hpc"]
     #: The image id (bare hex). Execution pins on the id, never a tag, so
     #: a retagged image in the local store can never substitute.
     image_id: str

--- a/src/lightcone/engine/sandbox/oci.py
+++ b/src/lightcone/engine/sandbox/oci.py
@@ -25,6 +25,10 @@ from typing import Literal
 from lightcone.engine.sandbox.boundary import SANDBOX_ENV
 from lightcone.engine.sandbox.model import Attestation, Capability, Policy
 
+#: The runtimes this backend can speak for — the one statement of the
+#: set, so the type does not get hand-copied out of step at its uses.
+OCIRuntime = Literal["podman", "docker", "podman-hpc"]
+
 
 @dataclass(frozen=True)
 class OCIBackend:
@@ -32,7 +36,7 @@ class OCIBackend:
 
     #: ``podman``, ``podman-hpc`` or ``docker`` — also what the
     #: attestation names.
-    runtime: Literal["podman", "docker", "podman-hpc"]
+    runtime: OCIRuntime
     #: The image id (bare hex). Execution pins on the id, never a tag, so
     #: a retagged image in the local store can never substitute.
     image_id: str

--- a/src/lightcone/engine/venue.py
+++ b/src/lightcone/engine/venue.py
@@ -93,17 +93,19 @@ def allocation_nodes() -> int:
     """
     if "SLURM_JOB_ID" not in os.environ:
         return 0
-    value = os.environ.get("SLURM_JOB_NUM_NODES") or os.environ.get("SLURM_NNODES")
-    return _int_env(value, "SLURM_JOB_NUM_NODES") if value else 1
+    return _int_env("SLURM_JOB_NUM_NODES", _int_env("SLURM_NNODES", 1))
 
 
-def _int_env(value: str, name: str) -> int:
-    """Parse a SLURM count, refusing garbage rather than tracebacking.
+def _int_env(name: str, default: int) -> int:
+    """Read a SLURM count, refusing garbage rather than tracebacking.
 
     SLURM writes plain integers into the variables read here; anything
     else is a hand-set or mangled environment — the same leak class as
     ``SLURM_JOB_ID`` without an srun, and it gets the same treatment.
     """
+    value = os.environ.get(name)
+    if not value:
+        return default
     try:
         return int(value)
     except ValueError:
@@ -140,9 +142,8 @@ def slurm_client() -> Iterator[Any]:
             "outside — a container, a copied environment — unset it to run on "
             "this machine alone."
         )
-    nodes = allocation_nodes() or 1
-    asked = os.environ.get("SLURM_CPUS_ON_NODE")
-    cpus = _int_env(asked, "SLURM_CPUS_ON_NODE") if asked else os.cpu_count() or 1
+    nodes = allocation_nodes()
+    cpus = _int_env("SLURM_CPUS_ON_NODE", os.cpu_count() or 1)
     host = os.environ.get("SLURMD_NODENAME") or socket.gethostname()
 
     try:
@@ -162,27 +163,26 @@ def slurm_client() -> Iterator[Any]:
             "address this process can bind — workers on the allocation's "
             "other nodes could not have reached it either."
         ) from e
-    with cluster:
-        with Client(cluster) as client:  # type: ignore[no-untyped-call]
-            # Not `project._run`, deliberately: that seam is run-to-completion
-            # capture, and this child lives as long as the run — and its
-            # stderr must reach the terminal live, because srun's own errors
-            # (bad step, drained node) are the user's to see as they happen.
-            env = dict(os.environ)
-            env.setdefault("DASK_LOGGING__DISTRIBUTED", "warning")
-            # Literal `/tmp`, not the driver's resolved tempdir: a site
-            # prolog can scope TMPDIR to the node or job step that set
-            # it, and a driver-side path baked into every worker's argv
-            # would then be absent on the allocation's other nodes.
-            proc = subprocess.Popen(
-                _srun_argv(cluster.scheduler_address, nodes, cpus, "/tmp"),
-                env=env,
-            )
-            try:
-                _await_workers(client, proc, nodes)
-                yield client
-            finally:
-                _wind_down(client, proc)
+    with cluster, Client(cluster) as client:  # type: ignore[no-untyped-call]
+        # Not `project._run`, deliberately: that seam is run-to-completion
+        # capture, and this child lives as long as the run — and its
+        # stderr must reach the terminal live, because srun's own errors
+        # (bad step, drained node) are the user's to see as they happen.
+        env = dict(os.environ)
+        env.setdefault("DASK_LOGGING__DISTRIBUTED", "warning")
+        # Literal `/tmp`, not the driver's resolved tempdir: a site
+        # prolog can scope TMPDIR to the node or job step that set
+        # it, and a driver-side path baked into every worker's argv
+        # would then be absent on the allocation's other nodes.
+        proc = subprocess.Popen(
+            _srun_argv(cluster.scheduler_address, nodes, cpus, "/tmp"),
+            env=env,
+        )
+        try:
+            _await_workers(client, proc, nodes)
+            yield client
+        finally:
+            _wind_down(client, proc)
 
 
 def _srun_argv(scheduler: str, nodes: int, cpus: int, scratch: str) -> list[str]:

--- a/src/lightcone/engine/venue.py
+++ b/src/lightcone/engine/venue.py
@@ -28,7 +28,6 @@ import shutil
 import socket
 import subprocess
 import sys
-import tempfile
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -46,13 +45,17 @@ _WORKER_WAIT = 120.0
 _REAP_GRACE = 20.0
 
 
-def require_compute_node() -> None:
-    """Refuse to materialize on a NERSC login node.
+def require_compute_node(command: str = "lc materialize") -> None:
+    """Refuse to execute recipes on a NERSC login node.
 
     A login node is for editing and submitting, not computing — and every
     node of an allocation becomes a worker, so the remedy is to run the
     same command inside one. NERSC_HOST is set on compute nodes too; an
     active allocation (SLURM_JOB_ID) is what distinguishes them.
+
+    Args:
+        command: What to name in the refusal — the command whose recipes
+            would have run here.
 
     Raises:
         ProjectError: On a NERSC login node, naming the salloc and sbatch
@@ -61,21 +64,53 @@ def require_compute_node() -> None:
     if "NERSC_HOST" not in os.environ or "SLURM_JOB_ID" in os.environ:
         return
     raise ProjectError(
-        "lc materialize executes on compute nodes, and this is a NERSC login "
-        "node (NERSC_HOST is set with no SLURM allocation active).\n"
+        f"{command} executes recipes on compute nodes, and this is a NERSC "
+        "login node (NERSC_HOST is set with no SLURM allocation active).\n"
         "\n"
-        "Get an allocation and run it there — every node becomes a worker:\n"
+        "Get an allocation and run it there:\n"
         "\n"
         "  interactive:\n"
         "      salloc --nodes=1 --constraint=cpu --qos=interactive --time=02:00:00\n"
-        "      lc materialize\n"
+        f"      {command}\n"
         "\n"
         "  batch (from the project root):\n"
         "      sbatch --nodes=1 --constraint=cpu --qos=regular --time=02:00:00 \\\n"
-        "          --wrap 'lc materialize'\n"
+        f"          --wrap '{command}'\n"
         "\n"
         "lc materialize --check, lc status and lc run work anywhere."
     )
+
+
+def allocation_nodes() -> int:
+    """How many nodes the surrounding SLURM allocation holds; 0 outside one.
+
+    Returns:
+        The node count, or 0 when this process is not inside an
+        allocation.
+
+    Raises:
+        ProjectError: If the allocation's node count is not a number.
+    """
+    if "SLURM_JOB_ID" not in os.environ:
+        return 0
+    value = os.environ.get("SLURM_JOB_NUM_NODES") or os.environ.get("SLURM_NNODES")
+    return _int_env(value, "SLURM_JOB_NUM_NODES") if value else 1
+
+
+def _int_env(value: str, name: str) -> int:
+    """Parse a SLURM count, refusing garbage rather than tracebacking.
+
+    SLURM writes plain integers into the variables read here; anything
+    else is a hand-set or mangled environment — the same leak class as
+    ``SLURM_JOB_ID`` without an srun, and it gets the same treatment.
+    """
+    try:
+        return int(value)
+    except ValueError:
+        raise ProjectError(
+            f"{name}={value!r} is not a number — this does not look like a real "
+            "SLURM allocation. If the variable leaked in from outside, unset it."
+        ) from None
 
 
 @contextmanager
@@ -105,15 +140,29 @@ def slurm_client() -> Iterator[Any]:
             "outside — a container, a copied environment — unset it to run on "
             "this machine alone."
         )
-    nodes = int(os.environ.get("SLURM_JOB_NUM_NODES") or os.environ.get("SLURM_NNODES") or 1)
-    cpus = int(os.environ.get("SLURM_CPUS_ON_NODE") or os.cpu_count() or 1)
+    nodes = allocation_nodes() or 1
+    asked = os.environ.get("SLURM_CPUS_ON_NODE")
+    cpus = _int_env(asked, "SLURM_CPUS_ON_NODE") if asked else os.cpu_count() or 1
     host = os.environ.get("SLURMD_NODENAME") or socket.gethostname()
 
-    with LocalCluster(  # type: ignore[no-untyped-call]
-        n_workers=0,
-        host=host,
-        dashboard_address=None,
-    ) as cluster:
+    try:
+        cluster = LocalCluster(  # type: ignore[no-untyped-call]
+            n_workers=0,
+            host=host,
+            dashboard_address=None,
+        )
+    except (OSError, RuntimeError) as e:
+        # SLURM's NodeName is an alias, not a promise of a resolvable
+        # hostname — a site where it differs from NodeHostname would
+        # otherwise die here as a raw traceback (distributed wraps the
+        # socket.gaierror in a RuntimeError of its own).
+        raise ProjectError(
+            f"cannot start the run's scheduler bound to `{host}` ({e}). The "
+            "usual cause is a node's SLURM name that did not resolve to an "
+            "address this process can bind — workers on the allocation's "
+            "other nodes could not have reached it either."
+        ) from e
+    with cluster:
         with Client(cluster) as client:  # type: ignore[no-untyped-call]
             # Not `project._run`, deliberately: that seam is run-to-completion
             # capture, and this child lives as long as the run — and its
@@ -121,8 +170,12 @@ def slurm_client() -> Iterator[Any]:
             # (bad step, drained node) are the user's to see as they happen.
             env = dict(os.environ)
             env.setdefault("DASK_LOGGING__DISTRIBUTED", "warning")
+            # Literal `/tmp`, not the driver's resolved tempdir: a site
+            # prolog can scope TMPDIR to the node or job step that set
+            # it, and a driver-side path baked into every worker's argv
+            # would then be absent on the allocation's other nodes.
             proc = subprocess.Popen(
-                _srun_argv(cluster.scheduler_address, nodes, cpus, tempfile.gettempdir()),
+                _srun_argv(cluster.scheduler_address, nodes, cpus, "/tmp"),
                 env=env,
             )
             try:

--- a/src/lightcone/engine/venue.py
+++ b/src/lightcone/engine/venue.py
@@ -1,0 +1,233 @@
+"""Where a run executes: the venue a materialization finds itself on.
+
+A venue is host state, never project state — nothing here reads the
+project or enters any identity. The one venue beyond the local machine is
+a SLURM allocation, detected rather than configured: the user already
+declared every resource question to SLURM (`salloc -N4 …`), so the
+allocation *is* the declaration, and lc's job is to span it — one Dask
+worker per allocated node, launched with a single `srun`, all connected
+to a scheduler living in the driver process.
+
+Workers run the driver's own interpreter (`sys.executable -m`), which on
+an HPC system is the lc tool environment on the shared filesystem — so
+driver and workers are the identical installation, which is all a worker
+process needs: `lightcone.engine` importable at the driver's version.
+Workers need no git and no git-annex; the driver owns git alone.
+
+If the driver dies uncleanly, workers exit on their own (death timeout)
+and the allocation's walltime is the backstop; whatever the interrupted
+run left behind meets the next run's dirty-tree refusal, which names the
+`results/` paths to discard — that is the designed recovery, not a
+watchdog.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from lightcone.engine.project import ProjectError
+
+#: How long the allocation's workers get to connect before the run
+#: refuses. Generous because the first import of `distributed` from a
+#: cold parallel filesystem is seconds, not milliseconds.
+_WORKER_WAIT = 120.0
+
+#: Grace given to srun to end on its own once the workers are retired,
+#: before the terminate/kill escalation.
+_REAP_GRACE = 20.0
+
+
+def require_compute_node() -> None:
+    """Refuse to materialize on a NERSC login node.
+
+    A login node is for editing and submitting, not computing — and every
+    node of an allocation becomes a worker, so the remedy is to run the
+    same command inside one. NERSC_HOST is set on compute nodes too; an
+    active allocation (SLURM_JOB_ID) is what distinguishes them.
+
+    Raises:
+        ProjectError: On a NERSC login node, naming the salloc and sbatch
+            commands to run instead.
+    """
+    if "NERSC_HOST" not in os.environ or "SLURM_JOB_ID" in os.environ:
+        return
+    raise ProjectError(
+        "lc materialize executes on compute nodes, and this is a NERSC login "
+        "node (NERSC_HOST is set with no SLURM allocation active).\n"
+        "\n"
+        "Get an allocation and run it there — every node becomes a worker:\n"
+        "\n"
+        "  interactive:\n"
+        "      salloc --nodes=1 --constraint=cpu --qos=interactive --time=02:00:00\n"
+        "      lc materialize\n"
+        "\n"
+        "  batch (from the project root):\n"
+        "      sbatch --nodes=1 --constraint=cpu --qos=regular --time=02:00:00 \\\n"
+        "          --wrap 'lc materialize'\n"
+        "\n"
+        "lc materialize --check, lc status and lc run work anywhere."
+    )
+
+
+@contextmanager
+def slurm_client() -> Iterator[Any]:
+    """Span the SLURM allocation this process is running inside.
+
+    The scheduler lives here, in the driver, bound to this node's
+    SLURM-canonical hostname so workers on the allocation's other nodes
+    can reach it — the default loopback bind cannot be. One `srun`
+    launches one worker per node; the driver's own node hosts a worker
+    too, because the driver's footprint is small against a node and
+    excluding it would waste one.
+
+    Yields:
+        A connected Dask client with every node's worker registered.
+
+    Raises:
+        ProjectError: If srun is missing, exits before the workers
+            connect, or the workers do not all connect in time.
+    """
+    from distributed import Client, LocalCluster
+
+    if shutil.which("srun") is None:
+        raise ProjectError(
+            "SLURM_JOB_ID is set but srun is not on PATH, so lc cannot launch "
+            "workers across the allocation. If the variable leaked in from "
+            "outside — a container, a copied environment — unset it to run on "
+            "this machine alone."
+        )
+    nodes = int(os.environ.get("SLURM_JOB_NUM_NODES") or os.environ.get("SLURM_NNODES") or 1)
+    cpus = int(os.environ.get("SLURM_CPUS_ON_NODE") or os.cpu_count() or 1)
+    host = os.environ.get("SLURMD_NODENAME") or socket.gethostname()
+
+    with LocalCluster(  # type: ignore[no-untyped-call]
+        n_workers=0,
+        host=host,
+        dashboard_address=None,
+    ) as cluster:
+        with Client(cluster) as client:  # type: ignore[no-untyped-call]
+            # Not `project._run`, deliberately: that seam is run-to-completion
+            # capture, and this child lives as long as the run — and its
+            # stderr must reach the terminal live, because srun's own errors
+            # (bad step, drained node) are the user's to see as they happen.
+            env = dict(os.environ)
+            env.setdefault("DASK_LOGGING__DISTRIBUTED", "warning")
+            proc = subprocess.Popen(
+                _srun_argv(cluster.scheduler_address, nodes, cpus, tempfile.gettempdir()),
+                env=env,
+            )
+            try:
+                _await_workers(client, proc, nodes)
+                yield client
+            finally:
+                _wind_down(client, proc)
+
+
+def _srun_argv(scheduler: str, nodes: int, cpus: int, scratch: str) -> list[str]:
+    """Build the one srun invocation that spans the allocation.
+
+    Args:
+        scheduler: The driver-side scheduler's address.
+        nodes: Allocated node count — one worker task per node.
+        cpus: Threads per worker; tasks block in ``subprocess.wait()``
+            with the GIL released, so threads carry a whole node.
+        scratch: Node-local directory for the worker's own state — never
+            the project tree, and explicit so ambient Dask configuration
+            cannot point it there.
+
+    Returns:
+        The argv, ready for Popen.
+    """
+    return [
+        "srun",
+        # Inside salloc's interactive step a plain srun can wait forever
+        # for the resources that step already holds.
+        "--overlap",
+        f"--ntasks={nodes}",
+        "--ntasks-per-node=1",
+        # Without it the step is entitled to one core and the worker's
+        # threads are bound to it.
+        f"--cpus-per-task={cpus}",
+        # The driver's own interpreter — the tool environment on the
+        # shared filesystem — so driver and workers are the identical
+        # installation. `-m` cannot resolve to some other install the
+        # way a PATH-found `dask` can.
+        sys.executable,
+        "-m",
+        "distributed.cli.dask_worker",
+        scheduler,
+        "--nthreads",
+        str(cpus),
+        "--nworkers",
+        "1",
+        "--no-dashboard",
+        # srun will not relaunch the task, so an auto-restart nanny adds
+        # nothing and logs a spurious death on every clean retirement.
+        "--no-nanny",
+        # A worker whose driver is gone exits instead of holding its node
+        # to walltime.
+        "--death-timeout",
+        "60",
+        # The real work happens in subprocesses behind the exec boundary,
+        # whose memory Dask cannot see — its manager could only ever
+        # pause a worker over phantom numbers.
+        "--memory-limit",
+        "0",
+        "--local-directory",
+        scratch,
+    ]
+
+
+def _await_workers(client: Any, proc: subprocess.Popen[bytes], nodes: int) -> None:
+    """Wait until every node's worker is registered.
+
+    A poll loop rather than ``wait_for_workers`` so that a dead srun is
+    reported as srun's own exit code, not as a timeout two minutes later.
+    """
+    deadline = time.monotonic() + _WORKER_WAIT
+    while True:
+        connected = len(client.scheduler_info()["workers"])
+        if connected >= nodes:
+            return
+        if (code := proc.poll()) is not None:
+            raise ProjectError(
+                f"srun exited with code {code} before the allocation's workers "
+                f"connected ({connected} of {nodes} had) — its error is above."
+            )
+        if time.monotonic() >= deadline:
+            raise ProjectError(
+                f"expected {nodes} dask workers (one per allocated node); "
+                f"{connected} connected within {int(_WORKER_WAIT)}s."
+            )
+        time.sleep(0.5)
+
+
+def _wind_down(client: Any, proc: subprocess.Popen[bytes]) -> None:
+    """Retire the workers, then reap srun — gracefully first.
+
+    Retirement makes each worker exit 0, so srun ends silently; killing
+    srun instead prints "srun: forcing job termination" on every clean
+    run. The escalation below it is for the runs that were not clean.
+    """
+    try:
+        client.retire_workers(close_workers=True, remove=True)
+    except Exception:
+        pass
+    try:
+        proc.wait(timeout=_REAP_GRACE)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        try:
+            proc.wait(timeout=_REAP_GRACE / 2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()

--- a/src/lightcone/engine/venue.py
+++ b/src/lightcone/engine/venue.py
@@ -31,6 +31,7 @@ import sys
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import Any
 
 from lightcone.engine.project import ProjectError
@@ -45,36 +46,75 @@ _WORKER_WAIT = 120.0
 _REAP_GRACE = 20.0
 
 
+@dataclass(frozen=True)
+class _Site:
+    """One HPC center whose login nodes must not run recipes.
+
+    A row is the whole cost of knowing a center: the variable its
+    systems put in every environment, and the center's own allocation
+    spellings for the refusal's remedies — copy-pasteable, so they are
+    verified against the center's documentation, never guessed.
+    """
+
+    #: The center's name, as the refusal states it.
+    name: str
+    #: The environment variable whose presence identifies the center's
+    #: machines — set on login and compute nodes alike; an active
+    #: allocation (SLURM_JOB_ID) is what tells the two apart.
+    marker: str
+    #: An interactive allocation, with concrete numbers the user edits.
+    salloc: str
+    #: The batch form of the same request; the guard appends ``--wrap``.
+    sbatch: str
+
+
+#: The centers the guard knows. Supporting another is one row here —
+#: nothing else changes, including the test-suite scrub, which derives
+#: its variable list from this table.
+_SITES = (
+    _Site(
+        name="NERSC",
+        marker="NERSC_HOST",
+        salloc="salloc --nodes=1 --constraint=cpu --qos=interactive --time=02:00:00",
+        sbatch="sbatch --nodes=1 --constraint=cpu --qos=regular --time=02:00:00",
+    ),
+)
+
+
 def require_compute_node(command: str = "lc materialize") -> None:
-    """Refuse to execute recipes on a NERSC login node.
+    """Refuse to execute recipes on a known HPC center's login node.
 
     A login node is for editing and submitting, not computing — and every
     node of an allocation becomes a worker, so the remedy is to run the
-    same command inside one. NERSC_HOST is set on compute nodes too; an
-    active allocation (SLURM_JOB_ID) is what distinguishes them.
+    same command inside one. A center's marker is set on compute nodes
+    too; an active allocation (SLURM_JOB_ID) is what distinguishes them.
 
     Args:
         command: What to name in the refusal — the command whose recipes
             would have run here.
 
     Raises:
-        ProjectError: On a NERSC login node, naming the salloc and sbatch
-            commands to run instead.
+        ProjectError: On a known center's login node, naming that
+            center's salloc and sbatch commands to run instead.
     """
-    if "NERSC_HOST" not in os.environ or "SLURM_JOB_ID" in os.environ:
+    if "SLURM_JOB_ID" in os.environ:
+        return
+    site = next((s for s in _SITES if s.marker in os.environ), None)
+    if site is None:
         return
     raise ProjectError(
-        f"{command} executes recipes on compute nodes, and this is a NERSC "
-        "login node (NERSC_HOST is set with no SLURM allocation active).\n"
+        f"{command} executes recipes on compute nodes, and this is a "
+        f"{site.name} login node ({site.marker} is set with no SLURM "
+        "allocation active).\n"
         "\n"
         "Get an allocation and run it there:\n"
         "\n"
         "  interactive:\n"
-        "      salloc --nodes=1 --constraint=cpu --qos=interactive --time=02:00:00\n"
+        f"      {site.salloc}\n"
         f"      {command}\n"
         "\n"
         "  batch (from the project root):\n"
-        "      sbatch --nodes=1 --constraint=cpu --qos=regular --time=02:00:00 \\\n"
+        f"      {site.sbatch} \\\n"
         f"          --wrap '{command}'\n"
         "\n"
         "lc materialize --check, lc status and lc run work anywhere."

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -35,7 +35,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Literal
 
-from lightcone.engine import assets, container, dataset, identity, plan, sandbox
+from lightcone.engine import assets, container, dataset, identity, plan, sandbox, venue
 from lightcone.engine.plan import Key, Task
 from lightcone.engine.project import (
     ProjectError,
@@ -346,6 +346,9 @@ def main(argv: list[str]) -> int:
 
     universe_id, _, output_id = argv[0].partition("/")
     try:
+        # A rerun executes a recipe, so it is gated the way materialize
+        # is: compute nodes, never a NERSC login node.
+        venue.require_compute_node("datalad rerun <commit>")
         root = declared_project()
         # The graph — and with it the task lookup — before any converge:
         # a typo'd target must cost nothing and mask nothing, and a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,12 +25,16 @@ def runner() -> CliRunner:
 def venue_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Strip the host's venue out of the suite's environment.
 
-    On a NERSC login node every materialize test would otherwise meet the
-    login guard, and inside an allocation the real-cluster test would
-    launch srun across it. The venue tests set these back deliberately.
+    On a known center's login node every materialize test would otherwise
+    meet the login guard, and inside an allocation the real-cluster test
+    would launch srun across it. The site markers come from the guard's
+    own table, so a center added there is scrubbed here for free; the
+    venue tests set these back deliberately.
     """
+    from lightcone.engine import venue
+
     for name in (
-        "NERSC_HOST",
+        *(site.marker for site in venue._SITES),
         "SLURM_JOB_ID",
         "SLURMD_NODENAME",
         "SLURM_JOB_NUM_NODES",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,25 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture(autouse=True)
+def venue_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip the host's venue out of the suite's environment.
+
+    On a NERSC login node every materialize test would otherwise meet the
+    login guard, and inside an allocation the real-cluster test would
+    launch srun across it. The venue tests set these back deliberately.
+    """
+    for name in (
+        "NERSC_HOST",
+        "SLURM_JOB_ID",
+        "SLURMD_NODENAME",
+        "SLURM_JOB_NUM_NODES",
+        "SLURM_NNODES",
+        "SLURM_CPUS_ON_NODE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture(autouse=True)
 def tools(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
     """Fake every external tool convergence shells out to, so the suite is
     hermetic — no network, no real resolution, no subprocesses.

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -103,8 +103,19 @@ def fake(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
 def hpc(
     fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
 ) -> list[list[str]]:
-    """The same host with the site's podman-hpc wrapper installed too."""
-    monkeypatch.setattr(shutil, "which", lambda name, path=None: f"/usr/bin/{name}")
+    """The same host with the site's podman-hpc wrapper installed too.
+
+    A wrap around `fake`'s stub rather than a replacement, so it changes
+    exactly one fact — anything else `fake` hides stays hidden here.
+    """
+    inner = shutil.which
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name, path=None: "/usr/bin/podman-hpc"
+        if name == "podman-hpc"
+        else inner(name, path),
+    )
     return fake
 
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -54,13 +54,19 @@ def _write_archive(path: Path, config: bytes = _CONFIG) -> str:
 
 @pytest.fixture
 def fake(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
-    """A podman-having host: records argv, models each command's effect."""
+    """A podman-having host: records argv, models each command's effect.
+
+    Every tool name resolves except ``podman-hpc`` — a site wrapper no
+    laptop has, and it would win detection everywhere. The host's
+    architecture is pinned to the test archives' ``amd64`` so the arch
+    gate answers the same on every CI machine.
+    """
     calls: list[list[str]] = []
     loaded: set[str] = set()
 
     def run(argv: list[str], *, cwd: Path) -> MagicMock:
         calls.append(list(argv))
-        if argv[0] in ("podman", "docker"):
+        if argv[0] in ("podman", "docker", "podman-hpc"):
             if argv[1] == "image":  # the loaded probe, both spellings
                 return MagicMock(returncode=0 if argv[3] in loaded else 1)
             if argv[1] == "load":
@@ -84,8 +90,22 @@ def fake(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
         return MagicMock(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(project, "_run", run)
-    monkeypatch.setattr(shutil, "which", lambda name, path=None: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name, path=None: None if name == "podman-hpc" else f"/usr/bin/{name}",
+    )
+    monkeypatch.setattr(container.platform, "machine", lambda: "x86_64")
     return calls
+
+
+@pytest.fixture
+def hpc(
+    fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> list[list[str]]:
+    """The same host with the site's podman-hpc wrapper installed too."""
+    monkeypatch.setattr(shutil, "which", lambda name, path=None: f"/usr/bin/{name}")
+    return fake
 
 
 def _argvs(calls: list[list[str]], *head: str) -> list[list[str]]:
@@ -482,3 +502,99 @@ def test_a_garbled_archive_is_a_pointed_refusal(tmp_path: Path) -> None:
     (tmp_path / "image").write_bytes(b"not a tar at all" * 4096)
     with pytest.raises(ProjectError, match="lc build"):
         container.archive_identity(tmp_path / "image")
+
+
+# ---- podman-hpc -------------------------------------------------------------
+
+
+def test_podman_hpc_is_preferred_where_present(root: Path, hpc: list[list[str]]) -> None:
+    """Where the site wrapper exists, the bare podman beside it is the one
+    whose store compute nodes cannot see."""
+    assert container.runtime_hint() == "podman-hpc"
+    assert container.runtime_name(root) == "podman-hpc"
+
+
+def test_podman_hpc_loads_then_migrates(root: Path, hpc: list[list[str]]) -> None:
+    expected = _write_archive(image.archive_path(root, image.tag(root)))
+
+    runtime = container.runtime_for_run(root, build=False)
+
+    assert runtime.runtime == "podman-hpc"
+    assert _argvs(hpc, "podman-hpc", "image") == [["podman-hpc", "image", "exists", expected]]
+    assert len(_argvs(hpc, "podman-hpc", "load")) == 1
+    assert _argvs(hpc, "podman-hpc", "migrate") == [["podman-hpc", "migrate", expected]]
+
+
+def test_migrate_runs_even_when_the_store_already_holds_the_image(
+    root: Path, hpc: list[list[str]]
+) -> None:
+    """The migrate lives outside the load branch: a store hit (or a fresh
+    build) must still put the squashed copy where compute nodes look."""
+    _write_archive(image.archive_path(root, image.tag(root)))
+
+    container.runtime_for_run(root, build=False)
+    container.runtime_for_run(root, build=False)
+
+    assert len(_argvs(hpc, "podman-hpc", "load")) == 1
+    assert len(_argvs(hpc, "podman-hpc", "migrate")) == 2
+
+
+def test_podman_hpc_builds_saves_and_migrates(root: Path, hpc: list[list[str]]) -> None:
+    """The wrapper is build-capable — NERSC login nodes are where the
+    matching-arch archive comes from — and a fresh build still migrates."""
+    runtime, verdict = container.build(root)
+
+    assert verdict == "built"
+    assert len(_argvs(hpc, "podman-hpc", "build")) == 1
+    (save,) = _argvs(hpc, "podman-hpc", "save")
+    assert save[2:4] == ["--format", "docker-archive"]
+    assert _argvs(hpc, "podman-hpc", "migrate") == [["podman-hpc", "migrate", runtime.image_id]]
+
+
+def test_podman_hpc_keeps_the_uid_and_forbids_pulling(root: Path, hpc: list[list[str]]) -> None:
+    _write_archive(image.archive_path(root, image.tag(root)))
+    runtime = container.runtime_for_run(root, build=False)
+
+    assert container.uid_flags("podman-hpc") == ["--userns=keep-id"]
+    backend = container.backend(runtime)
+    assert backend.capability.kind == "podman-hpc"
+    assert "--pull=never" in backend.user_flags  # type: ignore[attr-defined]
+    assert "--userns=keep-id" in backend.user_flags  # type: ignore[attr-defined]
+
+
+# ---- the architecture gate --------------------------------------------------
+
+
+def test_a_foreign_arch_archive_refuses_before_loading(
+    root: Path, fake: list[list[str]]
+) -> None:
+    """A wrong-arch load *succeeds* and then dies as `exec format error`
+    deep inside a recipe — so the refusal comes first, naming the fix."""
+    _write_archive(
+        image.archive_path(root, image.tag(root)), b'{"architecture":"arm64","os":"linux"}'
+    )
+
+    with pytest.raises(ProjectError, match="built for arm64 and this host is amd64"):
+        container.runtime_for_run(root, build=False)
+
+    assert _argvs(fake, "podman", "load") == []
+
+
+def test_the_matching_arch_loads(root: Path, fake: list[list[str]]) -> None:
+    _write_archive(image.archive_path(root, image.tag(root)))
+
+    assert container.runtime_for_run(root, build=False).arch == "amd64"
+    assert len(_argvs(fake, "podman", "load")) == 1
+
+
+def test_an_unknown_arch_is_not_refused(
+    root: Path, fake: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ignorance is not a mismatch — an archive that does not say, or a
+    host machine outside the map, passes rather than refusing blind."""
+    _write_archive(image.archive_path(root, image.tag(root)), b'{"os":"linux"}')
+    container.runtime_for_run(root, build=False)
+
+    monkeypatch.setattr(container.platform, "machine", lambda: "riscv64")
+    _write_archive(image.archive_path(root, image.tag(root)))
+    container.runtime_for_run(root, build=False)

--- a/tests/test_container_smoke.py
+++ b/tests/test_container_smoke.py
@@ -48,8 +48,15 @@ outputs:
 
 
 def _available() -> list[str]:
-    """The runtimes this host can actually run, probed once at collection."""
+    """The runtimes this host can actually run, probed once at collection.
+
+    podman-hpc exists only where a site installed it (NERSC login nodes),
+    so its parametrization never fires in CI — running this suite on such
+    a host is the site spike.
+    """
     found = []
+    if shutil.which("podman-hpc"):
+        found.append("podman-hpc")
     if shutil.which("podman"):
         found.append("podman")
     try:
@@ -90,7 +97,7 @@ def runtime(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> 
         shutil,
         "which",
         lambda tool, path=None: None
-        if tool in ("podman", "docker") and tool != name
+        if tool in ("podman-hpc", "podman", "docker") and tool != name
         else real_which(tool, path=path),
     )
     return name

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -867,6 +867,31 @@ def test_a_real_cluster_still_fits_through_the_seam(root: Path) -> None:
     assert not dataset.status(root)
 
 
+def test_a_processes_cluster_fits_through_the_seam(
+    root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Workers in other processes — the shape every venue beyond one
+    machine has. Pins that the unit crosses the boundary by reference
+    (`worker.materialize`, `Task`, `Versions`, `TaskResult`) and that
+    results travel back whole."""
+
+    @contextmanager
+    def processes() -> Iterator[engine._Dask]:
+        from distributed import Client, LocalCluster
+
+        with LocalCluster(  # type: ignore[no-untyped-call]
+            n_workers=2, threads_per_worker=1, processes=True, dashboard_address=None
+        ) as cluster:
+            with Client(cluster) as client:  # type: ignore[no-untyped-call]
+                yield engine._Dask(client)
+
+    monkeypatch.setattr(engine, "cluster_for_run", processes)
+    report = engine.materialize(root, [])
+
+    assert report.made == ["baseline/first", "baseline/second"]
+    assert not dataset.status(root)
+
+
 # ---- the report ------------------------------------------------------------
 
 

--- a/tests/test_sandbox_oci.py
+++ b/tests/test_sandbox_oci.py
@@ -172,19 +172,15 @@ def test_runtimes_differ_only_in_their_spellings(root: Path, policy: Policy) -> 
     assert "--userns=keep-id" in podman and "--pull=never" in podman
     assert "--user" in docker and "1000:1000" in docker
     # The site wrapper is podman's argv with only the runtime word swapped.
-    assert hpc == [
-        a.replace("=podman", "=podman-hpc")
-        if a == "--env=LC_SANDBOX=podman"
-        else ("podman-hpc" if a == "podman" else a)
-        for a in podman
-    ]
+    swap = {"podman": "podman-hpc", "--env=LC_SANDBOX=podman": "--env=LC_SANDBOX=podman-hpc"}
+    assert hpc == [swap.get(a, a) for a in podman]
     strip = {
         "--userns=keep-id", "--pull=never", "--user", "1000:1000",
         "podman", "docker", "podman-hpc",
         "--env=LC_SANDBOX=podman", "--env=LC_SANDBOX=docker", "--env=LC_SANDBOX=podman-hpc",
     }  # fmt: skip
-    stripped = [[a for a in argv if a not in strip] for argv in (podman, docker, hpc)]
-    assert stripped[0] == stripped[1] == stripped[2]
+    p, d, h = ([a for a in argv if a not in strip] for argv in (podman, docker, hpc))
+    assert p == d == h
 
 
 def test_the_environment_is_an_allowlist_never_ambient(

--- a/tests/test_sandbox_oci.py
+++ b/tests/test_sandbox_oci.py
@@ -45,7 +45,11 @@ def policy(root: Path) -> Policy:
 
 
 def _backend(root: Path, runtime: str = "podman") -> OCIBackend:
-    flags = ("--userns=keep-id", "--pull=never") if runtime == "podman" else ("--user", "1000:1000")
+    flags = (
+        ("--user", "1000:1000")
+        if runtime == "docker"
+        else ("--userns=keep-id", "--pull=never")
+    )
     return OCIBackend(
         runtime=runtime,  # type: ignore[arg-type]
         image_id=_IMAGE_ID,
@@ -164,13 +168,23 @@ def test_the_network_is_denied_by_flag(root: Path, policy: Policy) -> None:
 def test_runtimes_differ_only_in_their_spellings(root: Path, policy: Policy) -> None:
     podman = _backend(root, "podman").wrap(policy, ["true"])
     docker = _backend(root, "docker").wrap(policy, ["true"])
+    hpc = _backend(root, "podman-hpc").wrap(policy, ["true"])
     assert "--userns=keep-id" in podman and "--pull=never" in podman
     assert "--user" in docker and "1000:1000" in docker
+    # The site wrapper is podman's argv with only the runtime word swapped.
+    assert hpc == [
+        a.replace("=podman", "=podman-hpc")
+        if a == "--env=LC_SANDBOX=podman"
+        else ("podman-hpc" if a == "podman" else a)
+        for a in podman
+    ]
     strip = {
-        "--userns=keep-id", "--pull=never", "--user", "1000:1000", "podman", "docker",
-        "--env=LC_SANDBOX=podman", "--env=LC_SANDBOX=docker",
+        "--userns=keep-id", "--pull=never", "--user", "1000:1000",
+        "podman", "docker", "podman-hpc",
+        "--env=LC_SANDBOX=podman", "--env=LC_SANDBOX=docker", "--env=LC_SANDBOX=podman-hpc",
     }  # fmt: skip
-    assert [a for a in podman if a not in strip] == [a for a in docker if a not in strip]
+    stripped = [[a for a in argv if a not in strip] for argv in (podman, docker, hpc)]
+    assert stripped[0] == stripped[1] == stripped[2]
 
 
 def test_the_environment_is_an_allowlist_never_ambient(
@@ -197,7 +211,7 @@ def test_no_host_resolved_env_binary_in_the_argv(root: Path, policy: Policy) -> 
 
 
 def test_the_attestation_is_derived_from_the_flags(root: Path, policy: Policy) -> None:
-    for runtime in ("podman", "docker"):
+    for runtime in ("podman", "docker", "podman-hpc"):
         attested = _backend(root, runtime).attest(policy)
         assert attested.mechanism == runtime
         assert attested.fs == "declared"

--- a/tests/test_venue.py
+++ b/tests/test_venue.py
@@ -129,8 +129,38 @@ def test_an_allocation_passes_the_guard(monkeypatch: pytest.MonkeyPatch) -> None
     venue.require_compute_node()
 
 
-def test_a_machine_that_is_not_nersc_passes_the_guard() -> None:
+def test_a_host_no_site_marker_names_passes_the_guard() -> None:
     venue.require_compute_node()
+
+
+def test_a_new_center_is_one_table_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The guard is data: a center lands as its marker plus its own
+    verified allocation spellings, and the message carries them."""
+    monkeypatch.setattr(
+        venue,
+        "_SITES",
+        (
+            venue._Site(
+                name="Fictional Computing",
+                marker="FCC_HOST",
+                salloc="salloc --partition=work --time=01:00:00",
+                sbatch="sbatch --partition=work --time=01:00:00",
+            ),
+        ),
+    )
+    monkeypatch.setenv("FCC_HOST", "cluster9")
+
+    with pytest.raises(ProjectError) as err:
+        venue.require_compute_node()
+
+    message = str(err.value)
+    assert "Fictional Computing login node" in message
+    assert "FCC_HOST" in message
+    assert "salloc --partition=work --time=01:00:00" in message
+    assert "sbatch --partition=work --time=01:00:00" in message
+
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+    venue.require_compute_node()  # inside an allocation the same site passes
 
 
 def test_the_read_only_verbs_work_on_a_login_node(

--- a/tests/test_venue.py
+++ b/tests/test_venue.py
@@ -253,3 +253,82 @@ def test_a_dead_srun_reports_its_exit_code(
     with pytest.raises(ProjectError, match="exited with code 3"):
         with venue.slurm_client():
             pass
+
+
+# ---- the fixes the first review asked for -----------------------------------
+
+
+def test_slurm_counts_that_are_not_numbers_refuse(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mangled count is the same leak class as SLURM_JOB_ID without an
+    srun, and gets the same curated refusal — never a ValueError traceback."""
+    with pytest.raises(ProjectError, match="SLURM_CPUS_ON_NODE"):
+        venue._int_env("72(x2)", "SLURM_CPUS_ON_NODE")
+
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+    monkeypatch.setenv("SLURM_JOB_NUM_NODES", "four")
+    with pytest.raises(ProjectError, match="SLURM_JOB_NUM_NODES"):
+        venue.allocation_nodes()
+
+
+def test_allocation_nodes_answers_zero_outside_an_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert venue.allocation_nodes() == 0
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+    assert venue.allocation_nodes() == 1  # in one, count unstated
+    monkeypatch.setenv("SLURM_JOB_NUM_NODES", "3")
+    assert venue.allocation_nodes() == 3
+
+
+def test_an_unresolvable_node_name_is_a_refusal_not_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SLURM's NodeName is an alias, not a promise of a hostname."""
+    _allocation(monkeypatch)
+    monkeypatch.setenv("SLURMD_NODENAME", "no-such-node.invalid")
+    _stub_srun(tmp_path, monkeypatch, "exit 0\n")
+
+    with pytest.raises(ProjectError, match="did not resolve"):
+        with venue.slurm_client():
+            pass
+
+
+def test_a_multi_node_allocation_refuses_a_node_local_image_store(
+    root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """podman's and docker's stores are node-local; only podman-hpc's
+    migrate makes an image visible to the allocation's other nodes.
+    Mutation check: the same state under podman-hpc reaches runtime
+    resolution — the gate itself is what stands between them."""
+    from lightcone.engine import container
+
+    text = (root / "pyproject.toml").read_text()
+    (root / "pyproject.toml").write_text(text + '\n[tool.lightcone.image]\napt-install = ["bc"]\n')
+    dataset.save(root, [root], "containerize")
+    _allocation(monkeypatch, nodes=2)
+    monkeypatch.setattr(container, "runtime_name", lambda r: "podman")
+
+    with pytest.raises(ProjectError, match="node-local"):
+        engine.materialize(root, [])
+
+    monkeypatch.setattr(container, "runtime_name", lambda r: "podman-hpc")
+
+    def reached(r: Path, *, build: bool) -> None:
+        raise ProjectError("reached runtime resolution")
+
+    monkeypatch.setattr(container, "runtime_for_run", reached)
+    with pytest.raises(ProjectError, match="reached runtime resolution"):
+        engine.materialize(root, [])
+
+
+def test_the_rerun_entry_point_is_guarded_like_materialize(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A rerun executes a recipe, so a NERSC login node refuses it too."""
+    from lightcone.engine import worker
+
+    monkeypatch.setenv("NERSC_HOST", "perlmutter")
+
+    assert worker.main(["baseline/first"]) == 2
+    err = capsys.readouterr().err
+    assert "login node" in err and "salloc" in err

--- a/tests/test_venue.py
+++ b/tests/test_venue.py
@@ -69,21 +69,18 @@ def _allocation(monkeypatch: pytest.MonkeyPatch, *, nodes: int = 1) -> None:
     monkeypatch.setenv("SLURMD_NODENAME", "127.0.0.1")
 
 
-def _stub_srun(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, body: str) -> Path:
-    """Put a bash srun on PATH and return the directory holding it.
-
-    The default body is what a real srun does from lc's point of view:
-    drop the step flags, honor ``--ntasks``, run the worker command.
-    """
+def _stub_srun(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, body: str) -> None:
+    """Put a bash srun with *body* on PATH."""
     stubs = tmp_path / "stubs"
     stubs.mkdir(exist_ok=True)
     stub = stubs / "srun"
     stub.write_text(f"#!/usr/bin/env bash\n{textwrap.dedent(body)}")
     stub.chmod(0o755)
     monkeypatch.setenv("PATH", f"{stubs}{os.pathsep}{os.environ['PATH']}")
-    return stubs
 
 
+#: What a real srun does from lc's point of view: drop the step flags,
+#: honor ``--ntasks``, run the worker command.
 _FAITHFUL = """
 ntasks=1
 while [[ $1 == --* ]]; do
@@ -152,30 +149,27 @@ def test_the_read_only_verbs_work_on_a_login_node(
 
 def test_the_srun_argv_spans_the_allocation() -> None:
     import sys
-    import tempfile
 
-    argv = venue._srun_argv("tcp://10.0.0.1:8786", 4, 128, tempfile.gettempdir())
+    argv = venue._srun_argv("tcp://10.0.0.1:8786", 4, 128, "/scratch")
 
-    assert argv[:5] == [
+    assert argv == [
         "srun",
         "--overlap",
         "--ntasks=4",
         "--ntasks-per-node=1",
         "--cpus-per-task=128",
-    ]
-    assert argv[5:8] == [sys.executable, "-m", "distributed.cli.dask_worker"]
-    assert argv[8] == "tcp://10.0.0.1:8786"
-    rest = argv[9:]
-    for flag, value in (
-        ("--nthreads", "128"),
-        ("--nworkers", "1"),
-        ("--death-timeout", "60"),
-        ("--memory-limit", "0"),
-        ("--local-directory", tempfile.gettempdir()),
-    ):
-        assert rest[rest.index(flag) + 1] == value
-    assert "--no-dashboard" in rest
-    assert "--no-nanny" in rest
+        sys.executable,
+        "-m",
+        "distributed.cli.dask_worker",
+        "tcp://10.0.0.1:8786",
+        "--nthreads", "128",
+        "--nworkers", "1",
+        "--no-dashboard",
+        "--no-nanny",
+        "--death-timeout", "60",
+        "--memory-limit", "0",
+        "--local-directory", "/scratch",
+    ]  # fmt: skip
 
 
 def test_slurm_without_srun_refuses(
@@ -261,8 +255,9 @@ def test_a_dead_srun_reports_its_exit_code(
 def test_slurm_counts_that_are_not_numbers_refuse(monkeypatch: pytest.MonkeyPatch) -> None:
     """A mangled count is the same leak class as SLURM_JOB_ID without an
     srun, and gets the same curated refusal — never a ValueError traceback."""
+    monkeypatch.setenv("SLURM_CPUS_ON_NODE", "72(x2)")
     with pytest.raises(ProjectError, match="SLURM_CPUS_ON_NODE"):
-        venue._int_env("72(x2)", "SLURM_CPUS_ON_NODE")
+        venue._int_env("SLURM_CPUS_ON_NODE", 1)
 
     monkeypatch.setenv("SLURM_JOB_ID", "12345")
     monkeypatch.setenv("SLURM_JOB_NUM_NODES", "four")
@@ -306,12 +301,12 @@ def test_a_multi_node_allocation_refuses_a_node_local_image_store(
     (root / "pyproject.toml").write_text(text + '\n[tool.lightcone.image]\napt-install = ["bc"]\n')
     dataset.save(root, [root], "containerize")
     _allocation(monkeypatch, nodes=2)
-    monkeypatch.setattr(container, "runtime_name", lambda r: "podman")
+    monkeypatch.setattr(container, "runtime_hint", lambda: "podman")
 
     with pytest.raises(ProjectError, match="node-local"):
         engine.materialize(root, [])
 
-    monkeypatch.setattr(container, "runtime_name", lambda r: "podman-hpc")
+    monkeypatch.setattr(container, "runtime_hint", lambda: "podman-hpc")
 
     def reached(r: Path, *, build: bool) -> None:
         raise ProjectError("reached runtime resolution")

--- a/tests/test_venue.py
+++ b/tests/test_venue.py
@@ -1,0 +1,255 @@
+"""Tests for `lightcone.engine.venue` — the SLURM allocation, and the guard.
+
+The venue's whole surface is ambient: environment variables and an srun
+on PATH. So the suite fakes the *host* rather than the code — SLURM
+variables set deliberately, and a bash stub standing in for srun that
+launches the worker command locally — and the end-to-end tests run the
+real graph through the real detection, bind, launch and teardown path on
+any machine.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from lightcone.engine import dataset, venue
+from lightcone.engine import materialize as engine
+from lightcone.engine.project import ProjectError
+
+_SPEC = """
+version: "0.0.13"
+name: analysis
+
+inputs:
+  - id: catalog
+    type: data
+    source: data/catalog.fits
+
+outputs:
+  - id: first
+    type: metric
+    decisions: [method]
+    recipe:
+      command: echo {decisions.method} > {output}/value.txt
+
+  - id: second
+    type: report
+    inputs: [first]
+    recipe:
+      command: cat {inputs.first}/value.txt > {output}/copy.txt
+
+decisions:
+  method:
+    label: Method
+    default: alpha
+    options:
+      alpha: {label: alpha}
+      beta: {label: beta}
+"""
+
+_UNIVERSE = "id: baseline\ndecisions:\n  method: alpha\n"
+
+
+@pytest.fixture
+def root(analysis: Callable[..., Path]) -> Path:
+    return analysis(_SPEC, universes={"baseline": _UNIVERSE})
+
+
+def _allocation(monkeypatch: pytest.MonkeyPatch, *, nodes: int = 1) -> None:
+    """The environment salloc leaves on the head compute node."""
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+    monkeypatch.setenv("SLURM_JOB_NUM_NODES", str(nodes))
+    monkeypatch.setenv("SLURM_CPUS_ON_NODE", "2")
+    # The literal IP keeps the scheduler bind hermetic against CI DNS.
+    monkeypatch.setenv("SLURMD_NODENAME", "127.0.0.1")
+
+
+def _stub_srun(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, body: str) -> Path:
+    """Put a bash srun on PATH and return the directory holding it.
+
+    The default body is what a real srun does from lc's point of view:
+    drop the step flags, honor ``--ntasks``, run the worker command.
+    """
+    stubs = tmp_path / "stubs"
+    stubs.mkdir(exist_ok=True)
+    stub = stubs / "srun"
+    stub.write_text(f"#!/usr/bin/env bash\n{textwrap.dedent(body)}")
+    stub.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{stubs}{os.pathsep}{os.environ['PATH']}")
+    return stubs
+
+
+_FAITHFUL = """
+ntasks=1
+while [[ $1 == --* ]]; do
+  case "$1" in --ntasks=*) ntasks="${1#--ntasks=}";; esac
+  shift
+done
+pids=()
+for _ in $(seq "$ntasks"); do
+  "$@" &
+  pids+=($!)
+done
+wait "${pids[@]}"
+"""
+
+
+# ---- the login guard --------------------------------------------------------
+
+
+def test_a_login_node_refuses_with_both_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NERSC_HOST", "perlmutter")
+
+    with pytest.raises(ProjectError) as err:
+        venue.require_compute_node()
+
+    message = str(err.value)
+    assert "salloc" in message
+    assert "sbatch" in message
+    assert "--wrap 'lc materialize'" in message
+
+
+def test_the_guard_fires_before_anything_else(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even a directory that is not a project refuses as a login node — the
+    allocation is the remedy with queue latency, so it comes first."""
+    monkeypatch.setenv("NERSC_HOST", "perlmutter")
+
+    with pytest.raises(ProjectError, match="login node"):
+        engine.materialize(tmp_path, [])
+
+
+def test_an_allocation_passes_the_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NERSC_HOST", "perlmutter")
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+
+    venue.require_compute_node()
+
+
+def test_a_machine_that_is_not_nersc_passes_the_guard() -> None:
+    venue.require_compute_node()
+
+
+def test_the_read_only_verbs_work_on_a_login_node(
+    root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--check` and `status` are for finding out where a project stands,
+    and a login node is exactly where that question gets asked."""
+    monkeypatch.setenv("NERSC_HOST", "perlmutter")
+
+    assert set(engine.check(root, []).planned) == {"baseline/first", "baseline/second"}
+    assert engine.status(root).counts["stale"] == 2
+
+
+# ---- the srun invocation ----------------------------------------------------
+
+
+def test_the_srun_argv_spans_the_allocation() -> None:
+    import sys
+    import tempfile
+
+    argv = venue._srun_argv("tcp://10.0.0.1:8786", 4, 128, tempfile.gettempdir())
+
+    assert argv[:5] == [
+        "srun",
+        "--overlap",
+        "--ntasks=4",
+        "--ntasks-per-node=1",
+        "--cpus-per-task=128",
+    ]
+    assert argv[5:8] == [sys.executable, "-m", "distributed.cli.dask_worker"]
+    assert argv[8] == "tcp://10.0.0.1:8786"
+    rest = argv[9:]
+    for flag, value in (
+        ("--nthreads", "128"),
+        ("--nworkers", "1"),
+        ("--death-timeout", "60"),
+        ("--memory-limit", "0"),
+        ("--local-directory", tempfile.gettempdir()),
+    ):
+        assert rest[rest.index(flag) + 1] == value
+    assert "--no-dashboard" in rest
+    assert "--no-nanny" in rest
+
+
+def test_slurm_without_srun_refuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A leaked SLURM_JOB_ID — a container, a copied environment — must be
+    a loud refusal, never a silent fall back to running locally."""
+    _allocation(monkeypatch)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    with pytest.raises(ProjectError, match="srun is not on PATH"):
+        with venue.slurm_client():
+            pass
+
+
+# ---- the allocation, end to end ---------------------------------------------
+
+
+def test_a_run_spans_the_allocation(
+    root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole venue path — detection, scheduler bind, worker launch,
+    a real graph in a real worker process, teardown — with only srun faked."""
+    _allocation(monkeypatch)
+    _stub_srun(tmp_path, monkeypatch, _FAITHFUL)
+
+    report = engine.materialize(root, [])
+
+    assert report.made == ["baseline/first", "baseline/second"]
+    assert (root / "results/baseline/second/copy.txt").read_text() == "alpha\n"
+    assert not dataset.status(root)
+
+
+def test_every_allocated_node_gets_a_worker(
+    root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two declared nodes, a stub honoring ``--ntasks`` — completion proves
+    the run waited for both workers and used the count it was granted."""
+    _allocation(monkeypatch, nodes=2)
+    _stub_srun(tmp_path, monkeypatch, _FAITHFUL)
+
+    report = engine.materialize(root, [])
+
+    assert report.made == ["baseline/first", "baseline/second"]
+    assert not dataset.status(root)
+
+
+def test_workers_that_never_connect_refuse_and_reap_srun(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _allocation(monkeypatch)
+    pidfile = tmp_path / "srun.pid"
+    _stub_srun(tmp_path, monkeypatch, f"echo $$ > {pidfile}\nexec sleep 60\n")
+    monkeypatch.setattr(venue, "_WORKER_WAIT", 2.0)
+    monkeypatch.setattr(venue, "_REAP_GRACE", 0.5)
+
+    with pytest.raises(ProjectError, match=r"expected 1 dask worker"):
+        with venue.slurm_client():
+            pass
+
+    pid = int(pidfile.read_text())
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)
+
+
+def test_a_dead_srun_reports_its_exit_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """srun failing is srun's error, reported as such — not a two-minute
+    wait that ends in a timeout blaming the workers."""
+    _allocation(monkeypatch)
+    _stub_srun(tmp_path, monkeypatch, "exit 3\n")
+    monkeypatch.setattr(venue, "_REAP_GRACE", 0.5)
+
+    with pytest.raises(ProjectError, match="exited with code 3"):
+        with venue.slurm_client():
+            pass


### PR DESCRIPTION
The first HPC venue, NERSC-focused, in two commits.

## The SLURM venue (7a)

`lc materialize` inside a SLURM allocation now spans every node it was granted: `cluster_for_run()` detects `SLURM_JOB_ID`, binds the Dask scheduler in the driver process to `SLURMD_NODENAME`, and launches one worker per node with a single `srun` on the driver's own interpreter — so driver and workers are the identical installation off the shared filesystem, which is all a worker needs (`lightcone.engine` importable at the driver's version; no git, no annex). Detected, never configured: the allocation *is* the resource declaration, the same shape as mode derivation. No new dependency.

```
salloc -N 4 -C cpu -q regular -t 2:00:00
lc materialize            # runs across all 4 nodes

# or, fire-and-forget from a login node:
sbatch -N 4 -C cpu -q regular -t 2:00:00 --wrap 'lc materialize'
```

A NERSC login node refuses `lc materialize` first thing, naming both commands above; `--check`, `status` and `lc run` work anywhere. A dead srun reports its own exit code; teardown retires workers so srun ends silently. A dask-jobqueue submission venue, if ever wanted, is one more branch in the same ladder plus the config table it genuinely needs.

The suite fakes the *host*, never the code: SLURM env vars plus a bash stub for srun drive the real graph through the real detection → bind → launch → teardown path in CI, with real worker processes. A new `LocalCluster(processes=True)` test pins the cross-process pickling contract the recorded decision asked layer 7 to re-verify.

## podman-hpc (7b)

A containerized project now runs on NERSC: podman-hpc lands as a spelling inside the existing `OCIBackend` — no new shape — plus one step, `podman-hpc migrate <id>`, placed outside the load branch (a fresh build never loads, yet compute nodes only see migrated images) and run driver-side once for all nodes. Detection prefers the wrapper over bare podman (whose node-local store is exactly what compute nodes cannot see); it is build-capable, making a login node the source of matching-arch archives. A foreign-arch archive refuses before the load, naming both arches and the fix. apptainer/singularity stay deferred; CLAUDE.md records the design headroom they need (Runtime stays facts; honest `network: allowed` for a runtime that cannot deny; the exit-125 note is a podman/docker-family fact).

## Verification

- 519 tests pass locally (`uv run pytest`), ruff and mypy clean.
- The container smoke suite gains podman-hpc as a parametrization that fires only where the site tool exists — running it on a Perlmutter login node is the spike vehicle; the checklist (srun `--overlap`, `--network none` on compute, `--module` mounts vs `fs: declared`, migrate-by-id, Landlock in the SLES LSM list, Lustre annex timings) is recorded in CLAUDE.md.

Deviation from the approved plan, recorded: the plan called for two PRs; repo convention is one PR per layer (#175, #180), so both parts land here as separate commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oVCfc4eZdyKqT1zY95Xi2