### PR TITLE
Layer 8: the publication view — the RO-Crate converged, integrity as a status fact

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,9 @@ jobs:
       # the runtimes (ubuntu ships podman and a running docker daemon).
       # macOS runners have no podman machine, so there the suite skips.
       LC_CONTAINER_TESTS_REQUIRED: ${{ matrix.os == 'ubuntu-latest' && '1' || '' }}
+      # And for the crate validation: rocrate-validator is in the dev
+      # group, so every runner has it and none may skip.
+      LC_CRATE_TESTS_REQUIRED: "1"
 
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1778,15 +1778,17 @@ the bytes — so it classifies `stale` and **the next run remakes it**,
 the same philosophy as the dirty refusal's path split: `results/` is
 lc's to write, and a committed hand edit is wreckage with a commit
 message. Three coherent surfaces, one walk: `lc status` reports it
-stale (still exit 0; `OutputStatus.foreign_write` keeps the named
-commit for machine consumers), `--check` plans it, and materialize's
-driver answers the history question up front and hands each worker the
-foreign commit's message — workers have no git, the HEAD discipline on
-a third value. History enters `assets.classify` as **one more input
-value**, exactly like check mode's sentinel: computed by whoever has
-git, handed in, and the rule stays pure — so `calls_for_a_remake`
-remains the one bool that turns a state into an action, with no
-`foreign or …` re-spelled at any call site. `last_writer` answers "cannot say" as
+stale (still exit 0; `OutputStatus.foreign_write` carries the foreign
+commit's sha — what prose cannot give a machine consumer), `--check`
+plans it, and materialize's driver answers the history question up
+front and hands each worker the offending `dataset.LastWrite` —
+workers have no git, the HEAD discipline on a third value. History
+enters `assets.classify` as **one more input value**, exactly like
+check mode's sentinel: computed by whoever has git, handed in as the
+*fact*, and the rule stays pure — the verdict's prose is classify's,
+like every other why, so `calls_for_a_remake` remains the one bool
+that turns a state into an action, with no `foreign or …` re-spelled
+at any call site. `last_writer` answers "cannot say" as
 empty, never an error — a read-only verb must not refuse over an
 unborn HEAD or a stripped `.git`. A full-rehash `lc verify` was
 considered and rejected: O(bytes), blind on unfetched outputs (history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ speculatively.
 | 5 | **Sandbox layer** — Landlock / Seatbelt, exec-shim, denial UX, `lc run` | ✅ **done** |
 | 6 | **Container hatch** — `[tool.lightcone.image]`, `lc build`, OCI runtimes as the exec boundary, the image archived in the dataset | ✅ **done** |
 | 7 | **Venues** — SLURM in-allocation execution, login guard, podman-hpc | 🔶 **landed; Perlmutter spike pending** — hub/GKE and Cloud Build deferred to their own layer |
-| 8 | `lc verify`, WRROC export | ⬜ |
+| 8 | **Publication view** — the RO-Crate converged by materialize, the foreign-write status fact; **no `lc verify`, no `lc export`, by decision** | ✅ **done** |
 
 `lc status` landed with the invalidation model rather than at layer 8:
 once an output can be *behind*, something has to say which ones are, and
@@ -165,6 +165,7 @@ src/lightcone/              # namespace — NO __init__.py
     ├── identity.py         # env_version, definition_version, the lock scan
     ├── image.py            # the system layer: declaration, Containerfile, tag — pure
     ├── container.py        # runtimes, the build, the archived image — impure
+    ├── crate.py            # the publication view: the repo as an RO-Crate — pure
     ├── assets.py           # an output: its directory, its manifest, its state
     ├── plan.py             # the spec, read as a graph of tasks
     ├── worker.py           # making one output; also the `python -m` entry point
@@ -1156,7 +1157,11 @@ provides that, and for what workers do *not* need (git, git-annex).
   `git_remote`, `lc_version`, `hermeticity` — and, since layer 6,
   `image` (`{tag, id, archive, arch}`, defaulting to ``None`` because
   that is the true value for a host run — not back-compat machinery,
-  and `SCHEMA_VERSION` stays 1 pre-release). Spec §3's longer list —
+  and `SCHEMA_VERSION` stays 1 pre-release), and since layer 8
+  `started_at` / `finished_at` (ISO 8601 UTC, **millisecond** precision
+  because RO-Crate consumers parse `endTime` with at most three
+  fractional digits; attestation like `lc_version`, defaulted `""`,
+  never read by `classify`). Spec §3's longer list —
   `uv_version`, `platform`, `worker_runtime`, `python_build`,
   `dpkg_snapshot_sha256`, `sdist_built`, `env_snapshot`, `gpu_driver` —
   is attestation nothing here reads; it lands with the verb that reads
@@ -1683,6 +1688,111 @@ that could add a flag); whether Landlock is in the SLES boot LSM list
 the downgrade note); `git annex add`/`get` timings on `$SCRATCH` and
 `$CFS` (the recorded Lustre residue).
 
+## Key Invariants (layer 8)
+
+**The project is the crate, and materialize maintains it — there is no
+export verb.** `ro-crate-metadata.json` sits at the project root as a
+derived artifact, converged by `lc materialize` the way `uv.lock` is:
+`engine/crate.py` renders it from repository state, the hook
+(`materialize._converge_crate`) string-compares it against the tree, and
+only a difference is written and committed — alone, in its own trailing
+commit, which `datalad rerun` skips harmlessly as "no command". Deposit
+is `git archive` / `datalad export-archive` on a repository that is
+already a crate; nothing is copied and there is no bundle directory.
+The rerun entry point deliberately does not regenerate it (it is one
+task's executor, not the driver), so the crate lags until the next
+materialize — recorded residue.
+
+**Publication intent is derived, never configured.** A
+`[project].license` in `pyproject.toml` turns crate maintenance on —
+RO-Crate *requires* a license, materialize must not refuse to run
+science over a missing key, and inventing CC-BY-4.0 (the pre-rebuild
+default) asserts terms over someone's data. Absent ⇒ no crate and one
+report line; removed later ⇒ the file is left (it is in committed
+history either way) and the line says it is no longer maintained. The
+same shape as `[tool.lightcone.image]` deriving containerized mode.
+
+**The document is a pure function of repository state, and that is what
+makes convergence sound.** The clock never enters it: `datePublished` is
+the newest manifest `finished_at` (the spec file's own last-commit date
+for a never-materialized project) and **must override rocrate's
+default**, which stamps construction time — the old exporter carried a
+`datePublished` its code never set. Entities are built in sorted order
+and serialized with `sort_keys`;
+`test_rendering_twice_at_the_same_state_is_byte_identical` pins it. The
+render is also injected-pure: `dataset.last_writer` comes in as a
+callable and `dsid` as a value, so `tests/test_crate.py` runs with no
+git at all.
+
+**Run identity comes free from `git_sha`.** The driver reads HEAD once
+per run and hands it down, so every output of one materialize carries
+the same sha — grouping manifests by it *is* grouping by run, and that
+is what makes the Provenance profile expressible with no new manifest
+field: one `OrganizeAction` + workflow-level `CreateAction` per run, a
+`ControlAction` per output execution, a `HowToStep` per output id
+(deduped across universes: a step is spec structure, an action is one
+execution — exactly how the multiverse maps on).
+
+**The crate's `Person` is the author of the output's *saving* commit,
+via `last_writer` — never the manifest's `git_sha`**, which is the
+commit the run *started* at and can be someone else's. No `--author`
+flag, no env var, no config probe: `require_committer` already
+guarantees the commit has an author.
+
+**The manifest stays canonical; the crate does not transliterate it.**
+`env_version`, `definition_version` and `hermeticity` get no schema.org
+spelling — the manifest itself is in the crate as a `File`, `subjectOf`
+its output's `Dataset`, so nothing is lost and no vocabulary is
+invented. What does get real vocabulary comes from the workflow-run
+`@context` (`https://w3id.org/ro/terms/workflow-run`), without which
+`containerImage`, `sha256` and `ContainerImage` are undefined terms
+JSON-LD drops on expansion — the pre-rebuild exporter's silent failure.
+The committed archive is one entity, `["File", "ContainerImage"]`,
+identity (`sha256` = config-blob id) and payload together.
+
+**The validator floor is pinned as a set, not a count.**
+`tests/test_crate_smoke.py` materializes a real project and runs the
+official `rocrate-validator` (dev dependency) against Provenance Run
+Crate 0.5: REQUIRED must be clean, and RECOMMENDED failures must stay
+within `_FLOOR` — checks the crate cannot truthfully satisfy (the
+workflow's id is its in-crate path and the shape wants `^http`; an
+annex-stored image has no registry; lc knows no publisher and no
+affiliation). A new failure is a regression, a disappearing one is the
+floor to shrink. Gated like the container smoke suite:
+`LC_CRATE_TESTS_REQUIRED=1` in CI turns the no-validator skip into a
+failure, two tests cover the guard.
+
+**Integrity is a status fact, not a verb — and it is history, not
+hashing.** The hole layer 4 recorded: a skip returns the *recorded*
+digest, so a hand-edited-and-committed output (the agent-forged-file
+scenario) reads `current` forever. The check: every output is
+committed, so a hand edit requires a commit, and
+`dataset.last_writer` names it — an output is cleanly written iff the
+commit that last touched its directory carries its own run-record
+subject. `materialize.run_subject` is the one spelling of that subject,
+shared by `run_record` (the composer) and `_foreign_write` (the
+comparator), because two strings here would drift. Surfaced as
+`OutputStatus.foreign_write` with the commit, author, date and a
+`git show` remedy — better forensics than "hash differs", O(history)
+not O(bytes), and it answers on a bytes-free clone, which a rehash
+cannot. Status still always exits 0. A full-rehash `lc verify` was
+considered and rejected: unaffordable per run, blind on unfetched
+outputs, and with no lifecycle moment enforcing it — while status runs
+every time anyone asks where the project stands. What it leaves to
+existing tools, on purpose: uncommitted edits are a dirty tree, annex
+object corruption (the thin-write hazard included) is `git annex
+fsck`, and a manifest lc itself mis-recorded is the accepted residue
+only a rehash would catch. A commit that *forges* the run-record
+subject defeats the check — as a regenerated hash would defeat a
+rehash; the threat model is accidental damage and shortcuts, not
+adversaries (spec §7's line).
+
+**Forging in a test must break the hard link first.** Results are
+committed thin, so two byte-identical outputs share one annex object —
+an in-place `write_text` on one dirties the other, which is the
+recorded thin hazard demonstrating itself. `test_materialize._forge`
+unlinks before writing; a new tampering test should too.
+
 ### Recorded decisions
 
 - **The engine is the host's uv tool, never a project dependency**
@@ -1935,6 +2045,8 @@ the downgrade note); `git annex add`/`get` timings on `$SCRATCH` and
 | Change how a recipe runs | `src/lightcone/engine/worker.py` + `tests/test_worker.py` | Never raises, never writes git; mutation-check every denial test |
 | Change what a run commits | `src/lightcone/engine/materialize.py` + `tests/test_materialize.py` | The driver owns git alone; the tree ends as clean as it started |
 | Change where a run executes | `src/lightcone/engine/venue.py` + `materialize.cluster_for_run` + `tests/test_venue.py` | One detection ladder, in `cluster_for_run` alone; venues are detected, never configured; test by faking the host (env vars + a stub srun), never the code |
+| Change what the crate says | `src/lightcone/engine/crate.py` + `tests/test_crate.py` | Pure builder: sorted iteration, no clock, git injected as `writer`; structure tests, never byte goldens — the one byte-level claim is render-twice-identical. The validator floor lives in `tests/test_crate_smoke.py::_FLOOR` |
+| Change how a foreign write is detected | `dataset.last_writer` + `materialize._foreign_write` + `tests/test_dataset.py` | History, never hashing; `run_subject` is the one spelling of the record's subject |
 | Add a CLI verb | `src/lightcone/cli/commands.py` | `@main.command()`; keep logic in the engine, raise `ProjectError`, render here |
 | Add a sandbox mechanism | `src/lightcone/engine/sandbox/` | One module with a `Backend` (`wrap` pure, `attest` honest) + one line in `detect()`. Nothing above the seam changes |
 | Change what a sandboxed command may touch | `sandbox/policy.py` + `tests/test_sandbox_policy.py` | Path sets only — no mechanism ever leaks in here |
@@ -2034,6 +2146,15 @@ The sandbox suite splits along the seam, which is what makes it cheap:
   a real annex, materializes through the real Dask cluster, and runs a
   real `datalad rerun` on a bytes-free clone — the record's whole claim.
   Each denial sits beside its mutation check.
+- `tests/test_crate.py` — **pure**: fixture manifests on `tmp_path`, a
+  hand-built graph, a stub `writer` — no git anywhere. Structure and
+  ordering only; the single byte-level assertion is
+  render-twice-identical, the property convergence rests on.
+  `tests/test_crate_smoke.py` — **the validator's answer**, gated with
+  `LC_CRATE_TESTS_REQUIRED=1` (all CI runners — the validator is a dev
+  dependency, so none may skip): a real materialize, then the official
+  `rocrate-validator` against the Provenance profile, REQUIRED clean and
+  RECOMMENDED pinned to the recorded `_FLOOR` set.
 
 Note the autouse `tools` fixture stubs `engine.project._run` only —
 sandbox tests spawn real processes deliberately, and are the one place in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ speculatively.
 | 5 | **Sandbox layer** — Landlock / Seatbelt, exec-shim, denial UX, `lc run` | ✅ **done** |
 | 6 | **Container hatch** — `[tool.lightcone.image]`, `lc build`, OCI runtimes as the exec boundary, the image archived in the dataset | ✅ **done** |
 | 7 | **Venues** — SLURM in-allocation execution, login guard, podman-hpc | 🔶 **landed; Perlmutter spike pending** — hub/GKE and Cloud Build deferred to their own layer |
-| 8 | **Publication view** — the RO-Crate converged by materialize, the foreign-write status fact; **no `lc verify`, no `lc export`, by decision** | ✅ **done** |
+| 8 | **Publication view** — the RO-Crate converged by materialize, foreign writes stale by history; **no `lc verify`, no `lc export`, by decision** | ✅ **done** |
 
 `lc status` landed with the invalidation model rather than at layer 8:
 once an output can be *behind*, something has to say which ones are, and
@@ -1762,30 +1762,39 @@ floor to shrink. Gated like the container smoke suite:
 `LC_CRATE_TESTS_REQUIRED=1` in CI turns the no-validator skip into a
 failure, two tests cover the guard.
 
-**Integrity is a status fact, not a verb — and it is history, not
+**A foreign write is `stale`, everywhere, and it is history, not
 hashing.** The hole layer 4 recorded: a skip returns the *recorded*
 digest, so a hand-edited-and-committed output (the agent-forged-file
 scenario) reads `current` forever. The check: every output is
-committed, so a hand edit requires a commit, and
-`dataset.last_writer` names it — an output is cleanly written iff the
-commit that last touched its directory carries its own run-record
-subject. `materialize.run_subject` is the one spelling of that subject,
+committed, so a hand edit requires a commit, and `dataset.last_writer`
+names it — an output is cleanly written iff the commit that last
+touched its directory carries its own run-record subject.
+`materialize.datalad_run_subject` is the one spelling of that subject
+(named for whose format it is — datalad's, matched by `rerun`'s regex),
 shared by `run_record` (the composer) and `_foreign_write` (the
-comparator), because two strings here would drift. Surfaced as
-`OutputStatus.foreign_write` with the commit, author, date and a
-`git show` remedy — better forensics than "hash differs", O(history)
-not O(bytes), and it answers on a bytes-free clone, which a rehash
-cannot. Status still always exits 0. A full-rehash `lc verify` was
-considered and rejected: unaffordable per run, blind on unfetched
-outputs, and with no lifecycle moment enforcing it — while status runs
-every time anyone asks where the project stands. What it leaves to
-existing tools, on purpose: uncommitted edits are a dirty tree, annex
-object corruption (the thin-write hazard included) is `git annex
-fsck`, and a manifest lc itself mis-recorded is the accepted residue
-only a rehash would catch. A commit that *forges* the run-record
-subject defeats the check — as a regenerated hash would defeat a
-rehash; the threat model is accidental damage and shortcuts, not
-adversaries (spec §7's line).
+comparator), because two strings here would drift. A hit is a
+*contradiction*, not a circumstance — the manifest no longer describes
+the bytes — so it classifies `stale` and **the next run remakes it**,
+the same philosophy as the dirty refusal's path split: `results/` is
+lc's to write, and a committed hand edit is wreckage with a commit
+message. Three coherent surfaces, one walk: `lc status` reports it
+stale (still exit 0; `OutputStatus.foreign_write` keeps the named
+commit for machine consumers), `--check` plans it, and materialize's
+driver answers the history question up front and hands each worker a
+`foreign` flag — workers have no git, the HEAD discipline on a third
+value. The escalation lives in `_classified`, driver-side;
+`assets.classify` stays pure. `last_writer` answers "cannot say" as
+empty, never an error — a read-only verb must not refuse over an
+unborn HEAD or a stripped `.git`. A full-rehash `lc verify` was
+considered and rejected: O(bytes), blind on unfetched outputs (history
+answers on a bytes-free clone), and with no lifecycle moment enforcing
+it. What it leaves to existing tools, on purpose: uncommitted edits
+are a dirty tree, annex object corruption (the thin-write hazard
+included) is `git annex fsck`, and a manifest lc itself mis-recorded
+is the accepted residue only a rehash would catch. A commit that
+*forges* the run-record subject defeats the check — as a regenerated
+hash would defeat a rehash; the threat model is accidental damage and
+shortcuts, not adversaries (spec §7's line).
 
 **Forging in a test must break the hard link first.** Results are
 committed thin, so two byte-identical outputs share one annex object —
@@ -2046,7 +2055,7 @@ unlinks before writing; a new tampering test should too.
 | Change what a run commits | `src/lightcone/engine/materialize.py` + `tests/test_materialize.py` | The driver owns git alone; the tree ends as clean as it started |
 | Change where a run executes | `src/lightcone/engine/venue.py` + `materialize.cluster_for_run` + `tests/test_venue.py` | One detection ladder, in `cluster_for_run` alone; venues are detected, never configured; test by faking the host (env vars + a stub srun), never the code |
 | Change what the crate says | `src/lightcone/engine/crate.py` + `tests/test_crate.py` | Pure builder: sorted iteration, no clock, git injected as `writer`; structure tests, never byte goldens — the one byte-level claim is render-twice-identical. The validator floor lives in `tests/test_crate_smoke.py::_FLOOR` |
-| Change how a foreign write is detected | `dataset.last_writer` + `materialize._foreign_write` + `tests/test_dataset.py` | History, never hashing; `run_subject` is the one spelling of the record's subject |
+| Change how a foreign write is detected | `dataset.last_writer` + `materialize._foreign_write` + `tests/test_dataset.py` | History, never hashing; `datalad_run_subject` is the one spelling of the record's subject; a foreign write classifies `stale` in every verb |
 | Add a CLI verb | `src/lightcone/cli/commands.py` | `@main.command()`; keep logic in the engine, raise `ProjectError`, render here |
 | Add a sandbox mechanism | `src/lightcone/engine/sandbox/` | One module with a `Backend` (`wrap` pure, `attest` honest) + one line in `detect()`. Nothing above the seam changes |
 | Change what a sandboxed command may touch | `sandbox/policy.py` + `tests/test_sandbox_policy.py` | Path sets only — no mechanism ever leaks in here |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1780,10 +1780,13 @@ lc's to write, and a committed hand edit is wreckage with a commit
 message. Three coherent surfaces, one walk: `lc status` reports it
 stale (still exit 0; `OutputStatus.foreign_write` keeps the named
 commit for machine consumers), `--check` plans it, and materialize's
-driver answers the history question up front and hands each worker a
-`foreign` flag — workers have no git, the HEAD discipline on a third
-value. The escalation lives in `_classified`, driver-side;
-`assets.classify` stays pure. `last_writer` answers "cannot say" as
+driver answers the history question up front and hands each worker the
+foreign commit's message — workers have no git, the HEAD discipline on
+a third value. History enters `assets.classify` as **one more input
+value**, exactly like check mode's sentinel: computed by whoever has
+git, handed in, and the rule stays pure — so `calls_for_a_remake`
+remains the one bool that turns a state into an action, with no
+`foreign or …` re-spelled at any call site. `last_writer` answers "cannot say" as
 empty, never an error — a read-only verb must not refuse over an
 unborn HEAD or a stripped `.git`. A full-rehash `lc verify` was
 considered and rejected: O(bytes), blind on unfetched outputs (history

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "rich>=13.0",
     "git-annex>=10.2026",
     "distributed>=2026.7",
+    "rocrate>=0.15",
 ]
 
 [dependency-groups]
@@ -38,6 +39,7 @@ dev = [
     "ruff",
     "mypy",
     "datalad",
+    "roc-validator>=0.11.3",
 ]
 docs = [
     "zensical>=0.0.33",
@@ -88,9 +90,15 @@ explicit_package_bases = true
 mypy_path = "src"
 
 [[tool.mypy.overrides]]
-module = ["astra.*"]
+module = ["astra.*", "rocrate.*"]
 ignore_missing_imports = true
 follow_untyped_imports = true
+
+# rocrate ships no type information, and engine/crate.py is a client of
+# little else — one module-scoped relaxation beats an ignore on every call.
+[[tool.mypy.overrides]]
+module = ["lightcone.engine.crate"]
+disallow_untyped_calls = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -360,15 +360,17 @@ def status(as_json: bool) -> None:
     lines.append("")
     marks = {"current": "[dim]·[/dim]", "behind": "[cyan]·[/cyan]", "stale": "[yellow]![/yellow]"}
     width = max((len(o.output) for o in report.outputs), default=0)
-    lines += [
+    for o in report.outputs:
         # The commit gets a column of its own, for every state and not only
         # the interesting ones: "which code made this" is the question the
         # verb exists to answer, and it has an answer for a current output
         # too.
-        f"  {marks[o.status]} {o.status:<8} {o.output:<{width}}  "
-        f"{o.git_sha[:7] or '—':<7}" + (f"  [dim]{o.why}[/dim]" if o.why else "")
-        for o in report.outputs
-    ]
+        lines.append(
+            f"  {marks[o.status]} {o.status:<8} {o.output:<{width}}  "
+            f"{o.git_sha[:7] or '—':<7}" + (f"  [dim]{o.why}[/dim]" if o.why else "")
+        )
+        if o.foreign_write:
+            lines.append(f"      [yellow]! foreign write:[/yellow] {o.foreign_write}")
     lines += [f"  [yellow]![/yellow] {warning}" for warning in report.warnings]
 
     counts = report.counts

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -365,12 +365,13 @@ def status(as_json: bool) -> None:
         # the interesting ones: "which code made this" is the question the
         # verb exists to answer, and it has an answer for a current output
         # too.
+        # A foreign write arrives as an ordinary stale with its message in
+        # `why`, so the one rendering path covers it; the dedicated field
+        # exists for machine consumers of `--json`.
         lines.append(
             f"  {marks[o.status]} {o.status:<8} {o.output:<{width}}  "
             f"{o.git_sha[:7] or '—':<7}" + (f"  [dim]{o.why}[/dim]" if o.why else "")
         )
-        if o.foreign_write:
-            lines.append(f"      [yellow]! foreign write:[/yellow] {o.foreign_write}")
     lines += [f"  [yellow]![/yellow] {warning}" for warning in report.warnings]
 
     counts = report.counts

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -360,18 +360,17 @@ def status(as_json: bool) -> None:
     lines.append("")
     marks = {"current": "[dim]·[/dim]", "behind": "[cyan]·[/cyan]", "stale": "[yellow]![/yellow]"}
     width = max((len(o.output) for o in report.outputs), default=0)
-    for o in report.outputs:
-        # The commit gets a column of its own, for every state and not only
-        # the interesting ones: "which code made this" is the question the
-        # verb exists to answer, and it has an answer for a current output
-        # too.
-        # A foreign write arrives as an ordinary stale with its message in
-        # `why`, so the one rendering path covers it; the dedicated field
-        # exists for machine consumers of `--json`.
-        lines.append(
-            f"  {marks[o.status]} {o.status:<8} {o.output:<{width}}  "
-            f"{o.git_sha[:7] or '—':<7}" + (f"  [dim]{o.why}[/dim]" if o.why else "")
-        )
+    # The commit gets a column of its own, for every state and not only
+    # the interesting ones: "which code made this" is the question the
+    # verb exists to answer, and it has an answer for a current output
+    # too. A foreign write arrives as an ordinary stale with its message
+    # in `why`, so this one path covers it; the dedicated field exists
+    # for machine consumers of `--json`.
+    lines += [
+        f"  {marks[o.status]} {o.status:<8} {o.output:<{width}}  "
+        f"{o.git_sha[:7] or '—':<7}" + (f"  [dim]{o.why}[/dim]" if o.why else "")
+        for o in report.outputs
+    ]
     lines += [f"  [yellow]![/yellow] {warning}" for warning in report.warnings]
 
     counts = report.counts

--- a/src/lightcone/engine/assets.py
+++ b/src/lightcone/engine/assets.py
@@ -402,12 +402,16 @@ def classify(
     env_version: str,
     manifest: Manifest | None,
     inputs: Mapping[str, str | None],
+    foreign: str = "",
 ) -> Verdict:
     """Decide what an output is, relative to the project as it now stands.
 
     The only place this rule lives. Values rather than objects, because
-    the two callers arrive at them differently and must not diverge in
-    anything else.
+    the callers arrive at them differently and must not diverge in
+    anything else — history included: whether the output's directory was
+    last written by its own run record is git's to answer, so it arrives
+    here as a value computed by whoever has git (the driver), and the
+    rule stays pure.
 
     Args:
         definition_version: What the spec currently says this output is.
@@ -417,6 +421,11 @@ def classify(
             for an input the caller has already decided will be remade —
             check mode's sentinel, meaning "this is going to change",
             since it cannot know whether a rebuild is byte-identical.
+        foreign: Empty when the directory's last commit is the output's
+            own run record; otherwise the foreign commit, named. A hit is
+            a contradiction — the manifest no longer describes the bytes
+            — so it is ``stale``, though an output stale on its
+            definition or inputs keeps that more actionable reason.
 
     Returns:
         ``stale``, ``behind`` or ``current``, with the reason for the
@@ -424,6 +433,8 @@ def classify(
     """
     if (reason := _stale(definition_version, manifest, inputs)) is not None:
         return Verdict("stale", str(reason))
+    if foreign:
+        return Verdict("stale", foreign)
     assert manifest is not None  # `_stale` returns a reason when it is None
     if manifest.env_version != env_version:
         # The sentence says what happened; *where* it happened is the

--- a/src/lightcone/engine/assets.py
+++ b/src/lightcone/engine/assets.py
@@ -255,6 +255,13 @@ class Manifest:
     lc_version: str
     #: What the sandbox actually enforced, as the boundary attested it.
     hermeticity: dict[str, Any]
+    #: When the recipe entered and left the boundary, ISO 8601 UTC with
+    #: millisecond precision. Attestation, like ``lc_version``: outside
+    #: both hashes, never a rebuild signal — and defaulted empty because
+    #: that is the true value for a manifest written before the fields
+    #: existed, not back-compat machinery.
+    started_at: str = ""
+    finished_at: str = ""
     #: The image the recipe ran in — ``{tag, id, archive, arch}`` — or
     #: ``None`` on the host. Defaulted, and that is not back-compat
     #: machinery: ``None`` is the *true* value for every manifest a

--- a/src/lightcone/engine/assets.py
+++ b/src/lightcone/engine/assets.py
@@ -22,9 +22,13 @@ import json
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from lightcone.engine.project import ProjectError
+
+if TYPE_CHECKING:
+    # A type only: history is git's, and this module runs no git.
+    from lightcone.engine.dataset import LastWrite
 
 MANIFEST_FILENAME = ".lightcone-manifest.json"
 SCHEMA_VERSION = 1
@@ -402,7 +406,7 @@ def classify(
     env_version: str,
     manifest: Manifest | None,
     inputs: Mapping[str, str | None],
-    foreign: str = "",
+    foreign: LastWrite | None = None,
 ) -> Verdict:
     """Decide what an output is, relative to the project as it now stands.
 
@@ -411,7 +415,9 @@ def classify(
     anything else — history included: whether the output's directory was
     last written by its own run record is git's to answer, so it arrives
     here as a value computed by whoever has git (the driver), and the
-    rule stays pure.
+    rule stays pure. The *prose* for every verdict lives here too, which
+    is why this takes the offending commit rather than a finished
+    sentence.
 
     Args:
         definition_version: What the spec currently says this output is.
@@ -421,11 +427,11 @@ def classify(
             for an input the caller has already decided will be remade —
             check mode's sentinel, meaning "this is going to change",
             since it cannot know whether a rebuild is byte-identical.
-        foreign: Empty when the directory's last commit is the output's
-            own run record; otherwise the foreign commit, named. A hit is
-            a contradiction — the manifest no longer describes the bytes
-            — so it is ``stale``, though an output stale on its
-            definition or inputs keeps that more actionable reason.
+        foreign: The commit that last wrote the output's directory, when
+            it was not the output's own run record; ``None`` when clean.
+            A hit is a contradiction — the manifest no longer describes
+            the bytes — so it is ``stale``, though an output stale on
+            its definition or inputs keeps that more actionable reason.
 
     Returns:
         ``stale``, ``behind`` or ``current``, with the reason for the
@@ -433,8 +439,14 @@ def classify(
     """
     if (reason := _stale(definition_version, manifest, inputs)) is not None:
         return Verdict("stale", str(reason))
-    if foreign:
-        return Verdict("stale", foreign)
+    if foreign is not None:
+        return Verdict(
+            "stale",
+            f'last changed by {foreign.sha[:7]} ("{foreign.subject}", {foreign.author}, '
+            f"{foreign.date}) rather than its run record, so the manifest no longer "
+            f"describes these bytes — the next run remakes it; inspect first with "
+            f"`git show {foreign.sha[:7]}`",
+        )
     assert manifest is not None  # `_stale` returns a reason when it is None
     if manifest.env_version != env_version:
         # The sentence says what happened; *where* it happened is the

--- a/src/lightcone/engine/crate.py
+++ b/src/lightcone/engine/crate.py
@@ -1,0 +1,637 @@
+"""The publication view: the repository described as a Workflow Run RO-Crate.
+
+The project *is* the crate. ``ro-crate-metadata.json`` sits at the root
+and describes what the repository already holds — the spec, the lock, the
+universes, each materialized output and the run that made it — so a
+deposit is ``git archive`` on the repository, not an export step that
+copies bytes. lc's manifests stay the canonical record; the crate is the
+same facts in schema.org vocabulary, readable by archives and viewers
+that will never run ``lc``.
+
+The document is a pure function of repository state: :func:`render`
+takes the graph, the license, and a way to ask git who last wrote each
+output, and returns bytes that are identical when nothing changed. That
+is what lets ``lc materialize`` converge the file the way it converges
+``uv.lock`` — compare, and commit only a difference — with no verb for a
+human to remember.
+
+Profiles targeted: Process, Workflow and Provenance Run Crate 0.5, plus
+Workflow RO-Crate 1.0. The Provenance layer is structural, not claimed:
+one ``lc materialize`` invocation is one ``OrganizeAction`` (outputs of a
+run share their manifests' ``git_sha``, because the driver reads HEAD
+once and hands it down), each output's execution is a ``CreateAction``
+steered by a ``ControlAction``, and the spec's outputs are the
+workflow's ``HowToStep`` s.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from rocrate.model import ContextEntity
+from rocrate.model.computerlanguage import ComputerLanguage
+from rocrate.rocrate import ROCrate
+
+from lightcone.engine import assets, plan, worker
+from lightcone.engine.plan import Graph, Key
+
+CRATE_FILENAME = "ro-crate-metadata.json"
+
+#: The vocabulary the run-level facts come from. Without it in the
+#: ``@context``, terms like ``containerImage`` and ``sha256`` are
+#: undefined and silently dropped on JSON-LD expansion — typed but inert.
+_WORKFLOW_RUN_CONTEXT = "https://w3id.org/ro/terms/workflow-run"
+
+#: What the root conforms to, each also declared as a CreativeWork in the
+#: graph — consumers resolve the reference inside the crate, not on the
+#: network.
+_PROFILES = (
+    ("https://w3id.org/ro/wfrun/process/0.5", "Process Run Crate", "0.5"),
+    ("https://w3id.org/ro/wfrun/workflow/0.5", "Workflow Run Crate", "0.5"),
+    ("https://w3id.org/ro/wfrun/provenance/0.5", "Provenance Run Crate", "0.5"),
+    ("https://w3id.org/workflowhub/workflow-ro-crate/1.0", "Workflow RO-Crate", "1.0"),
+)
+
+#: What one commit that last touched a path looks like:
+#: ``(sha, subject, author name, author email, author date)`` — the shape
+#: :func:`lightcone.engine.dataset.last_writer` returns.
+LastWrite = tuple[str, str, str, str, str]
+
+
+def license_of(root: Path) -> str:
+    """Read the project's declared license out of ``pyproject.toml``.
+
+    Presence is what turns crate maintenance on: RO-Crate requires a
+    license, a run must not refuse over a missing key, and inventing one
+    would assert terms over someone's data — so declaring
+    ``[project].license`` is declaring the intent to publish.
+
+    Args:
+        root: The project root.
+
+    Returns:
+        The license as declared — an SPDX expression, a URL, free text,
+        or a file path for the table forms — or empty when undeclared.
+    """
+    try:
+        data = tomllib.loads((root / "pyproject.toml").read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return ""
+    declared = data.get("project", {}).get("license")
+    if isinstance(declared, str):
+        return declared
+    if isinstance(declared, dict):
+        return str(declared.get("text") or declared.get("file") or "")
+    return ""
+
+
+def render(
+    root: Path,
+    graph: Graph,
+    *,
+    license: str,
+    dsid: str,
+    writer: Callable[[Path], LastWrite],
+    engine_url: str = "",
+) -> str:
+    """Build the crate document for the project as it stands.
+
+    Pure given its arguments: reads the tree, runs nothing, and returns
+    identical bytes for identical repository state — timestamps come from
+    manifests and commits, never from the clock, and entities are built
+    in sorted order.
+
+    Args:
+        root: The project root.
+        graph: The full task graph — every universe, every output.
+        license: The declared license, from :func:`license_of`.
+        dsid: The dataset UUID, the namespace absolute entity ids are
+            minted under so they are stable across clones.
+        writer: Answers "which commit last touched this path" —
+            :func:`dataset.last_writer` bound to the root, injected so
+            the builder stays free of git.
+        engine_url: The engine's repository URL, or empty.
+
+    Returns:
+        The ``ro-crate-metadata.json`` text, trailing newline included.
+    """
+    build = _Builder(root, graph, license, dsid, writer, engine_url)
+    return build.document()
+
+
+class _Builder:
+    """One render: accumulates entities into a ``ROCrate``, in one order."""
+
+    def __init__(
+        self,
+        root: Path,
+        graph: Graph,
+        license: str,
+        dsid: str,
+        writer: Callable[[Path], LastWrite],
+        engine_url: str,
+    ) -> None:
+        self.root = root
+        self.graph = graph
+        self.license = license
+        self.dsid = dsid
+        self.writer = writer
+        self.engine_url = engine_url
+        self.crate = ROCrate()
+        self.crate.metadata.extra_contexts.append(_WORKFLOW_RUN_CONTEXT)
+        #: Every materialized task, sorted: the one iteration order.
+        self.made: list[tuple[Key, assets.Manifest]] = sorted(
+            (
+                (key, manifest)
+                for key, task in graph.tasks.items()
+                if (manifest := assets.read(task.output_dir)) is not None
+            ),
+            key=lambda pair: pair[0],
+        )
+        self.persons: dict[str, str] = {}  # email/name → @id
+        self.images: dict[str, str] = {}  # archive path → @id
+        self.actions: list[ContextEntity] = []
+
+    def document(self) -> str:
+        """Assemble the graph and serialize it, deterministically."""
+        spec = self._spec()
+        workflow = self._workflow(spec)
+        self._steps_and_tools(workflow)
+        self._environment_files()
+        datasets = {key: self._dataset(key, manifest) for key, manifest in self.made}
+        for key, manifest in self.made:
+            self._control(key, self._action(key, manifest, datasets))
+        self._runs(workflow, datasets)
+        self._root(spec)
+        text: str = json.dumps(
+            self.crate.metadata.generate(), indent=1, sort_keys=True, ensure_ascii=False
+        )
+        return text + "\n"
+
+    # ----- the workflow and its structure -----
+
+    def _spec(self) -> dict[str, Any]:
+        from astra.helpers import load_yaml
+
+        loaded = load_yaml(self.root / "astra.yaml")
+        return dict(loaded) if isinstance(loaded, dict) else {}
+
+    def _workflow(self, spec: dict[str, Any]) -> Any:
+        # Before `add_workflow` rewrites the descriptor's conformsTo: 1.1
+        # is what RO-Crate validators key on, 1.2 is the context actually
+        # emitted — the crate is structurally both, and saying only the
+        # newer one reads as conforming to neither.
+        self.crate.metadata["conformsTo"] = [
+            {"@id": "https://w3id.org/ro/crate/1.1"},
+            {"@id": "https://w3id.org/ro/crate/1.2"},
+        ]
+        lang = ComputerLanguage(
+            self.crate,
+            "#astra",
+            properties={
+                "@type": "ComputerLanguage",
+                "name": "ASTRA",
+                "alternateName": "Agentic Schema for Transparent Research Analysis",
+                "url": "https://pypi.org/project/astra-tools/",
+                "version": _astra_version(),
+            },
+        )
+        self.crate.add(lang)
+        sha, _, author, email, date = self.writer(self.root / "astra.yaml")
+        workflow = self.crate.add_workflow(
+            self.root / "astra.yaml",
+            "astra.yaml",
+            main=True,
+            lang=lang,
+            properties={
+                # `HowTo` is what licenses the `step` list below — the
+                # Provenance profile's requirement, not decoration.
+                "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow", "HowTo"],
+                "name": str(spec.get("name") or self.root.name),
+                "encodingFormat": "application/yaml",
+            },
+        )
+        if description := spec.get("description"):
+            workflow["description"] = str(description)
+        workflow["conformsTo"] = {
+            "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"
+        }
+        workflow["license"] = self._license_ref()
+        if remote := self._remote():
+            workflow["url"] = remote
+        if sha:
+            # The spec's version is the commit that last changed it — the
+            # only version an astra.yaml actually has.
+            workflow["version"] = sha[:7]
+            workflow["dateCreated"] = date
+            workflow["creator"] = {"@id": self._person(author, email)}
+        for decision in sorted({d for _, t in self.graph.tasks.items() for d in t.decisions}):
+            parameter = ContextEntity(
+                self.crate,
+                f"#param-{decision}",
+                properties={
+                    "@type": "FormalParameter",
+                    "name": decision,
+                    # ASTRA decisions arrive rendered, as strings.
+                    "additionalType": "Text",
+                },
+            )
+            self.crate.add(parameter)
+            workflow.append_to("input", parameter)
+        return workflow
+
+    def _steps_and_tools(self, workflow: Any) -> None:
+        for position, output_id in enumerate(self._output_ids()):
+            tool = ContextEntity(
+                self.crate,
+                self._tool_id(output_id),
+                properties={
+                    "@type": "SoftwareApplication",
+                    "name": output_id,
+                    "description": f"the recipe of output `{output_id}`",
+                },
+            )
+            if remote := self._remote():
+                tool["url"] = remote
+            if version := self._spec_sha():
+                tool["softwareVersion"] = version
+            self.crate.add(tool)
+            step = ContextEntity(
+                self.crate,
+                f"#step-{output_id}",
+                properties={
+                    "@type": "HowToStep",
+                    "position": position,
+                    "workExample": {"@id": tool.id},
+                },
+            )
+            self.crate.add(step)
+            workflow.append_to("step", step)
+            # The Provenance profile's one MUST on the workflow itself:
+            # the tools it orchestrates are its parts.
+            workflow.append_to("hasPart", tool)
+
+    def _output_ids(self) -> list[str]:
+        return sorted({output_id for _, output_id in self.graph.tasks})
+
+    def _spec_sha(self) -> str:
+        sha = self.writer(self.root / "astra.yaml")[0]
+        return sha[:7]
+
+    def _remote(self) -> str:
+        """The project's one remote as its manifests recorded it, or empty."""
+        remotes = {m.git_remote for _, m in self.made if m.git_remote}
+        return remotes.pop() if len(remotes) == 1 else ""
+
+    def _tool_id(self, output_id: str) -> str:
+        """An id for one output's recipe — under the project's own
+        repository URL when it has one (an http URI, which is what the
+        profiles prefer for an application), a ``urn:uuid`` otherwise."""
+        if remote := self._remote():
+            return f"{remote}#tool/{output_id}"
+        return self._uri(f"tool/{output_id}")
+
+    # ----- the data entities -----
+
+    def _environment_files(self) -> None:
+        """The lock and its companions — what every run consumed."""
+        for name in ("pyproject.toml", "uv.lock", ".python-version", *self._universe_files()):
+            if (self.root / name).is_file():
+                self._file(name)
+        if (self.root / "README.md").is_file():
+            readme = self._file("README.md")
+            readme["about"] = {"@id": "./"}
+
+    def _universe_files(self) -> list[str]:
+        return sorted(
+            path.relative_to(self.root).as_posix()
+            for path in (self.root / "universes").glob("*.yaml")
+        )
+
+    def _file(self, name: str, **extra: Any) -> Any:
+        properties = {"encodingFormat": _format_of(name), **extra}
+        return self.crate.add_file(self.root / name, name, properties=properties)
+
+    def _dataset(self, key: Key, manifest: assets.Manifest) -> str:
+        universe_id, output_id = key
+        dataset_id = f"results/{universe_id}/{output_id}/"
+        entity = self.crate.add_dataset(self.graph.tasks[key].output_dir, dataset_id)
+        entity["name"] = f"{output_id} (universe {universe_id})"
+        entity["description"] = f"output `{output_id}` materialized under `{universe_id}`"
+        entity["version"] = manifest.data_version
+        manifest_file = self._file(f"{dataset_id}{assets.MANIFEST_FILENAME}")
+        manifest_file["about"] = {"@id": dataset_id}
+        entity["subjectOf"] = {"@id": manifest_file.id}
+        return dataset_id
+
+    # ----- the runs -----
+
+    def _action(
+        self, key: Key, manifest: assets.Manifest, datasets: dict[Key, str]
+    ) -> ContextEntity:
+        universe_id, output_id = key
+        task = self.graph.tasks[key]
+        sha, _, author, email, _ = self.writer(task.output_dir)
+        properties: dict[str, Any] = {
+            "@type": "CreateAction",
+            "name": f"run of `{output_id}` in universe `{universe_id}`",
+            "description": task.recipe,
+            "instrument": {"@id": self._tool_id(output_id)},
+            "result": [{"@id": datasets[key]}],
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "object": self._objects(key, manifest, datasets),
+        }
+        if manifest.started_at:
+            properties["startTime"] = manifest.started_at
+        if manifest.finished_at:
+            properties["endTime"] = manifest.finished_at
+        if sha:
+            properties["agent"] = {"@id": self._person(author, email)}
+        if manifest.image is not None:
+            properties["containerImage"] = {"@id": self._image(manifest.image)}
+        action = ContextEntity(
+            self.crate, self._uri(f"action/{universe_id}/{output_id}"), properties
+        )
+        self.crate.add(action)
+        self.actions.append(action)
+        return action
+
+    def _objects(
+        self, key: Key, manifest: assets.Manifest, datasets: dict[Key, str]
+    ) -> list[dict[str, str]]:
+        task = self.graph.tasks[key]
+        refs = [
+            {"@id": name}
+            for name in ("uv.lock", ".python-version", "pyproject.toml")
+            if (self.root / name).is_file()
+        ]
+        for name in sorted(task.inputs):
+            upstream = task.produced_by.get(name)
+            if upstream is not None:
+                if upstream in datasets:
+                    refs.append({"@id": datasets[upstream]})
+                continue
+            refs.append({"@id": self._external(name, task.inputs[name], manifest)})
+        for decision in sorted(task.decisions):
+            value = ContextEntity(
+                self.crate,
+                f"#value-{key[0]}-{key[1]}-{decision}",
+                properties={
+                    "@type": "PropertyValue",
+                    "name": decision,
+                    "value": task.decisions[decision],
+                    "exampleOfWork": {"@id": f"#param-{decision}"},
+                },
+            )
+            self.crate.add(value)
+            refs.append({"@id": value.id})
+        return refs
+
+    def _external(self, name: str, path: Path, manifest: assets.Manifest) -> str:
+        """A declared input the spec points at, in or out of the tree."""
+        declared = plan.declared_path(self.root, path)
+        entity_id = declared if self.root in path.parents else path.as_uri()
+        if self.crate.dereference(entity_id) is None:
+            properties: dict[str, Any] = {"@type": "File", "name": declared}
+            if fmt := _format_of(declared):
+                properties["encodingFormat"] = fmt
+            digest = manifest.input_versions.get(name, "")
+            if digest.startswith("sha256:"):
+                properties["sha256"] = digest.removeprefix("sha256:")
+            if self.root in path.parents:
+                self.crate.add_file(path, declared, properties=properties)
+            else:
+                # Outside the repository: recorded by content, not stored
+                # in it — the layer's stated weaker promise, so a context
+                # entity rather than a data entity the crate cannot hold.
+                self.crate.add(ContextEntity(self.crate, entity_id, properties))
+        return entity_id
+
+    def _control(self, key: Key, action: ContextEntity) -> ContextEntity:
+        universe_id, output_id = key
+        control = ContextEntity(
+            self.crate,
+            f"#control-{universe_id}-{output_id}",
+            properties={
+                "@type": "ControlAction",
+                "name": f"orchestration of `{output_id}` in universe `{universe_id}`",
+                "instrument": {"@id": f"#step-{output_id}"},
+                "object": {"@id": action.id},
+            },
+        )
+        self.crate.add(control)
+        return control
+
+    def _runs(self, workflow: Any, datasets: dict[Key, str]) -> None:
+        """One ``OrganizeAction`` per run — outputs sharing a ``git_sha``
+        were made by one ``lc materialize``, the driver's one HEAD read."""
+        runs: dict[str, list[tuple[Key, assets.Manifest]]] = {}
+        for key, manifest in self.made:
+            runs.setdefault(manifest.git_sha, []).append((key, manifest))
+        engine = self._engine()
+        for sha in sorted(runs):
+            group = runs[sha]
+            times = sorted(t for _, m in group for t in (m.started_at, m.finished_at) if t)
+            run_action = ContextEntity(
+                self.crate,
+                self._uri(f"run/{sha}"),
+                properties={
+                    "@type": "CreateAction",
+                    "name": f"lc materialize at {sha[:7] or 'unknown commit'}",
+                    "description": (
+                        f"one materialization run, starting from commit {sha or '(unrecorded)'}"
+                    ),
+                    "instrument": {"@id": workflow.id},
+                    "result": [{"@id": datasets[key]} for key, _ in group],
+                    "actionStatus": "http://schema.org/CompletedActionStatus",
+                },
+            )
+            if times:
+                run_action["startTime"] = times[0]
+                run_action["endTime"] = times[-1]
+            writer_sha, _, author, email, _ = self.writer(self.graph.tasks[group[0][0]].output_dir)
+            if writer_sha:
+                run_action["agent"] = {"@id": self._person(author, email)}
+            self.crate.add(run_action)
+            self.actions.append(run_action)
+            organize = ContextEntity(
+                self.crate,
+                f"#organize-{sha[:7] or 'unknown'}",
+                properties={
+                    "@type": "OrganizeAction",
+                    "name": f"scheduling of the run at {sha[:7] or 'unknown commit'}",
+                    "instrument": {"@id": engine},
+                    "object": [
+                        {"@id": f"#control-{key[0]}-{key[1]}"} for key, _ in group
+                    ],
+                    "result": {"@id": run_action.id},
+                },
+            )
+            self.crate.add(organize)
+
+    def _engine(self) -> str:
+        version = worker.lc_version()
+        engine_id = (
+            f"https://pypi.org/project/lightcone-cli/{version}/"
+            if version
+            else "#lightcone-cli"
+        )
+        if self.crate.dereference(engine_id) is None:
+            properties: dict[str, Any] = {
+                "@type": "SoftwareApplication",
+                "name": "lightcone-cli",
+            }
+            if version:
+                properties["softwareVersion"] = version
+            if self.engine_url:
+                properties["url"] = self.engine_url
+            self.crate.add(ContextEntity(self.crate, engine_id, properties))
+        return engine_id
+
+    def _image(self, image: dict[str, Any]) -> str:
+        """The committed archive: identity and payload as one entity."""
+        archive = str(image.get("archive") or "")
+        if archive not in self.images:
+            properties: dict[str, Any] = {
+                "@type": ["File", "ContainerImage"],
+                "name": str(image.get("tag") or archive),
+                "tag": str(image.get("tag") or ""),
+                "encodingFormat": "application/x-tar",
+                # The archive is `docker-archive` format wherever it runs —
+                # podman, docker and podman-hpc all consume it as one.
+                "additionalType": {"@id": "https://w3id.org/ro/terms/workflow-run#DockerImage"},
+            }
+            if str(image.get("id") or "").startswith("sha256:"):
+                properties["sha256"] = str(image["id"]).removeprefix("sha256:")
+            self.crate.add_file(self.root / archive, archive, properties=properties)
+            self.images[archive] = archive
+        return self.images[archive]
+
+    # ----- shared entities and the root -----
+
+    def _person(self, author: str, email: str) -> str:
+        person_key = email or author
+        if person_key not in self.persons:
+            person_id = f"mailto:{email}" if email else f"#person-{len(self.persons)}"
+            self.crate.add(
+                ContextEntity(
+                    self.crate,
+                    person_id,
+                    properties={"@type": "Person", "name": author, "email": email},
+                )
+            )
+            self.persons[person_key] = person_id
+        return self.persons[person_key]
+
+    def _root(self, spec: dict[str, Any]) -> None:
+        root = self.crate.root_dataset
+        root["name"] = str(spec.get("name") or self.root.name)
+        root["description"] = str(
+            spec.get("description")
+            or f"ASTRA analysis `{spec.get('name') or self.root.name}`, "
+            "materialized by lightcone-cli."
+        )
+        root["license"] = self._license_ref()
+        # The newest recorded instant, never the clock: the document must
+        # be a pure function of repository state, or every render is a
+        # fresh diff and convergence commits forever.
+        stamps = sorted(m.finished_at for _, m in self.made if m.finished_at)
+        spec_date = self.writer(self.root / "astra.yaml")[4]
+        root["datePublished"] = stamps[-1] if stamps else (spec_date or "1970-01-01")
+        root["conformsTo"] = [{"@id": profile_id} for profile_id, _, _ in _PROFILES]
+        for profile_id, name, version in _PROFILES:
+            self.crate.add(
+                ContextEntity(
+                    self.crate,
+                    profile_id,
+                    properties={
+                        "@type": "CreativeWork",
+                        "name": f"{name} {version}",
+                        "version": version,
+                    },
+                )
+            )
+        if self.persons:
+            root["author"] = [
+                {"@id": person_id} for person_id in sorted(self.persons.values())
+            ]
+        if self.actions:
+            root["mentions"] = [{"@id": action.id} for action in self.actions]
+
+    def _license_ref(self) -> Any:
+        """The root's license value, as an entity where one can be named.
+
+        A path in the tree becomes a File data entity; a URL or a
+        single-token SPDX id becomes a CreativeWork; an SPDX *expression*
+        or free text stays a plain string, which RO-Crate allows.
+        """
+        if (self.root / self.license).is_file():
+            self._file(self.license)
+            return {"@id": self.license}
+        if self.license.startswith(("http://", "https://")):
+            license_id = self.license
+        elif " " not in self.license:
+            license_id = f"https://spdx.org/licenses/{self.license}"
+        else:
+            return self.license
+        self.crate.add(
+            ContextEntity(
+                self.crate,
+                license_id,
+                properties={"@type": "CreativeWork", "name": self.license},
+            )
+        )
+        return {"@id": license_id}
+
+    def _uri(self, kind: str) -> str:
+        """Mint an absolute, deterministic id under the dataset's UUID.
+
+        ``urn:uuid`` from the dsid namespace, so the same entity gets the
+        same id in every clone and every render — and an absolute URI is
+        what the profiles ask of an application id.
+        """
+        namespace = uuid.uuid5(uuid.NAMESPACE_URL, self.dsid)
+        return f"urn:uuid:{uuid.uuid5(namespace, kind)}"
+
+
+def _astra_version() -> str:
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("astra-tools")
+    except PackageNotFoundError:  # pragma: no cover - only in a source tree
+        return ""
+
+
+#: A closed suffix → media type map, deliberately not ``mimetypes``:
+#: that module reads the host's own tables (``/etc/mime.types``), which
+#: would make the rendered document differ between machines — and the
+#: document must be a pure function of repository state. Unknown stays
+#: unknown; empty means the entity simply carries no ``encodingFormat``.
+_FORMATS = {
+    ".toml": "application/toml",
+    ".lock": "application/toml",
+    ".yaml": "application/yaml",
+    ".yml": "application/yaml",
+    ".json": "application/json",
+    ".md": "text/markdown",
+    ".python-version": "text/plain",
+    ".txt": "text/plain",
+    ".csv": "text/csv",
+    ".fits": "image/fits",
+    ".h5": "application/x-hdf5",
+    ".hdf5": "application/x-hdf5",
+    ".parquet": "application/vnd.apache.parquet",
+    ".png": "image/png",
+    ".pdf": "application/pdf",
+}
+
+
+def _format_of(name: str) -> str:
+    """A media type for *name* from the closed map — empty when unknown."""
+    return _FORMATS.get(Path(name).suffix or Path(name).name, "")

--- a/src/lightcone/engine/crate.py
+++ b/src/lightcone/engine/crate.py
@@ -37,7 +37,7 @@ from rocrate.model import ContextEntity
 from rocrate.model.computerlanguage import ComputerLanguage
 from rocrate.rocrate import ROCrate
 
-from lightcone.engine import assets, plan, worker
+from lightcone.engine import assets, plan
 from lightcone.engine.plan import Graph, Key
 
 CRATE_FILENAME = "ro-crate-metadata.json"
@@ -155,7 +155,14 @@ class _Builder:
         )
         self.persons: dict[str, str] = {}  # email/name → @id
         self.images: dict[str, str] = {}  # archive path → @id
+        self.engines: dict[str, str] = {}  # lc_version → @id
+        self.parameters: set[str] = set()  # decision ids declared on the workflow
         self.actions: list[ContextEntity] = []
+        #: Loop invariants, asked once: the uuid5 namespace every minted
+        #: id lives under, and the project's one recorded remote.
+        self.namespace = uuid.uuid5(uuid.NAMESPACE_URL, dsid)
+        remotes = {m.git_remote for _, m in self.made if m.git_remote}
+        self.remote = remotes.pop() if len(remotes) == 1 else ""
 
     def document(self) -> str:
         """Assemble the graph and serialize it, deterministically."""
@@ -198,7 +205,6 @@ class _Builder:
                 "name": "ASTRA",
                 "alternateName": "Agentic Schema for Transparent Research Analysis",
                 "url": "https://pypi.org/project/astra-tools/",
-                "version": _astra_version(),
             },
         )
         self.crate.add(lang)
@@ -222,15 +228,16 @@ class _Builder:
             "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"
         }
         workflow["license"] = self._license_ref()
-        if remote := self._remote():
-            workflow["url"] = remote
+        if self.remote:
+            workflow["url"] = self.remote
         if sha:
             # The spec's version is the commit that last changed it — the
             # only version an astra.yaml actually has.
             workflow["version"] = sha[:7]
             workflow["dateCreated"] = date
             workflow["creator"] = {"@id": self._person(author, email)}
-        for decision in sorted({d for _, t in self.graph.tasks.items() for d in t.decisions}):
+        self.parameters = {d for _, t in self.graph.tasks.items() for d in t.decisions}
+        for decision in sorted(self.parameters):
             parameter = ContextEntity(
                 self.crate,
                 f"#param-{decision}",
@@ -256,8 +263,8 @@ class _Builder:
                     "description": f"the recipe of output `{output_id}`",
                 },
             )
-            if remote := self._remote():
-                tool["url"] = remote
+            if self.remote:
+                tool["url"] = self.remote
             if version := self._spec_sha():
                 tool["softwareVersion"] = version
             self.crate.add(tool)
@@ -283,17 +290,12 @@ class _Builder:
         sha = self.writer(self.root / "astra.yaml")[0]
         return sha[:7]
 
-    def _remote(self) -> str:
-        """The project's one remote as its manifests recorded it, or empty."""
-        remotes = {m.git_remote for _, m in self.made if m.git_remote}
-        return remotes.pop() if len(remotes) == 1 else ""
-
     def _tool_id(self, output_id: str) -> str:
         """An id for one output's recipe — under the project's own
         repository URL when it has one (an http URI, which is what the
         profiles prefer for an application), a ``urn:uuid`` otherwise."""
-        if remote := self._remote():
-            return f"{remote}#tool/{output_id}"
+        if self.remote:
+            return f"{self.remote}#tool/{output_id}"
         return self._uri(f"tool/{output_id}")
 
     # ----- the data entities -----
@@ -314,7 +316,9 @@ class _Builder:
         )
 
     def _file(self, name: str, **extra: Any) -> Any:
-        properties = {"encodingFormat": _format_of(name), **extra}
+        properties = dict(extra)
+        if fmt := _format_of(name):
+            properties["encodingFormat"] = fmt
         return self.crate.add_file(self.root / name, name, properties=properties)
 
     def _dataset(self, key: Key, manifest: assets.Manifest) -> str:
@@ -340,7 +344,10 @@ class _Builder:
         properties: dict[str, Any] = {
             "@type": "CreateAction",
             "name": f"run of `{output_id}` in universe `{universe_id}`",
-            "description": task.recipe,
+            # The *recorded* recipe, not the graph's: the action states
+            # what ran, and the spec may have moved since — the manifest
+            # is the canonical record of the execution.
+            "description": manifest.recipe,
             "instrument": {"@id": self._tool_id(output_id)},
             "result": [{"@id": datasets[key]}],
             "actionStatus": "http://schema.org/CompletedActionStatus",
@@ -377,39 +384,58 @@ class _Builder:
                     refs.append({"@id": datasets[upstream]})
                 continue
             refs.append({"@id": self._external(name, task.inputs[name], manifest)})
-        for decision in sorted(task.decisions):
+        # The *recorded* decisions: the values the recipe actually ran
+        # under, whatever the spec says today. A decision the workflow no
+        # longer declares gets no exampleOfWork — there is no parameter
+        # for it to exemplify.
+        for decision in sorted(manifest.decisions):
+            properties: dict[str, Any] = {
+                "@type": "PropertyValue",
+                "name": decision,
+                "value": manifest.decisions[decision],
+            }
+            if decision in self.parameters:
+                properties["exampleOfWork"] = {"@id": f"#param-{decision}"}
             value = ContextEntity(
-                self.crate,
-                f"#value-{key[0]}-{key[1]}-{decision}",
-                properties={
-                    "@type": "PropertyValue",
-                    "name": decision,
-                    "value": task.decisions[decision],
-                    "exampleOfWork": {"@id": f"#param-{decision}"},
-                },
+                self.crate, f"#value-{key[0]}-{key[1]}-{decision}", properties
             )
             self.crate.add(value)
             refs.append({"@id": value.id})
         return refs
 
     def _external(self, name: str, path: Path, manifest: assets.Manifest) -> str:
-        """A declared input the spec points at, in or out of the tree."""
+        """A declared input the spec points at, in or out of the tree.
+
+        In-or-out is :func:`plan.declared_path`'s answer — relative
+        inside the tree, absolute outside it — never a second spelling
+        of that rule here: two copies of one path rule is how the first
+        one shipped a bug.
+        """
         declared = plan.declared_path(self.root, path)
-        entity_id = declared if self.root in path.parents else path.as_uri()
-        if self.crate.dereference(entity_id) is None:
-            properties: dict[str, Any] = {"@type": "File", "name": declared}
-            if fmt := _format_of(declared):
-                properties["encodingFormat"] = fmt
-            digest = manifest.input_versions.get(name, "")
-            if digest.startswith("sha256:"):
-                properties["sha256"] = digest.removeprefix("sha256:")
-            if self.root in path.parents:
-                self.crate.add_file(path, declared, properties=properties)
-            else:
-                # Outside the repository: recorded by content, not stored
-                # in it — the layer's stated weaker promise, so a context
-                # entity rather than a data entity the crate cannot hold.
-                self.crate.add(ContextEntity(self.crate, entity_id, properties))
+        in_tree = not Path(declared).is_absolute()
+        entity_id = declared if in_tree else Path(declared).as_uri()
+        recorded = manifest.input_versions.get(name, "")
+        digest = recorded.removeprefix("sha256:") if recorded.startswith("sha256:") else ""
+        if (existing := self.crate.dereference(entity_id)) is not None:
+            # Two manifests can testify to different bytes for one input
+            # — a half-rebuilt project. Publishing either digest would
+            # contradict a manifest in the same crate, so publish
+            # neither; the manifests themselves keep the full story.
+            if digest and existing.get("sha256") not in (None, digest):
+                existing.pop("sha256")
+            return entity_id
+        properties: dict[str, Any] = {"@type": "File", "name": declared}
+        if fmt := _format_of(declared):
+            properties["encodingFormat"] = fmt
+        if digest:
+            properties["sha256"] = digest
+        if in_tree:
+            self.crate.add_file(path, declared, properties=properties)
+        else:
+            # Outside the repository: recorded by content, not stored
+            # in it — the layer's stated weaker promise, so a context
+            # entity rather than a data entity the crate cannot hold.
+            self.crate.add(ContextEntity(self.crate, entity_id, properties))
         return entity_id
 
     def _control(self, key: Key, action: ContextEntity) -> ContextEntity:
@@ -433,9 +459,15 @@ class _Builder:
         runs: dict[str, list[tuple[Key, assets.Manifest]]] = {}
         for key, manifest in self.made:
             runs.setdefault(manifest.git_sha, []).append((key, manifest))
-        engine = self._engine()
         for sha in sorted(runs):
             group = runs[sha]
+            # The engine *that run* recorded, never the one installed
+            # here: the render must be a function of repository state,
+            # or two collaborators on different lc versions re-commit
+            # the crate at each other forever — and an lc upgrade is
+            # recorded as moving nothing. One run has one engine by
+            # construction; every manifest of the group agrees.
+            engine = self._engine(group[0][1].lc_version)
             times = sorted(t for _, m in group for t in (m.started_at, m.finished_at) if t)
             run_action = ContextEntity(
                 self.crate,
@@ -474,14 +506,14 @@ class _Builder:
             )
             self.crate.add(organize)
 
-    def _engine(self) -> str:
-        version = worker.lc_version()
-        engine_id = (
-            f"https://pypi.org/project/lightcone-cli/{version}/"
-            if version
-            else "#lightcone-cli"
-        )
-        if self.crate.dereference(engine_id) is None:
+    def _engine(self, version: str) -> str:
+        """The engine one run's manifests attest, deduplicated by version."""
+        if version not in self.engines:
+            engine_id = (
+                f"https://pypi.org/project/lightcone-cli/{version}/"
+                if version
+                else "#lightcone-cli"
+            )
             properties: dict[str, Any] = {
                 "@type": "SoftwareApplication",
                 "name": "lightcone-cli",
@@ -491,7 +523,8 @@ class _Builder:
             if self.engine_url:
                 properties["url"] = self.engine_url
             self.crate.add(ContextEntity(self.crate, engine_id, properties))
-        return engine_id
+            self.engines[version] = engine_id
+        return self.engines[version]
 
     def _image(self, image: dict[str, Any]) -> str:
         """The committed archive: identity and payload as one entity."""
@@ -564,21 +597,24 @@ class _Builder:
             root["mentions"] = [{"@id": action.id} for action in self.actions]
 
     def _license_ref(self) -> Any:
-        """The root's license value, as an entity where one can be named.
+        """The root's license value, always a linkable entity.
 
-        A path in the tree becomes a File data entity; a URL or a
-        single-token SPDX id becomes a CreativeWork; an SPDX *expression*
-        or free text stays a plain string, which RO-Crate allows.
+        A path in the tree becomes a File data entity; a URL becomes a
+        CreativeWork at that URL; anything else — an SPDX id, an SPDX
+        expression, free text — becomes a *local* CreativeWork carrying
+        the declared string. Deliberately never a minted spdx.org URL:
+        the declaration is not validated against the SPDX list, and a
+        fabricated dead URL in a document built for archives is worse
+        than a local entity.
         """
         if (self.root / self.license).is_file():
             self._file(self.license)
             return {"@id": self.license}
-        if self.license.startswith(("http://", "https://")):
-            license_id = self.license
-        elif " " not in self.license:
-            license_id = f"https://spdx.org/licenses/{self.license}"
-        else:
-            return self.license
+        license_id = (
+            self.license
+            if self.license.startswith(("http://", "https://"))
+            else "#license"
+        )
         self.crate.add(
             ContextEntity(
                 self.crate,
@@ -595,17 +631,7 @@ class _Builder:
         same id in every clone and every render — and an absolute URI is
         what the profiles ask of an application id.
         """
-        namespace = uuid.uuid5(uuid.NAMESPACE_URL, self.dsid)
-        return f"urn:uuid:{uuid.uuid5(namespace, kind)}"
-
-
-def _astra_version() -> str:
-    from importlib.metadata import PackageNotFoundError, version
-
-    try:
-        return version("astra-tools")
-    except PackageNotFoundError:  # pragma: no cover - only in a source tree
-        return ""
+        return f"urn:uuid:{uuid.uuid5(self.namespace, kind)}"
 
 
 #: A closed suffix → media type map, deliberately not ``mimetypes``:

--- a/src/lightcone/engine/crate.py
+++ b/src/lightcone/engine/crate.py
@@ -38,7 +38,9 @@ from rocrate.model.computerlanguage import ComputerLanguage
 from rocrate.rocrate import ROCrate
 
 from lightcone.engine import assets, plan
+from lightcone.engine.dataset import LastWrite
 from lightcone.engine.plan import Graph, Key
+from lightcone.engine.project import SPEC_FILENAME
 
 CRATE_FILENAME = "ro-crate-metadata.json"
 
@@ -57,10 +59,9 @@ _PROFILES = (
     ("https://w3id.org/workflowhub/workflow-ro-crate/1.0", "Workflow RO-Crate", "1.0"),
 )
 
-#: What one commit that last touched a path looks like:
-#: ``(sha, subject, author name, author email, author date)`` — the shape
-#: :func:`lightcone.engine.dataset.last_writer` returns.
-LastWrite = tuple[str, str, str, str, str]
+#: The files that pin what a run installed — one spelling, so the crate's
+#: data entities and every action's ``object`` list cannot drift apart.
+_ENVIRONMENT = ("pyproject.toml", "uv.lock", ".python-version")
 
 
 def license_of(root: Path) -> str:
@@ -97,14 +98,13 @@ def render(
     license: str,
     dsid: str,
     writer: Callable[[Path], LastWrite],
-    engine_url: str = "",
 ) -> str:
     """Build the crate document for the project as it stands.
 
     Pure given its arguments: reads the tree, runs nothing, and returns
     identical bytes for identical repository state — timestamps come from
     manifests and commits, never from the clock, and entities are built
-    in sorted order.
+    in sorted order. The writer is asked about each path at most once.
 
     Args:
         root: The project root.
@@ -115,13 +115,16 @@ def render(
         writer: Answers "which commit last touched this path" —
             :func:`dataset.last_writer` bound to the root, injected so
             the builder stays free of git.
-        engine_url: The engine's repository URL, or empty.
 
     Returns:
         The ``ro-crate-metadata.json`` text, trailing newline included.
     """
-    build = _Builder(root, graph, license, dsid, writer, engine_url)
+    build = _Builder(root, graph, license, dsid, writer)
     return build.document()
+
+
+def _control_id(key: Key) -> str:
+    return f"#control-{key[0]}-{key[1]}"
 
 
 class _Builder:
@@ -134,14 +137,13 @@ class _Builder:
         license: str,
         dsid: str,
         writer: Callable[[Path], LastWrite],
-        engine_url: str,
     ) -> None:
+        from astra.helpers import load_yaml
+
         self.root = root
         self.graph = graph
         self.license = license
-        self.dsid = dsid
         self.writer = writer
-        self.engine_url = engine_url
         self.crate = ROCrate()
         self.crate.metadata.extra_contexts.append(_WORKFLOW_RUN_CONTEXT)
         #: Every materialized task, sorted: the one iteration order.
@@ -153,28 +155,35 @@ class _Builder:
             ),
             key=lambda pair: pair[0],
         )
+        self.made_keys = {key for key, _ in self.made}
         self.persons: dict[str, str] = {}  # email/name → @id
-        self.images: dict[str, str] = {}  # archive path → @id
-        self.engines: dict[str, str] = {}  # lc_version → @id
-        self.parameters: set[str] = set()  # decision ids declared on the workflow
-        self.actions: list[ContextEntity] = []
+        self.agents: dict[Key, str] = {}  # each action's Person @id, or ""
+        self.images: set[str] = set()  # archive paths already added
+        self.engines: set[str] = set()  # engine @ids already added
+        self.actions: list[str] = []  # action @ids, for the root's mentions
         #: Loop invariants, asked once: the uuid5 namespace every minted
-        #: id lives under, and the project's one recorded remote.
+        #: id lives under, the project's one recorded remote, the spec's
+        #: header and last commit, and which decisions it declares.
         self.namespace = uuid.uuid5(uuid.NAMESPACE_URL, dsid)
         remotes = {m.git_remote for _, m in self.made if m.git_remote}
         self.remote = remotes.pop() if len(remotes) == 1 else ""
+        loaded = load_yaml(root / SPEC_FILENAME)
+        self.spec: dict[str, Any] = dict(loaded) if isinstance(loaded, dict) else {}
+        self.title = str(self.spec.get("name") or root.name)
+        self.spec_write = writer(root / SPEC_FILENAME)
+        self.parameters = {d for t in graph.tasks.values() for d in t.decisions}
 
     def document(self) -> str:
         """Assemble the graph and serialize it, deterministically."""
-        spec = self._spec()
-        workflow = self._workflow(spec)
+        workflow = self._workflow()
         self._steps_and_tools(workflow)
         self._environment_files()
-        datasets = {key: self._dataset(key, manifest) for key, manifest in self.made}
         for key, manifest in self.made:
-            self._control(key, self._action(key, manifest, datasets))
-        self._runs(workflow, datasets)
-        self._root(spec)
+            self._dataset(key, manifest)
+        for key, manifest in self.made:
+            self._control(key, self._action(key, manifest))
+        self._runs(workflow)
+        self._root()
         text: str = json.dumps(
             self.crate.metadata.generate(), indent=1, sort_keys=True, ensure_ascii=False
         )
@@ -182,13 +191,7 @@ class _Builder:
 
     # ----- the workflow and its structure -----
 
-    def _spec(self) -> dict[str, Any]:
-        from astra.helpers import load_yaml
-
-        loaded = load_yaml(self.root / "astra.yaml")
-        return dict(loaded) if isinstance(loaded, dict) else {}
-
-    def _workflow(self, spec: dict[str, Any]) -> Any:
+    def _workflow(self) -> Any:
         # Before `add_workflow` rewrites the descriptor's conformsTo: 1.1
         # is what RO-Crate validators key on, 1.2 is the context actually
         # emitted — the crate is structurally both, and saying only the
@@ -208,21 +211,20 @@ class _Builder:
             },
         )
         self.crate.add(lang)
-        sha, _, author, email, date = self.writer(self.root / "astra.yaml")
         workflow = self.crate.add_workflow(
-            self.root / "astra.yaml",
-            "astra.yaml",
+            self.root / SPEC_FILENAME,
+            SPEC_FILENAME,
             main=True,
             lang=lang,
             properties={
                 # `HowTo` is what licenses the `step` list below — the
                 # Provenance profile's requirement, not decoration.
                 "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow", "HowTo"],
-                "name": str(spec.get("name") or self.root.name),
+                "name": self.title,
                 "encodingFormat": "application/yaml",
             },
         )
-        if description := spec.get("description"):
+        if description := self.spec.get("description"):
             workflow["description"] = str(description)
         workflow["conformsTo"] = {
             "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"
@@ -230,13 +232,14 @@ class _Builder:
         workflow["license"] = self._license_ref()
         if self.remote:
             workflow["url"] = self.remote
-        if sha:
+        if self.spec_write:
             # The spec's version is the commit that last changed it — the
             # only version an astra.yaml actually has.
-            workflow["version"] = sha[:7]
-            workflow["dateCreated"] = date
-            workflow["creator"] = {"@id": self._person(author, email)}
-        self.parameters = {d for _, t in self.graph.tasks.items() for d in t.decisions}
+            workflow["version"] = self.spec_write.sha[:7]
+            workflow["dateCreated"] = self.spec_write.date
+            workflow["creator"] = {
+                "@id": self._person(self.spec_write.author, self.spec_write.email)
+            }
         for decision in sorted(self.parameters):
             parameter = ContextEntity(
                 self.crate,
@@ -253,7 +256,8 @@ class _Builder:
         return workflow
 
     def _steps_and_tools(self, workflow: Any) -> None:
-        for position, output_id in enumerate(self._output_ids()):
+        output_ids = sorted({output_id for _, output_id in self.graph.tasks})
+        for position, output_id in enumerate(output_ids):
             tool = ContextEntity(
                 self.crate,
                 self._tool_id(output_id),
@@ -265,8 +269,8 @@ class _Builder:
             )
             if self.remote:
                 tool["url"] = self.remote
-            if version := self._spec_sha():
-                tool["softwareVersion"] = version
+            if self.spec_write:
+                tool["softwareVersion"] = self.spec_write.sha[:7]
             self.crate.add(tool)
             step = ContextEntity(
                 self.crate,
@@ -283,13 +287,6 @@ class _Builder:
             # the tools it orchestrates are its parts.
             workflow.append_to("hasPart", tool)
 
-    def _output_ids(self) -> list[str]:
-        return sorted({output_id for _, output_id in self.graph.tasks})
-
-    def _spec_sha(self) -> str:
-        sha = self.writer(self.root / "astra.yaml")[0]
-        return sha[:7]
-
     def _tool_id(self, output_id: str) -> str:
         """An id for one output's recipe — under the project's own
         repository URL when it has one (an http URI, which is what the
@@ -302,28 +299,31 @@ class _Builder:
 
     def _environment_files(self) -> None:
         """The lock and its companions — what every run consumed."""
-        for name in ("pyproject.toml", "uv.lock", ".python-version", *self._universe_files()):
+        universes = sorted(
+            path.relative_to(self.root).as_posix()
+            for path in (self.root / "universes").glob("*.yaml")
+        )
+        for name in (*_ENVIRONMENT, *universes):
             if (self.root / name).is_file():
                 self._file(name)
         if (self.root / "README.md").is_file():
             readme = self._file("README.md")
             readme["about"] = {"@id": "./"}
 
-    def _universe_files(self) -> list[str]:
-        return sorted(
-            path.relative_to(self.root).as_posix()
-            for path in (self.root / "universes").glob("*.yaml")
-        )
-
-    def _file(self, name: str, **extra: Any) -> Any:
-        properties = dict(extra)
+    def _file(self, name: str) -> Any:
+        properties: dict[str, Any] = {}
         if fmt := _format_of(name):
             properties["encodingFormat"] = fmt
         return self.crate.add_file(self.root / name, name, properties=properties)
 
-    def _dataset(self, key: Key, manifest: assets.Manifest) -> str:
+    def _dataset_id(self, key: Key) -> str:
+        """One output directory's crate id — :func:`plan.declared_path`'s
+        answer, never a second spelling of the results layout."""
+        return plan.declared_path(self.root, self.graph.tasks[key].output_dir) + "/"
+
+    def _dataset(self, key: Key, manifest: assets.Manifest) -> None:
         universe_id, output_id = key
-        dataset_id = f"results/{universe_id}/{output_id}/"
+        dataset_id = self._dataset_id(key)
         entity = self.crate.add_dataset(self.graph.tasks[key].output_dir, dataset_id)
         entity["name"] = f"{output_id} (universe {universe_id})"
         entity["description"] = f"output `{output_id}` materialized under `{universe_id}`"
@@ -331,16 +331,13 @@ class _Builder:
         manifest_file = self._file(f"{dataset_id}{assets.MANIFEST_FILENAME}")
         manifest_file["about"] = {"@id": dataset_id}
         entity["subjectOf"] = {"@id": manifest_file.id}
-        return dataset_id
 
     # ----- the runs -----
 
-    def _action(
-        self, key: Key, manifest: assets.Manifest, datasets: dict[Key, str]
-    ) -> ContextEntity:
+    def _action(self, key: Key, manifest: assets.Manifest) -> str:
         universe_id, output_id = key
-        task = self.graph.tasks[key]
-        sha, _, author, email, _ = self.writer(task.output_dir)
+        write = self.writer(self.graph.tasks[key].output_dir)
+        self.agents[key] = self._person(write.author, write.email) if write else ""
         properties: dict[str, Any] = {
             "@type": "CreateAction",
             "name": f"run of `{output_id}` in universe `{universe_id}`",
@@ -349,39 +346,33 @@ class _Builder:
             # is the canonical record of the execution.
             "description": manifest.recipe,
             "instrument": {"@id": self._tool_id(output_id)},
-            "result": [{"@id": datasets[key]}],
+            "result": [{"@id": self._dataset_id(key)}],
             "actionStatus": "http://schema.org/CompletedActionStatus",
-            "object": self._objects(key, manifest, datasets),
+            "object": self._objects(key, manifest),
         }
         if manifest.started_at:
             properties["startTime"] = manifest.started_at
         if manifest.finished_at:
             properties["endTime"] = manifest.finished_at
-        if sha:
-            properties["agent"] = {"@id": self._person(author, email)}
+        if self.agents[key]:
+            properties["agent"] = {"@id": self.agents[key]}
         if manifest.image is not None:
             properties["containerImage"] = {"@id": self._image(manifest.image)}
         action = ContextEntity(
             self.crate, self._uri(f"action/{universe_id}/{output_id}"), properties
         )
         self.crate.add(action)
-        self.actions.append(action)
-        return action
+        self.actions.append(str(action.id))
+        return str(action.id)
 
-    def _objects(
-        self, key: Key, manifest: assets.Manifest, datasets: dict[Key, str]
-    ) -> list[dict[str, str]]:
+    def _objects(self, key: Key, manifest: assets.Manifest) -> list[dict[str, str]]:
         task = self.graph.tasks[key]
-        refs = [
-            {"@id": name}
-            for name in ("uv.lock", ".python-version", "pyproject.toml")
-            if (self.root / name).is_file()
-        ]
+        refs = [{"@id": name} for name in _ENVIRONMENT if (self.root / name).is_file()]
         for name in sorted(task.inputs):
             upstream = task.produced_by.get(name)
             if upstream is not None:
-                if upstream in datasets:
-                    refs.append({"@id": datasets[upstream]})
+                if upstream in self.made_keys:
+                    refs.append({"@id": self._dataset_id(upstream)})
                 continue
             refs.append({"@id": self._external(name, task.inputs[name], manifest)})
         # The *recorded* decisions: the values the recipe actually ran
@@ -438,22 +429,22 @@ class _Builder:
             self.crate.add(ContextEntity(self.crate, entity_id, properties))
         return entity_id
 
-    def _control(self, key: Key, action: ContextEntity) -> ContextEntity:
+    def _control(self, key: Key, action_id: str) -> None:
         universe_id, output_id = key
-        control = ContextEntity(
-            self.crate,
-            f"#control-{universe_id}-{output_id}",
-            properties={
-                "@type": "ControlAction",
-                "name": f"orchestration of `{output_id}` in universe `{universe_id}`",
-                "instrument": {"@id": f"#step-{output_id}"},
-                "object": {"@id": action.id},
-            },
+        self.crate.add(
+            ContextEntity(
+                self.crate,
+                _control_id(key),
+                properties={
+                    "@type": "ControlAction",
+                    "name": f"orchestration of `{output_id}` in universe `{universe_id}`",
+                    "instrument": {"@id": f"#step-{output_id}"},
+                    "object": {"@id": action_id},
+                },
+            )
         )
-        self.crate.add(control)
-        return control
 
-    def _runs(self, workflow: Any, datasets: dict[Key, str]) -> None:
+    def _runs(self, workflow: Any) -> None:
         """One ``OrganizeAction`` per run — outputs sharing a ``git_sha``
         were made by one ``lc materialize``, the driver's one HEAD read."""
         runs: dict[str, list[tuple[Key, assets.Manifest]]] = {}
@@ -479,18 +470,17 @@ class _Builder:
                         f"one materialization run, starting from commit {sha or '(unrecorded)'}"
                     ),
                     "instrument": {"@id": workflow.id},
-                    "result": [{"@id": datasets[key]} for key, _ in group],
+                    "result": [{"@id": self._dataset_id(key)} for key, _ in group],
                     "actionStatus": "http://schema.org/CompletedActionStatus",
                 },
             )
             if times:
                 run_action["startTime"] = times[0]
                 run_action["endTime"] = times[-1]
-            writer_sha, _, author, email, _ = self.writer(self.graph.tasks[group[0][0]].output_dir)
-            if writer_sha:
-                run_action["agent"] = {"@id": self._person(author, email)}
+            if agent := self.agents.get(group[0][0], ""):
+                run_action["agent"] = {"@id": agent}
             self.crate.add(run_action)
-            self.actions.append(run_action)
+            self.actions.append(str(run_action.id))
             organize = ContextEntity(
                 self.crate,
                 f"#organize-{sha[:7] or 'unknown'}",
@@ -498,33 +488,35 @@ class _Builder:
                     "@type": "OrganizeAction",
                     "name": f"scheduling of the run at {sha[:7] or 'unknown commit'}",
                     "instrument": {"@id": engine},
-                    "object": [
-                        {"@id": f"#control-{key[0]}-{key[1]}"} for key, _ in group
-                    ],
+                    "object": [{"@id": _control_id(key)} for key, _ in group],
                     "result": {"@id": run_action.id},
                 },
             )
             self.crate.add(organize)
 
     def _engine(self, version: str) -> str:
-        """The engine one run's manifests attest, deduplicated by version."""
-        if version not in self.engines:
-            engine_id = (
-                f"https://pypi.org/project/lightcone-cli/{version}/"
-                if version
-                else "#lightcone-cli"
-            )
+        """The engine one run's manifests attest, added once per version.
+
+        Its release page is both the id and the ``url`` — the one address
+        derivable from repository state alone; anything read off the
+        installed engine would differ between collaborators' hosts.
+        """
+        engine_id = (
+            f"https://pypi.org/project/lightcone-cli/{version}/"
+            if version
+            else "#lightcone-cli"
+        )
+        if engine_id not in self.engines:
             properties: dict[str, Any] = {
                 "@type": "SoftwareApplication",
                 "name": "lightcone-cli",
             }
             if version:
                 properties["softwareVersion"] = version
-            if self.engine_url:
-                properties["url"] = self.engine_url
+                properties["url"] = engine_id
             self.crate.add(ContextEntity(self.crate, engine_id, properties))
-            self.engines[version] = engine_id
-        return self.engines[version]
+            self.engines.add(engine_id)
+        return engine_id
 
     def _image(self, image: dict[str, Any]) -> str:
         """The committed archive: identity and payload as one entity."""
@@ -542,8 +534,8 @@ class _Builder:
             if str(image.get("id") or "").startswith("sha256:"):
                 properties["sha256"] = str(image["id"]).removeprefix("sha256:")
             self.crate.add_file(self.root / archive, archive, properties=properties)
-            self.images[archive] = archive
-        return self.images[archive]
+            self.images.add(archive)
+        return archive
 
     # ----- shared entities and the root -----
 
@@ -561,21 +553,19 @@ class _Builder:
             self.persons[person_key] = person_id
         return self.persons[person_key]
 
-    def _root(self, spec: dict[str, Any]) -> None:
+    def _root(self) -> None:
         root = self.crate.root_dataset
-        root["name"] = str(spec.get("name") or self.root.name)
+        root["name"] = self.title
         root["description"] = str(
-            spec.get("description")
-            or f"ASTRA analysis `{spec.get('name') or self.root.name}`, "
-            "materialized by lightcone-cli."
+            self.spec.get("description")
+            or f"ASTRA analysis `{self.title}`, materialized by lightcone-cli."
         )
         root["license"] = self._license_ref()
         # The newest recorded instant, never the clock: the document must
         # be a pure function of repository state, or every render is a
         # fresh diff and convergence commits forever.
         stamps = sorted(m.finished_at for _, m in self.made if m.finished_at)
-        spec_date = self.writer(self.root / "astra.yaml")[4]
-        root["datePublished"] = stamps[-1] if stamps else (spec_date or "1970-01-01")
+        root["datePublished"] = stamps[-1] if stamps else (self.spec_write.date or "1970-01-01")
         root["conformsTo"] = [{"@id": profile_id} for profile_id, _, _ in _PROFILES]
         for profile_id, name, version in _PROFILES:
             self.crate.add(
@@ -594,7 +584,7 @@ class _Builder:
                 {"@id": person_id} for person_id in sorted(self.persons.values())
             ]
         if self.actions:
-            root["mentions"] = [{"@id": action.id} for action in self.actions]
+            root["mentions"] = [{"@id": action_id} for action_id in self.actions]
 
     def _license_ref(self) -> Any:
         """The root's license value, always a linkable entity.
@@ -605,7 +595,8 @@ class _Builder:
         the declared string. Deliberately never a minted spdx.org URL:
         the declaration is not validated against the SPDX list, and a
         fabricated dead URL in a document built for archives is worse
-        than a local entity.
+        than a local entity. Idempotent: `add` replaces by id, so the
+        workflow and the root may both ask.
         """
         if (self.root / self.license).is_file():
             self._file(self.license)

--- a/src/lightcone/engine/dataset.py
+++ b/src/lightcone/engine/dataset.py
@@ -200,19 +200,28 @@ def last_writer(directory: Path, path: Path) -> tuple[str, str, str, str, str]:
     repository — and since nothing parses paths out of its output, no
     prefix handling is needed.
 
+    "Cannot say" is the empty answer, never an error: the callers are
+    ``lc status`` and the crate render, and a read-only verb must not
+    refuse a project over an unborn HEAD, a deposit stripped of its
+    ``.git``, or a host without git — states such projects are actually
+    in.
+
     Args:
         directory: The project root.
         path: The path to ask about, absolute or repository-relative.
 
     Returns:
         ``(sha, subject, author name, author email, author date)``, all
-        empty when no commit has touched the path.
+        empty when no commit has touched the path — or when git cannot
+        answer at all.
     """
-    out = _git(
-        ["log", "-1", "--format=%H%x00%s%x00%an%x00%ae%x00%as", "--", _rel(directory, path)],
-        cwd=directory,
-    ).strip("\n")
-    if not out:
+    argv = ["log", "-1", "--format=%H%x00%s%x00%an%x00%ae%x00%as", "--", _rel(directory, path)]
+    try:
+        proc = project._run(["git", *argv], cwd=directory)
+    except OSError:
+        return ("", "", "", "", "")
+    out = str(proc.stdout or "").strip("\n")
+    if proc.returncode != 0 or not out:
         return ("", "", "", "", "")
     sha, subject, author, email, date = out.split("\0")
     return (sha, subject, author, email, date)

--- a/src/lightcone/engine/dataset.py
+++ b/src/lightcone/engine/dataset.py
@@ -192,6 +192,32 @@ def dataset_id(directory: Path) -> str:
     return found.stdout.strip() if found.returncode == 0 else ""
 
 
+def last_writer(directory: Path, path: Path) -> tuple[str, str, str, str, str]:
+    """Find the commit that last touched *path*.
+
+    Run from the project root with a relative pathspec, so it answers
+    about the project's own subdirectory even inside an enclosing
+    repository — and since nothing parses paths out of its output, no
+    prefix handling is needed.
+
+    Args:
+        directory: The project root.
+        path: The path to ask about, absolute or repository-relative.
+
+    Returns:
+        ``(sha, subject, author name, author email, author date)``, all
+        empty when no commit has touched the path.
+    """
+    out = _git(
+        ["log", "-1", "--format=%H%x00%s%x00%an%x00%ae%x00%as", "--", _rel(directory, path)],
+        cwd=directory,
+    ).strip("\n")
+    if not out:
+        return ("", "", "", "", "")
+    sha, subject, author, email, date = out.split("\0")
+    return (sha, subject, author, email, date)
+
+
 def save(directory: Path, paths: Iterable[Path], message: str) -> bool:
     """Commit *paths*.
 

--- a/src/lightcone/engine/dataset.py
+++ b/src/lightcone/engine/dataset.py
@@ -19,9 +19,25 @@ asks anyone to run a git-annex command by hand.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 from lightcone.engine import project
+
+
+@dataclass(frozen=True)
+class LastWrite:
+    """The commit that last touched a path — empty fields mean "cannot
+    say", and the whole record is falsy then."""
+
+    sha: str = ""
+    subject: str = ""
+    author: str = ""
+    email: str = ""
+    date: str = ""
+
+    def __bool__(self) -> bool:
+        return bool(self.sha)
 
 # =============================================================================
 # The repository
@@ -192,7 +208,7 @@ def dataset_id(directory: Path) -> str:
     return found.stdout.strip() if found.returncode == 0 else ""
 
 
-def last_writer(directory: Path, path: Path) -> tuple[str, str, str, str, str]:
+def last_writer(directory: Path, path: Path) -> LastWrite:
     """Find the commit that last touched *path*.
 
     Run from the project root with a relative pathspec, so it answers
@@ -211,20 +227,18 @@ def last_writer(directory: Path, path: Path) -> tuple[str, str, str, str, str]:
         path: The path to ask about, absolute or repository-relative.
 
     Returns:
-        ``(sha, subject, author name, author email, author date)``, all
-        empty when no commit has touched the path — or when git cannot
-        answer at all.
+        The commit, falsy-empty when none has touched the path — or when
+        git cannot answer at all.
     """
     argv = ["log", "-1", "--format=%H%x00%s%x00%an%x00%ae%x00%as", "--", _rel(directory, path)]
     try:
         proc = project._run(["git", *argv], cwd=directory)
     except OSError:
-        return ("", "", "", "", "")
+        return LastWrite()
     out = str(proc.stdout or "").strip("\n")
     if proc.returncode != 0 or not out:
-        return ("", "", "", "", "")
-    sha, subject, author, email, date = out.split("\0")
-    return (sha, subject, author, email, date)
+        return LastWrite()
+    return LastWrite(*out.split("\0"))
 
 
 def save(directory: Path, paths: Iterable[Path], message: str) -> bool:

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -271,6 +271,15 @@ class OutputStatus:
     git_sha: str
     #: Its content identity, or empty if it was never materialized.
     data_version: str
+    #: Empty when the commit that last touched the output's directory is
+    #: its own run record. Otherwise the foreign commit, named — the
+    #: agent-forged-file fact: a hand-edited-and-committed output reads
+    #: `current` forever, because a skip returns the recorded digest, and
+    #: this is the one place that says so. History-based on purpose: it
+    #: costs no hashing and answers on a clone that holds none of the
+    #: bytes. What it leaves to existing tools: uncommitted edits are a
+    #: dirty tree, and annex object corruption is `git annex fsck`.
+    foreign_write: str = ""
 
     def as_dict(self) -> dict[str, Any]:
         """Return the record as JSON-ready data.
@@ -357,10 +366,25 @@ def status(root: Path) -> StatusReport:
                 why=verdict.why,
                 git_sha=manifest.git_sha if manifest else "",
                 data_version=manifest.data_version if manifest else "",
+                foreign_write="" if manifest is None else _foreign_write(root, key),
             )
         )
     result.warnings = report.warnings
     return result
+
+
+def _foreign_write(root: Path, key: Key) -> str:
+    """Name the commit that last touched *key*'s directory, unless it is
+    the output's own run record — then empty, the clean answer."""
+    directory = assets.output_dir(root, *key)
+    sha, subject, author, _, date = dataset.last_writer(root, directory)
+    if not sha or subject == run_subject(key):
+        return ""
+    return (
+        f'last changed by {sha[:7]} ("{subject}", {author}, {date}) rather than '
+        f"its run record, so the manifest may not describe these bytes — "
+        f"inspect with `git show {sha[:7]}`, or rebuild by deleting the directory"
+    )
 
 
 def _sandbox_line(mode: str) -> str:
@@ -502,6 +526,7 @@ def materialize(
         # survive.
         for task in outstanding.values():
             dataset.restore(root, [task.output_dir])
+    _converge_crate(root, report)
     return report
 
 
@@ -665,6 +690,66 @@ def _fetch_inputs(root: Path, graph: Graph, report: MaterializeReport) -> None:
 
 
 # =============================================================================
+# The publication view
+# =============================================================================
+
+
+def _converge_crate(root: Path, report: MaterializeReport) -> None:
+    """Bring ``ro-crate-metadata.json`` in line with the repository.
+
+    A derived artifact, converged the way ``uv.lock`` is: rendered from
+    repository state, compared, and committed only on a difference — so
+    an idempotent re-run commits nothing and nobody has to remember a
+    verb. Maintenance is derived from publication intent: a declared
+    ``[project].license`` turns it on, the same shape as
+    ``[tool.lightcone.image]`` deriving containerized mode. Runs after
+    the consume loop, driver-side, on the full graph rather than the
+    run's targets — the crate describes the project, not one invocation.
+    (The rerun entry point does not come through here: it is one task's
+    executor, so the crate lags until the next materialize.)
+    """
+    import functools
+
+    from lightcone.engine import crate
+
+    spdx = crate.license_of(root)
+    path = root / crate.CRATE_FILENAME
+    if not spdx:
+        report.warnings.append(
+            f"pyproject.toml no longer declares [project].license, so "
+            f"{crate.CRATE_FILENAME} is no longer maintained"
+            if path.exists()
+            else "no [project].license in pyproject.toml, so no RO-Crate "
+            "publication view is maintained — declare one to enable it"
+        )
+        return
+    full = plan.build(root)
+    for directory in sorted((root / "results").glob("*/*/")):
+        key = (directory.parent.name, directory.name)
+        if key not in full.tasks and assets.read(directory) is not None:
+            report.warnings.append(
+                f"results/{key[0]}/{key[1]} has a manifest but the spec no "
+                "longer declares it, so it is not in the publication view"
+            )
+    try:
+        engine_url = _repository_url()
+    except ProjectError:
+        engine_url = ""
+    document = crate.render(
+        root,
+        full,
+        license=spdx,
+        dsid=dataset.dataset_id(root),
+        writer=functools.partial(dataset.last_writer, root),
+        engine_url=engine_url,
+    )
+    if path.is_file() and path.read_text() == document:
+        return
+    path.write_text(document)
+    dataset.save(root, [path], "Update the RO-Crate publication view")
+
+
+# =============================================================================
 # The commit
 # =============================================================================
 
@@ -718,11 +803,22 @@ def run_record(root: Path, task: Task, dsid: str, runtime: container.Runtime) ->
         info["extra_inputs"] = [runtime.archive]
     body = json.dumps(info, indent=1, sort_keys=True, ensure_ascii=False)
     return (
-        f"[DATALAD RUNCMD] {task.output_id} [{task.universe_id}]\n\n"
+        f"{run_subject(task.key)}\n\n"
         "=== Do not change lines below ===\n"
         f"{body}\n"
         "^^^ Do not change lines above ^^^"
     )
+
+
+def run_subject(key: Key) -> str:
+    """The subject line of *key*'s run-record commit.
+
+    One spelling, shared with the foreign-write check: an output is
+    cleanly written iff the commit that last touched its directory
+    carries exactly this subject, so the composer and the comparator must
+    not be two strings that can drift apart.
+    """
+    return f"[DATALAD RUNCMD] {key[1]} [{key[0]}]"
 
 
 def _engine_requirement() -> str:

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -178,21 +178,17 @@ def _classified(
     for key in graph.order():
         task = graph.tasks[key]
         manifest = assets.read(task.output_dir)
+        # History is git's to answer, so it enters the one classification
+        # rule as a value — computed here, where git lives, exactly as
+        # the worker's driver computes it for a run.
+        foreign = "" if manifest is None else _foreign_write(root, key)
         verdict = assets.classify(
             definition_version=task.definition_version,
             env_version=env_version,
             manifest=manifest,
             inputs=_predicted(root, task, would_run, versions, unfetched),
+            foreign=foreign,
         )
-        # A foreign write is a *contradiction*, not a circumstance: the
-        # directory was last written by something other than its own run
-        # record, so the manifest no longer describes the bytes. That is
-        # `stale` by the model's own definition — escalated here, driver-
-        # side, because history is git's to answer and `classify` stays
-        # pure. An output already stale keeps its more actionable why.
-        foreign = "" if manifest is None else _foreign_write(root, key)
-        if foreign and verdict.status != "stale":
-            verdict = assets.Verdict("stale", foreign)
         if verdict.calls_for_a_remake(refresh=refresh):
             would_run.add(key)
         classified.append((key, verdict, manifest, foreign))
@@ -516,7 +512,7 @@ def materialize(
     # directory was last written by something other than its own run
     # record. A foreign write contradicts the manifest, and a worker that
     # trusted the recorded digest would skip the output forever.
-    foreign = {key: bool(_foreign_write(root, key)) for key in graph.tasks}
+    foreign = {key: _foreign_write(root, key) for key in graph.tasks}
     outstanding: dict[Key, Task] = dict(graph.tasks)
     try:
         with cluster_for_run() as scheduler:

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -134,7 +134,7 @@ def check(root: Path, targets: Sequence[str], *, refresh: bool = False) -> Mater
             read, or a target matches nothing.
     """
     report = MaterializeReport()
-    for key, verdict, _ in _classified(root, targets, report, refresh=refresh):
+    for key, verdict, _, _ in _classified(root, targets, report, refresh=refresh):
         name = _name(key)
         if verdict.calls_for_a_remake(refresh=refresh):
             report.planned[name] = verdict.why
@@ -147,7 +147,7 @@ def check(root: Path, targets: Sequence[str], *, refresh: bool = False) -> Mater
 
 def _classified(
     root: Path, targets: Sequence[str], report: MaterializeReport, *, refresh: bool
-) -> list[tuple[Key, assets.Verdict, assets.Manifest | None]]:
+) -> list[tuple[Key, assets.Verdict, assets.Manifest | None, str]]:
     """Classify every task in topological order, reading nothing but disk.
 
     The walk both read-only modes share, so there is one answer to "what
@@ -166,7 +166,8 @@ def _classified(
             decides whether their dependents see the sentinel.
 
     Returns:
-        One ``(key, verdict, manifest)`` per task, upstream first.
+        One ``(key, verdict, manifest, foreign write)`` per task, upstream
+        first.
     """
     graph, env_version = _graph(root, targets, report)
     versions = assets.Versions()
@@ -183,9 +184,18 @@ def _classified(
             manifest=manifest,
             inputs=_predicted(root, task, would_run, versions, unfetched),
         )
+        # A foreign write is a *contradiction*, not a circumstance: the
+        # directory was last written by something other than its own run
+        # record, so the manifest no longer describes the bytes. That is
+        # `stale` by the model's own definition — escalated here, driver-
+        # side, because history is git's to answer and `classify` stays
+        # pure. An output already stale keeps its more actionable why.
+        foreign = "" if manifest is None else _foreign_write(root, key)
+        if foreign and verdict.status != "stale":
+            verdict = assets.Verdict("stale", foreign)
         if verdict.calls_for_a_remake(refresh=refresh):
             would_run.add(key)
-        classified.append((key, verdict, manifest))
+        classified.append((key, verdict, manifest, foreign))
 
     if unfetched:
         report.warnings.append(
@@ -273,12 +283,14 @@ class OutputStatus:
     data_version: str
     #: Empty when the commit that last touched the output's directory is
     #: its own run record. Otherwise the foreign commit, named — the
-    #: agent-forged-file fact: a hand-edited-and-committed output reads
-    #: `current` forever, because a skip returns the recorded digest, and
-    #: this is the one place that says so. History-based on purpose: it
-    #: costs no hashing and answers on a clone that holds none of the
-    #: bytes. What it leaves to existing tools: uncommitted edits are a
-    #: dirty tree, and annex object corruption is `git annex fsck`.
+    #: agent-forged-file fact, which also makes ``status`` read `stale`:
+    #: the manifest no longer describes the bytes, and a skip would
+    #: return the recorded digest forever. Kept as its own field so a
+    #: machine consumer can tell a foreign write from any other stale
+    #: without parsing prose. History-based on purpose: it costs no
+    #: hashing and answers on a clone that holds none of the bytes. What
+    #: it leaves to existing tools: uncommitted edits are a dirty tree,
+    #: and annex object corruption is `git annex fsck`.
     foreign_write: str = ""
 
     def as_dict(self) -> dict[str, Any]:
@@ -358,7 +370,7 @@ def status(root: Path) -> StatusReport:
     if state != "direct":
         result.image = {"tag": tag, "state": state, "archive": archive}
     result.sandbox = _sandbox_line(result.mode)
-    for key, verdict, manifest in _classified(root, [], report, refresh=False):
+    for key, verdict, manifest, foreign in _classified(root, [], report, refresh=False):
         result.outputs.append(
             OutputStatus(
                 output=_name(key),
@@ -366,7 +378,7 @@ def status(root: Path) -> StatusReport:
                 why=verdict.why,
                 git_sha=manifest.git_sha if manifest else "",
                 data_version=manifest.data_version if manifest else "",
-                foreign_write="" if manifest is None else _foreign_write(root, key),
+                foreign_write=foreign,
             )
         )
     result.warnings = report.warnings
@@ -378,12 +390,12 @@ def _foreign_write(root: Path, key: Key) -> str:
     the output's own run record — then empty, the clean answer."""
     directory = assets.output_dir(root, *key)
     sha, subject, author, _, date = dataset.last_writer(root, directory)
-    if not sha or subject == run_subject(key):
+    if not sha or subject == datalad_run_subject(key):
         return ""
     return (
         f'last changed by {sha[:7]} ("{subject}", {author}, {date}) rather than '
-        f"its run record, so the manifest may not describe these bytes — "
-        f"inspect with `git show {sha[:7]}`, or rebuild by deleting the directory"
+        f"its run record, so the manifest no longer describes these bytes — "
+        f"the next run remakes it; inspect first with `git show {sha[:7]}`"
     )
 
 
@@ -455,6 +467,10 @@ def materialize(
     # "failed" on a typo in the spec.
     graph, env_version = _graph(root, targets, report)
     if not graph.tasks:
+        # No tasks is not no project: a spec whose outputs were all
+        # dropped still has a crate describing them, and this is its
+        # only maintainer.
+        _converge_crate(root, report, full=graph if not targets else None)
         return report
     _fetch_inputs(root, graph, report)
     # Before the runtime resolves, because the refusal must not cost an
@@ -495,6 +511,12 @@ def materialize(
     # declared input shared by several outputs — or by one output across
     # several universes — is the same bytes every time it is asked for.
     versions = assets.Versions()
+    # The history question is the driver's to answer — workers have no
+    # git, by design — so each task is told up front whether its
+    # directory was last written by something other than its own run
+    # record. A foreign write contradicts the manifest, and a worker that
+    # trusted the recorded digest would skip the output forever.
+    foreign = {key: bool(_foreign_write(root, key)) for key in graph.tasks}
     outstanding: dict[Key, Task] = dict(graph.tasks)
     try:
         with cluster_for_run() as scheduler:
@@ -512,6 +534,7 @@ def materialize(
                     head,
                     versions,
                     refresh,
+                    foreign[key],
                     runtime,
                     *[pending[dep] for dep in task.depends_on],
                     key=_name(key),
@@ -526,7 +549,7 @@ def materialize(
         # survive.
         for task in outstanding.values():
             dataset.restore(root, [task.output_dir])
-    _converge_crate(root, report)
+    _converge_crate(root, report, full=graph if not targets else None)
     return report
 
 
@@ -694,7 +717,7 @@ def _fetch_inputs(root: Path, graph: Graph, report: MaterializeReport) -> None:
 # =============================================================================
 
 
-def _converge_crate(root: Path, report: MaterializeReport) -> None:
+def _converge_crate(root: Path, report: MaterializeReport, full: Graph | None = None) -> None:
     """Bring ``ro-crate-metadata.json`` in line with the repository.
 
     A derived artifact, converged the way ``uv.lock`` is: rendered from
@@ -707,6 +730,20 @@ def _converge_crate(root: Path, report: MaterializeReport) -> None:
     run's targets — the crate describes the project, not one invocation.
     (The rerun entry point does not come through here: it is one task's
     executor, so the crate lags until the next materialize.)
+
+    Contained on purpose: by the time this runs every output is already
+    committed, so a failure here becomes a warning and the report still
+    reaches the user — the crate is the publication view, not the run.
+    An interrupt between the write and its commit restores the file, so
+    the tree ends as clean as the loop left it; and the save runs even
+    when the text already matches, healing a previously interrupted
+    converge whose write survived uncommitted.
+
+    Args:
+        root: The project root.
+        report: Collects the one maintenance line and any warnings.
+        full: The whole-project graph, when the caller already built one
+            — a targeted run's is narrowed, so it rebuilds here.
     """
     import functools
 
@@ -723,30 +760,44 @@ def _converge_crate(root: Path, report: MaterializeReport) -> None:
             "publication view is maintained — declare one to enable it"
         )
         return
-    full = plan.build(root)
-    for directory in sorted((root / "results").glob("*/*/")):
-        key = (directory.parent.name, directory.name)
-        if key not in full.tasks and assets.read(directory) is not None:
-            report.warnings.append(
-                f"results/{key[0]}/{key[1]} has a manifest but the spec no "
-                "longer declares it, so it is not in the publication view"
-            )
     try:
-        engine_url = _repository_url()
-    except ProjectError:
-        engine_url = ""
-    document = crate.render(
-        root,
-        full,
-        license=spdx,
-        dsid=dataset.dataset_id(root),
-        writer=functools.partial(dataset.last_writer, root),
-        engine_url=engine_url,
-    )
-    if path.is_file() and path.read_text() == document:
-        return
-    path.write_text(document)
-    dataset.save(root, [path], "Update the RO-Crate publication view")
+        graph = full if full is not None else plan.build(root)
+        for directory in sorted((root / "results").glob("*/*/")):
+            key = (directory.parent.name, directory.name)
+            if key not in graph.tasks and assets.read(directory) is not None:
+                report.warnings.append(
+                    f"results/{key[0]}/{key[1]} has a manifest but the spec no "
+                    "longer declares it, so it is not in the publication view"
+                )
+        try:
+            engine_url = _repository_url()
+        except ProjectError:
+            engine_url = ""
+        document = crate.render(
+            root,
+            graph,
+            license=spdx,
+            dsid=dataset.dataset_id(root),
+            # Cached: the render asks about `astra.yaml` and each run's
+            # directory more than once, and one answer per path per run
+            # is the memo discipline `assets.Versions` already sets.
+            writer=functools.lru_cache(maxsize=None)(
+                functools.partial(dataset.last_writer, root)
+            ),
+            engine_url=engine_url,
+        )
+        if not (path.is_file() and path.read_text() == document):
+            path.write_text(document)
+        try:
+            dataset.save(root, [path], "Update the RO-Crate publication view")
+        except BaseException:
+            # An interrupt or a git failure between the write and its
+            # commit must not leave a file lc wrote for the next run's
+            # dirty refusal to blame on the user.
+            dataset.restore(root, [path])
+            raise
+    except Exception as e:
+        report.warnings.append(f"the RO-Crate publication view could not be updated: {e}")
 
 
 # =============================================================================
@@ -803,17 +854,19 @@ def run_record(root: Path, task: Task, dsid: str, runtime: container.Runtime) ->
         info["extra_inputs"] = [runtime.archive]
     body = json.dumps(info, indent=1, sort_keys=True, ensure_ascii=False)
     return (
-        f"{run_subject(task.key)}\n\n"
+        f"{datalad_run_subject(task.key)}\n\n"
         "=== Do not change lines below ===\n"
         f"{body}\n"
         "^^^ Do not change lines above ^^^"
     )
 
 
-def run_subject(key: Key) -> str:
-    """The subject line of *key*'s run-record commit.
+def datalad_run_subject(key: Key) -> str:
+    """The subject line of *key*'s ``[DATALAD RUNCMD]`` commit — datalad's
+    format, which its ``rerun`` matches with a regex, not a spelling of
+    ours to adjust.
 
-    One spelling, shared with the foreign-write check: an output is
+    One function, shared with the foreign-write check: an output is
     cleanly written iff the commit that last touched its directory
     carries exactly this subject, so the composer and the comparator must
     not be two strings that can drift apart.

--- a/src/lightcone/engine/materialize.py
+++ b/src/lightcone/engine/materialize.py
@@ -32,6 +32,7 @@ task — that is what puts git back in the workers.
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import re
@@ -147,7 +148,7 @@ def check(root: Path, targets: Sequence[str], *, refresh: bool = False) -> Mater
 
 def _classified(
     root: Path, targets: Sequence[str], report: MaterializeReport, *, refresh: bool
-) -> list[tuple[Key, assets.Verdict, assets.Manifest | None, str]]:
+) -> list[tuple[Key, assets.Verdict, assets.Manifest | None, dataset.LastWrite | None]]:
     """Classify every task in topological order, reading nothing but disk.
 
     The walk both read-only modes share, so there is one answer to "what
@@ -169,7 +170,7 @@ def _classified(
         One ``(key, verdict, manifest, foreign write)`` per task, upstream
         first.
     """
-    graph, env_version = _graph(root, targets, report)
+    graph, env_version, _ = _graph(root, targets, report)
     versions = assets.Versions()
     would_run: set[Key] = set()
     unfetched: set[str] = set()
@@ -181,7 +182,7 @@ def _classified(
         # History is git's to answer, so it enters the one classification
         # rule as a value — computed here, where git lives, exactly as
         # the worker's driver computes it for a run.
-        foreign = "" if manifest is None else _foreign_write(root, key)
+        foreign = None if manifest is None else _foreign_write(root, key)
         verdict = assets.classify(
             definition_version=task.definition_version,
             env_version=env_version,
@@ -278,15 +279,15 @@ class OutputStatus:
     #: Its content identity, or empty if it was never materialized.
     data_version: str
     #: Empty when the commit that last touched the output's directory is
-    #: its own run record. Otherwise the foreign commit, named — the
-    #: agent-forged-file fact, which also makes ``status`` read `stale`:
+    #: its own run record. Otherwise that foreign commit's sha — the
+    #: agent-forged-file fact, which also makes the output read `stale`:
     #: the manifest no longer describes the bytes, and a skip would
-    #: return the recorded digest forever. Kept as its own field so a
-    #: machine consumer can tell a foreign write from any other stale
-    #: without parsing prose. History-based on purpose: it costs no
-    #: hashing and answers on a clone that holds none of the bytes. What
-    #: it leaves to existing tools: uncommitted edits are a dirty tree,
-    #: and annex object corruption is `git annex fsck`.
+    #: return the recorded digest forever. The sha rather than prose,
+    #: so a machine consumer gets what `why`'s sentence cannot carry.
+    #: History-based on purpose: it costs no hashing and answers on a
+    #: clone that holds none of the bytes. What it leaves to existing
+    #: tools: uncommitted edits are a dirty tree, and annex object
+    #: corruption is `git annex fsck`.
     foreign_write: str = ""
 
     def as_dict(self) -> dict[str, Any]:
@@ -374,25 +375,22 @@ def status(root: Path) -> StatusReport:
                 why=verdict.why,
                 git_sha=manifest.git_sha if manifest else "",
                 data_version=manifest.data_version if manifest else "",
-                foreign_write=foreign,
+                foreign_write=foreign.sha if foreign else "",
             )
         )
     result.warnings = report.warnings
     return result
 
 
-def _foreign_write(root: Path, key: Key) -> str:
-    """Name the commit that last touched *key*'s directory, unless it is
-    the output's own run record — then empty, the clean answer."""
-    directory = assets.output_dir(root, *key)
-    sha, subject, author, _, date = dataset.last_writer(root, directory)
-    if not sha or subject == datalad_run_subject(key):
-        return ""
-    return (
-        f'last changed by {sha[:7]} ("{subject}", {author}, {date}) rather than '
-        f"its run record, so the manifest no longer describes these bytes — "
-        f"the next run remakes it; inspect first with `git show {sha[:7]}`"
-    )
+def _foreign_write(root: Path, key: Key) -> dataset.LastWrite | None:
+    """Find the commit that last touched *key*'s directory, unless it is
+    the output's own run record — then ``None``, the clean answer. The
+    fact only: the verdict's prose is `classify`'s, like every other
+    why."""
+    write = dataset.last_writer(root, assets.output_dir(root, *key))
+    if not write or write.subject == datalad_run_subject(key):
+        return None
+    return write
 
 
 def _sandbox_line(mode: str) -> str:
@@ -461,12 +459,13 @@ def materialize(
     # before the image: a refusal here must not cost a minutes-long
     # build, and must not leave an archive commit behind a run that
     # "failed" on a typo in the spec.
-    graph, env_version = _graph(root, targets, report)
+    graph, env_version, full = _graph(root, targets, report)
+    dsid = dataset.dataset_id(root)
     if not graph.tasks:
         # No tasks is not no project: a spec whose outputs were all
         # dropped still has a crate describing them, and this is its
         # only maintainer.
-        _converge_crate(root, report, full=graph if not targets else None)
+        _converge_crate(root, report, full, dsid)
         return report
     _fetch_inputs(root, graph, report)
     # Before the runtime resolves, because the refusal must not cost an
@@ -497,7 +496,6 @@ def materialize(
     # rerun does not come through here; its entry point converges too.)
     report.warnings.extend(f"uv: {w}" for w in container.converge(runtime))
 
-    dsid = dataset.dataset_id(root)
     # Read once, for every task: the driver commits each output as it lands,
     # so HEAD moves during the run, and a per-task read would give later
     # manifests a commit this run created — nondeterministically, depending
@@ -511,8 +509,16 @@ def materialize(
     # git, by design — so each task is told up front whether its
     # directory was last written by something other than its own run
     # record. A foreign write contradicts the manifest, and a worker that
-    # trusted the recorded digest would skip the output forever.
-    foreign = {key: _foreign_write(root, key) for key in graph.tasks}
+    # trusted the recorded digest would skip the output forever. Guarded
+    # on the manifest's presence, as `_classified` is: without one the
+    # answer is dead — the output is remade regardless — and each ask is
+    # a git process.
+    foreign = {
+        key: _foreign_write(root, key)
+        if (task.output_dir / assets.MANIFEST_FILENAME).is_file()
+        else None
+        for key, task in graph.tasks.items()
+    }
     outstanding: dict[Key, Task] = dict(graph.tasks)
     try:
         with cluster_for_run() as scheduler:
@@ -545,7 +551,7 @@ def materialize(
         # survive.
         for task in outstanding.values():
             dataset.restore(root, [task.output_dir])
-    _converge_crate(root, report, full=graph if not targets else None)
+    _converge_crate(root, report, full, dsid)
     return report
 
 
@@ -713,7 +719,7 @@ def _fetch_inputs(root: Path, graph: Graph, report: MaterializeReport) -> None:
 # =============================================================================
 
 
-def _converge_crate(root: Path, report: MaterializeReport, full: Graph | None = None) -> None:
+def _converge_crate(root: Path, report: MaterializeReport, full: Graph, dsid: str) -> None:
     """Bring ``ro-crate-metadata.json`` in line with the repository.
 
     A derived artifact, converged the way ``uv.lock`` is: rendered from
@@ -738,11 +744,11 @@ def _converge_crate(root: Path, report: MaterializeReport, full: Graph | None = 
     Args:
         root: The project root.
         report: Collects the one maintenance line and any warnings.
-        full: The whole-project graph, when the caller already built one
-            — a targeted run's is narrowed, so it rebuilds here.
+        full: The whole-project graph — never a run's narrowed one.
+        dsid: The dataset's UUID, already read by the caller.
     """
-    import functools
-
+    # Deferred so `lc status` and `--check` never import rocrate — the
+    # crate is the one materialize-only dependency on their shared path.
     from lightcone.engine import crate
 
     spdx = crate.license_of(root)
@@ -756,31 +762,20 @@ def _converge_crate(root: Path, report: MaterializeReport, full: Graph | None = 
             "publication view is maintained — declare one to enable it"
         )
         return
+    for directory in sorted((root / "results").glob("*/*/")):
+        key = (directory.parent.name, directory.name)
+        if key not in full.tasks and assets.read(directory) is not None:
+            report.warnings.append(
+                f"{plan.declared_path(root, directory)} has a manifest but the "
+                "spec no longer declares it, so it is not in the publication view"
+            )
     try:
-        graph = full if full is not None else plan.build(root)
-        for directory in sorted((root / "results").glob("*/*/")):
-            key = (directory.parent.name, directory.name)
-            if key not in graph.tasks and assets.read(directory) is not None:
-                report.warnings.append(
-                    f"results/{key[0]}/{key[1]} has a manifest but the spec no "
-                    "longer declares it, so it is not in the publication view"
-                )
-        try:
-            engine_url = _repository_url()
-        except ProjectError:
-            engine_url = ""
         document = crate.render(
             root,
-            graph,
+            full,
             license=spdx,
-            dsid=dataset.dataset_id(root),
-            # Cached: the render asks about `astra.yaml` and each run's
-            # directory more than once, and one answer per path per run
-            # is the memo discipline `assets.Versions` already sets.
-            writer=functools.lru_cache(maxsize=None)(
-                functools.partial(dataset.last_writer, root)
-            ),
-            engine_url=engine_url,
+            dsid=dsid,
+            writer=functools.partial(dataset.last_writer, root),
         )
         if not (path.is_file() and path.read_text() == document):
             path.write_text(document)
@@ -915,12 +910,16 @@ def _repository_url() -> str:
 # =============================================================================
 
 
-def _graph(root: Path, targets: Sequence[str], report: MaterializeReport) -> tuple[Graph, str]:
+def _graph(
+    root: Path, targets: Sequence[str], report: MaterializeReport
+) -> tuple[Graph, str, Graph]:
     """The tasks a run covers, and the environment they will be compared to.
 
     The lock scan runs here, once, for both modes: what it refuses is a
     dependency whose bytes the lock does not pin, which makes every hash
-    below it a claim nobody can check.
+    below it a claim nobody can check. The unnarrowed graph is returned
+    beside the narrowed one, because the crate describes the whole
+    project and must not pay a second spec validation to see it.
     """
     scan = identity.scan_lock(root)
     if scan.refusals:
@@ -942,9 +941,8 @@ def _graph(root: Path, targets: Sequence[str], report: MaterializeReport) -> tup
         )
 
     env_version = identity.env_version(root)
-    graph = plan.build(root)
-    if targets:
-        graph = graph.closure(graph.resolve(list(targets)))
+    full = plan.build(root)
+    graph = full.closure(full.resolve(list(targets))) if targets else full
 
     # A declared input outside the project is hashed into the manifest like
     # any other, so a change to it still cascades — but it is not in the
@@ -963,7 +961,7 @@ def _graph(root: Path, targets: Sequence[str], report: MaterializeReport) -> tup
             "not stored in it, so a commit cannot restore them: "
             + ", ".join(sorted(outside))
         )
-    return graph, env_version
+    return graph, env_version, full
 
 
 def _name(key: Key) -> str:

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -97,7 +97,7 @@ def materialize(
     head: Head,
     versions: assets.Versions,
     refresh: bool,
-    foreign: str,
+    foreign: dataset.LastWrite | None,
     runtime: container.Runtime,
     *upstream: TaskResult,
 ) -> TaskResult:
@@ -117,8 +117,8 @@ def materialize(
             driver because it commits as outputs land and HEAD moves.
         versions: The run's content-hash memo for declared inputs.
         refresh: Whether to remake an output that is merely behind.
-        foreign: Empty, or the commit that last wrote the output's
-            directory in place of its own run record — answered by the
+        foreign: The commit that last wrote the output's directory in
+            place of its own run record, or ``None`` — answered by the
             driver, because history is git's and workers have no git;
             handed to the one classification rule, where it is `stale`.
         runtime: The execution world, resolved once by the driver — the
@@ -146,7 +146,7 @@ def _materialize(
     head: Head,
     versions: assets.Versions,
     refresh: bool,
-    foreign: str,
+    foreign: dataset.LastWrite | None,
     runtime: container.Runtime,
     upstream: tuple[TaskResult, ...],
 ) -> TaskResult:

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -97,7 +97,7 @@ def materialize(
     head: Head,
     versions: assets.Versions,
     refresh: bool,
-    foreign: bool,
+    foreign: str,
     runtime: container.Runtime,
     *upstream: TaskResult,
 ) -> TaskResult:
@@ -117,11 +117,10 @@ def materialize(
             driver because it commits as outputs land and HEAD moves.
         versions: The run's content-hash memo for declared inputs.
         refresh: Whether to remake an output that is merely behind.
-        foreign: Whether the output's directory was last written by
-            something other than its own run record — answered by the
-            driver, because history is git's and workers have no git.
-            True forces a remake: the manifest no longer describes the
-            bytes, so the recorded digest a skip would return is a lie.
+        foreign: Empty, or the commit that last wrote the output's
+            directory in place of its own run record — answered by the
+            driver, because history is git's and workers have no git;
+            handed to the one classification rule, where it is `stale`.
         runtime: The execution world, resolved once by the driver — the
             same discipline as *head*, because resolving per task could
             answer differently mid-run.
@@ -147,7 +146,7 @@ def _materialize(
     head: Head,
     versions: assets.Versions,
     refresh: bool,
-    foreign: bool,
+    foreign: str,
     runtime: container.Runtime,
     upstream: tuple[TaskResult, ...],
 ) -> TaskResult:
@@ -167,8 +166,9 @@ def _materialize(
         env_version=env_version,
         manifest=manifest,
         inputs=inputs,
+        foreign=foreign,
     )
-    if foreign or verdict.calls_for_a_remake(refresh=refresh):
+    if verdict.calls_for_a_remake(refresh=refresh):
         return execute(root, task, env_version, inputs, head=head, runtime=runtime)
 
     # Left alone, so the bytes on disk stand. Their *recorded* digest,

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -97,6 +97,7 @@ def materialize(
     head: Head,
     versions: assets.Versions,
     refresh: bool,
+    foreign: bool,
     runtime: container.Runtime,
     *upstream: TaskResult,
 ) -> TaskResult:
@@ -116,6 +117,11 @@ def materialize(
             driver because it commits as outputs land and HEAD moves.
         versions: The run's content-hash memo for declared inputs.
         refresh: Whether to remake an output that is merely behind.
+        foreign: Whether the output's directory was last written by
+            something other than its own run record — answered by the
+            driver, because history is git's and workers have no git.
+            True forces a remake: the manifest no longer describes the
+            bytes, so the recorded digest a skip would return is a lie.
         runtime: The execution world, resolved once by the driver — the
             same discipline as *head*, because resolving per task could
             answer differently mid-run.
@@ -127,7 +133,9 @@ def materialize(
         What happened. Never raises.
     """
     try:
-        return _materialize(root, task, env_version, head, versions, refresh, runtime, upstream)
+        return _materialize(
+            root, task, env_version, head, versions, refresh, foreign, runtime, upstream
+        )
     except Exception as e:  # the contract is that this function returns
         return TaskResult(task.key, "failed", reason=f"{type(e).__name__}: {e}")
 
@@ -139,6 +147,7 @@ def _materialize(
     head: Head,
     versions: assets.Versions,
     refresh: bool,
+    foreign: bool,
     runtime: container.Runtime,
     upstream: tuple[TaskResult, ...],
 ) -> TaskResult:
@@ -159,7 +168,7 @@ def _materialize(
         manifest=manifest,
         inputs=inputs,
     )
-    if verdict.calls_for_a_remake(refresh=refresh):
+    if foreign or verdict.calls_for_a_remake(refresh=refresh):
         return execute(root, task, env_version, inputs, head=head, runtime=runtime)
 
     # Left alone, so the bytes on disk stand. Their *recorded* digest,

--- a/src/lightcone/engine/worker.py
+++ b/src/lightcone/engine/worker.py
@@ -32,6 +32,7 @@ import shutil
 import sys
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
@@ -223,6 +224,7 @@ def execute(
 
     read_paths = [p for p in task.inputs.values() if p.exists()]
     policy = container.policy_for(runtime, read_paths)
+    started_at = _now()
     with sandbox.scope(policy):
         outcome = sandbox.run(
             container.backend(runtime),
@@ -232,6 +234,7 @@ def execute(
             prefix=uv_prefix(root, sync=False),
             env=child_env(),
         )
+    finished_at = _now()
 
     if outcome.returncode != 0:
         return TaskResult(
@@ -264,6 +267,8 @@ def execute(
                 git_remote=remote,
                 lc_version=lc_version(),
                 hermeticity=asdict(outcome.attestation),
+                started_at=started_at,
+                finished_at=finished_at,
                 image=runtime.manifest_image(),
             ),
         )
@@ -275,6 +280,16 @@ def execute(
             notes=outcome.notes,
         )
     return TaskResult(task.key, "ok", data_version=data_version, notes=outcome.notes)
+
+
+def _now() -> str:
+    """The current instant, as a manifest timestamp.
+
+    Milliseconds, not microseconds: RO-Crate consumers parse
+    ``schema:endTime`` with at most three fractional digits, and the
+    manifest is where that string is minted.
+    """
+    return datetime.now(UTC).isoformat(timespec="milliseconds")
 
 
 def _gate(root: Path, env_version: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import shutil
 import subprocess
 import textwrap
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -110,6 +111,34 @@ def tools(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
 
     monkeypatch.setattr(project.shutil, "which", fake_which)
     return calls
+
+
+class _Inline:
+    """Run a graph in this thread, in the order it was submitted.
+
+    Submission is topological, so a dependent is submitted only after its
+    upstreams have already run — which means the "handles" it is passed
+    are the upstream results themselves, exactly what the worker expects.
+    """
+
+    def submit(self, fn: Callable[..., object], *args: object, key: str) -> object:
+        return fn(*args)
+
+    def completed(self, handles: list[object]) -> Iterator[object]:
+        yield from handles
+
+
+@pytest.fixture
+def inline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the Dask cluster with an in-thread scheduler — the one
+    monkeypatch point `cluster_for_run` exists to be."""
+    from lightcone.engine import materialize
+
+    @contextmanager
+    def fake() -> Iterator[_Inline]:
+        yield _Inline()
+
+    monkeypatch.setattr(materialize, "cluster_for_run", fake)
 
 
 @pytest.fixture

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from lightcone.engine import assets
+from lightcone.engine import assets, dataset
 from lightcone.engine.assets import Manifest, classify, data_version, output_dir
 from lightcone.engine.project import ProjectError
 
@@ -277,6 +277,11 @@ def test_writing_a_manifest_replaces_the_previous_one_whole(tmp_path: Path) -> N
 _ENV = "sha256:env"
 
 
+_TWEAK = dataset.LastWrite(
+    "8d31f00" + "0" * 33, "tweak colors", "Ada", "ada@example.org", "2026-08-19"
+)
+
+
 def _classify(**overrides: object) -> assets.Verdict:
     """Classify against the manifest `_manifest()` builds, unchanged."""
     call: dict[str, object] = {
@@ -385,31 +390,33 @@ def test_stale_wins_over_behind() -> None:
     assert verdict.calls_for_a_remake(refresh=False)
 
 
-def test_a_foreign_write_is_stale() -> None:
-    """History enters the one rule as a value — the caller with git asks
-    who last wrote the directory, and a hit is a contradiction: the
-    manifest no longer describes the bytes."""
-    verdict = _classify(foreign='last changed by 8d31f00 ("tweak colors")')
+def test_a_foreign_write_is_stale_and_the_prose_is_composed_here() -> None:
+    """History enters the one rule as a value — the caller with git hands
+    over the offending commit, and a hit is a contradiction: the manifest
+    no longer describes the bytes. The sentence, like every other why,
+    is this module's."""
+    verdict = _classify(foreign=_TWEAK)
     assert verdict.status == "stale"
     assert verdict.calls_for_a_remake(refresh=False)
-    assert "8d31f00" in verdict.why
+    assert "8d31f00" in verdict.why and "tweak colors" in verdict.why
+    assert "git show 8d31f00" in verdict.why
 
 
 def test_a_definition_stale_output_keeps_its_own_why_over_a_foreign_write() -> None:
     """Both call for the same remake, and the definition drift is the more
     actionable reason to report."""
-    verdict = _classify(definition_version="sha256:other", foreign="also hand-edited")
+    verdict = _classify(definition_version="sha256:other", foreign=_TWEAK)
     assert verdict.status == "stale"
-    assert "also hand-edited" not in verdict.why
+    assert "tweak colors" not in verdict.why
 
 
 def test_a_foreign_write_wins_over_behind() -> None:
     """A behind output is not wrong; a foreign-written one is — reporting
     "left alone" about something the run is about to remake is the one
     wrong answer, the same rule as stale-over-behind."""
-    verdict = _classify(env_version="sha256:moved", foreign="hand-edited")
+    verdict = _classify(env_version="sha256:moved", foreign=_TWEAK)
     assert verdict.status == "stale"
-    assert verdict.why == "hand-edited"
+    assert "tweak colors" in verdict.why
 
 
 def test_an_environment_that_did_not_move_is_not_behind() -> None:

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -385,6 +385,33 @@ def test_stale_wins_over_behind() -> None:
     assert verdict.calls_for_a_remake(refresh=False)
 
 
+def test_a_foreign_write_is_stale() -> None:
+    """History enters the one rule as a value — the caller with git asks
+    who last wrote the directory, and a hit is a contradiction: the
+    manifest no longer describes the bytes."""
+    verdict = _classify(foreign='last changed by 8d31f00 ("tweak colors")')
+    assert verdict.status == "stale"
+    assert verdict.calls_for_a_remake(refresh=False)
+    assert "8d31f00" in verdict.why
+
+
+def test_a_definition_stale_output_keeps_its_own_why_over_a_foreign_write() -> None:
+    """Both call for the same remake, and the definition drift is the more
+    actionable reason to report."""
+    verdict = _classify(definition_version="sha256:other", foreign="also hand-edited")
+    assert verdict.status == "stale"
+    assert "also hand-edited" not in verdict.why
+
+
+def test_a_foreign_write_wins_over_behind() -> None:
+    """A behind output is not wrong; a foreign-written one is — reporting
+    "left alone" about something the run is about to remake is the one
+    wrong answer, the same rule as stale-over-behind."""
+    verdict = _classify(env_version="sha256:moved", foreign="hand-edited")
+    assert verdict.status == "stale"
+    assert verdict.why == "hand-edited"
+
+
 def test_an_environment_that_did_not_move_is_not_behind() -> None:
     """The negative half of the sensitivity pair: `behind` has to be off by
     default, or every output reports it forever and the signal is dead."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -574,7 +574,7 @@ def test_status_renders_a_foreign_write_as_a_stale_output(
                 message,
                 "3f2a1c8ffff",
                 "sha256:one",
-                foreign_write=message,
+                foreign_write="8d31f00" + "0" * 33,
             ),
         ]
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -553,27 +553,28 @@ def test_build_on_a_direct_project_is_an_explanatory_no_op(
     assert "[tool.lightcone.image]" in result.output
 
 
-def test_status_renders_a_foreign_write_under_its_output(
+def test_status_renders_a_foreign_write_as_a_stale_output(
     runner: CliRunner, project: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The agent-forged-file fact gets its own line, under the output it
-    is about — and it does not change the exit code: status reports."""
+    """A foreign write arrives as a stale with its message in `why`, so
+    the one rendering path covers it — and it does not change the exit
+    code: status reports."""
     from lightcone.engine.materialize import OutputStatus, StatusReport
 
+    message = (
+        'last changed by 8d31f00 ("tweak colors", Ada, 2026-08-19) rather '
+        "than its run record, so the manifest no longer describes these "
+        "bytes — the next run remakes it; inspect first with `git show 8d31f00`"
+    )
     report = StatusReport(
         outputs=[
             OutputStatus(
                 "baseline/first",
-                "current",
-                "",
+                "stale",
+                message,
                 "3f2a1c8ffff",
                 "sha256:one",
-                foreign_write=(
-                    'last changed by 8d31f00 ("tweak colors", Ada, 2026-08-19) rather '
-                    "than its run record, so the manifest may not describe these bytes "
-                    "— inspect with `git show 8d31f00`, or rebuild by deleting the "
-                    "directory"
-                ),
+                foreign_write=message,
             ),
         ]
     )
@@ -582,7 +583,7 @@ def test_status_renders_a_foreign_write_under_its_output(
     result = runner.invoke(main, ["status"])
 
     assert result.exit_code == 0
-    assert "foreign write" in result.output
+    assert "stale" in result.output
     assert "8d31f00" in result.output
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -553,6 +553,39 @@ def test_build_on_a_direct_project_is_an_explanatory_no_op(
     assert "[tool.lightcone.image]" in result.output
 
 
+def test_status_renders_a_foreign_write_under_its_output(
+    runner: CliRunner, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The agent-forged-file fact gets its own line, under the output it
+    is about — and it does not change the exit code: status reports."""
+    from lightcone.engine.materialize import OutputStatus, StatusReport
+
+    report = StatusReport(
+        outputs=[
+            OutputStatus(
+                "baseline/first",
+                "current",
+                "",
+                "3f2a1c8ffff",
+                "sha256:one",
+                foreign_write=(
+                    'last changed by 8d31f00 ("tweak colors", Ada, 2026-08-19) rather '
+                    "than its run record, so the manifest may not describe these bytes "
+                    "— inspect with `git show 8d31f00`, or rebuild by deleting the "
+                    "directory"
+                ),
+            ),
+        ]
+    )
+    _status_stub(monkeypatch, report)
+
+    result = runner.invoke(main, ["status"])
+
+    assert result.exit_code == 0
+    assert "foreign write" in result.output
+    assert "8d31f00" in result.output
+
+
 def test_status_exits_zero_even_with_stale_outputs(
     runner: CliRunner, project: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -583,6 +616,7 @@ def test_status_json_is_machine_readable(
                 "why": "",
                 "git_sha": "3f2a1c8ffff",
                 "data_version": "sha256:one",
+                "foreign_write": "",
             },
             {
                 "output": "baseline/second",
@@ -590,6 +624,7 @@ def test_status_json_is_machine_readable(
                 "why": "made under an earlier environment",
                 "git_sha": "3f2a1c8ffff",
                 "data_version": "sha256:two",
+                "foreign_write": "",
             },
             {
                 "output": "baseline/third",
@@ -597,6 +632,7 @@ def test_status_json_is_machine_readable(
                 "why": "the input `first` changed",
                 "git_sha": "",
                 "data_version": "",
+                "foreign_write": "",
             },
         ],
         "warnings": [],

--- a/tests/test_crate.py
+++ b/tests/test_crate.py
@@ -296,11 +296,19 @@ def test_a_never_materialized_project_still_describes_its_workflow(project: Path
     assert "astra.yaml" in entities
 
 
-def test_the_license_is_an_spdx_entity(project: Path) -> None:
+def test_the_license_is_a_local_entity_never_a_minted_url(project: Path) -> None:
+    """The declaration is not validated against the SPDX list, so a minted
+    spdx.org URL could be a fabricated dead link — a local CreativeWork
+    carries the declared string instead, and a URL license is used as
+    given."""
     entities = _entities(_render(project, _graph(project)))
 
-    assert entities["./"]["license"] == {"@id": "https://spdx.org/licenses/MIT"}
-    assert entities["https://spdx.org/licenses/MIT"]["@type"] == "CreativeWork"
+    assert entities["./"]["license"] == {"@id": "#license"}
+    assert entities["#license"] == {
+        "@id": "#license",
+        "@type": "CreativeWork",
+        "name": "MIT",
+    }
 
 
 def test_license_of_reads_every_spelling(tmp_path: Path) -> None:

--- a/tests/test_crate.py
+++ b/tests/test_crate.py
@@ -17,11 +17,12 @@ from typing import Any
 import pytest
 
 from lightcone.engine import assets, crate
+from lightcone.engine.dataset import LastWrite
 from lightcone.engine.plan import Graph, Key, Task
 
 _DSID = "4b7b5c1e-0000-4000-8000-000000000000"
 
-Writer = Callable[[Path], crate.LastWrite]
+Writer = Callable[[Path], LastWrite]
 
 
 @pytest.fixture
@@ -102,8 +103,8 @@ def _graph(root: Path, universes: tuple[str, ...] = ("baseline",)) -> Graph:
     return Graph(tasks)
 
 
-def _writer(path: Path) -> crate.LastWrite:
-    return ("a" * 40, "irrelevant", "Ada Lovelace", "ada@example.org", "2026-08-19")
+def _writer(path: Path) -> LastWrite:
+    return LastWrite("a" * 40, "irrelevant", "Ada Lovelace", "ada@example.org", "2026-08-19")
 
 
 def _render(root: Path, graph: Graph, writer: Writer = _writer) -> dict[str, Any]:

--- a/tests/test_crate.py
+++ b/tests/test_crate.py
@@ -1,0 +1,319 @@
+"""Tests for `lightcone.engine.crate` — the publication view, rendered pure.
+
+Everything here is disk-only: fixture manifests under ``tmp_path``, a
+hand-built graph, and a stub for "who last wrote this path" — no git, no
+subprocess. Structure and ordering are asserted, never byte goldens; the
+one byte-level claim is determinism, because convergence-by-materialize
+rests on rendering twice at the same state yielding identical text.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lightcone.engine import assets, crate
+from lightcone.engine.plan import Graph, Key, Task
+
+_DSID = "4b7b5c1e-0000-4000-8000-000000000000"
+
+Writer = Callable[[Path], crate.LastWrite]
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    root = tmp_path / "demo"
+    (root / "universes").mkdir(parents=True)
+    (root / "data").mkdir()
+    (root / "astra.yaml").write_text("name: demo\ndescription: A demo analysis.\n")
+    (root / "universes" / "baseline.yaml").write_text("id: baseline\n")
+    (root / "universes" / "alt.yaml").write_text("id: alt\n")
+    (root / "pyproject.toml").write_text('[project]\nname = "demo"\nlicense = "MIT"\n')
+    (root / "uv.lock").write_text("version = 1\n")
+    (root / ".python-version").write_text("3.12.5\n")
+    (root / "data" / "catalog.csv").write_text("a,b\n")
+    return root
+
+
+def _made(
+    root: Path,
+    universe_id: str,
+    output_id: str,
+    *,
+    git_sha: str,
+    image: dict[str, str] | None = None,
+    inputs: dict[str, str] | None = None,
+    finished_at: str = "2026-08-19T10:05:00.000+00:00",
+) -> Path:
+    directory = root / "results" / universe_id / output_id
+    directory.mkdir(parents=True)
+    (directory / "out.txt").write_text(f"{universe_id}/{output_id}\n")
+    assets.write(
+        directory,
+        assets.Manifest(
+            output_id=output_id,
+            universe_id=universe_id,
+            recipe=f"make {output_id}",
+            definition_version="sha256:def",
+            env_version="sha256:env",
+            data_version=f"sha256:{universe_id}-{output_id}",
+            decisions={"method": "alpha"},
+            input_versions=inputs or {},
+            git_sha=git_sha,
+            git_remote="https://github.com/example/demo.git",
+            lc_version="0.4.2",
+            hermeticity={"mechanism": "landlock"},
+            started_at="2026-08-19T10:00:00.000+00:00",
+            finished_at=finished_at,
+            image=image,
+        ),
+    )
+    return directory
+
+
+def _graph(root: Path, universes: tuple[str, ...] = ("baseline",)) -> Graph:
+    tasks: dict[Key, Task] = {}
+    for universe_id in universes:
+        first_dir = root / "results" / universe_id / "first"
+        tasks[(universe_id, "first")] = Task(
+            universe_id,
+            "first",
+            first_dir,
+            "make first",
+            {"catalog": root / "data" / "catalog.csv"},
+            {},
+            {"method": "alpha"},
+            "sha256:def",
+        )
+        tasks[(universe_id, "second")] = Task(
+            universe_id,
+            "second",
+            root / "results" / universe_id / "second",
+            "make second",
+            {"first": first_dir},
+            {"first": (universe_id, "first")},
+            {"method": "alpha"},
+            "sha256:def",
+        )
+    return Graph(tasks)
+
+
+def _writer(path: Path) -> crate.LastWrite:
+    return ("a" * 40, "irrelevant", "Ada Lovelace", "ada@example.org", "2026-08-19")
+
+
+def _render(root: Path, graph: Graph, writer: Writer = _writer) -> dict[str, Any]:
+    text = crate.render(root, graph, license="MIT", dsid=_DSID, writer=writer)
+    loaded = json.loads(text)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _entities(document: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {entity["@id"]: entity for entity in document["@graph"]}
+
+
+# ---- determinism, the property convergence rests on ------------------------
+
+
+def test_rendering_twice_at_the_same_state_is_byte_identical(project: Path) -> None:
+    _made(project, "baseline", "first", git_sha="aaa111")
+    _made(project, "baseline", "second", git_sha="aaa111")
+    graph = _graph(project)
+
+    first = crate.render(project, graph, license="MIT", dsid=_DSID, writer=_writer)
+    second = crate.render(project, graph, license="MIT", dsid=_DSID, writer=_writer)
+
+    assert first == second
+
+
+def test_the_clock_never_enters_the_document(project: Path) -> None:
+    """`datePublished` is the newest recorded instant — rocrate's own
+    default stamps the current time, and this pins the override."""
+    _made(project, "baseline", "first", git_sha="aaa111")
+    _made(
+        project,
+        "baseline",
+        "second",
+        git_sha="aaa111",
+        finished_at="2026-08-20T09:00:00.000+00:00",
+    )
+
+    root_entity = _entities(_render(project, _graph(project)))["./"]
+
+    assert root_entity["datePublished"] == "2026-08-20T09:00:00.000+00:00"
+
+
+# ---- the workflow-run context and the profiles -----------------------------
+
+
+def test_the_context_carries_the_workflow_run_vocabulary(project: Path) -> None:
+    """Without it, `containerImage` and `sha256` are undefined terms that
+    JSON-LD silently drops on expansion — typed but inert."""
+    _made(project, "baseline", "first", git_sha="aaa111")
+    document = _render(project, _graph(project))
+
+    assert "https://w3id.org/ro/terms/workflow-run" in document["@context"]
+
+
+def test_the_root_conforms_to_every_claimed_profile_and_declares_each(
+    project: Path,
+) -> None:
+    _made(project, "baseline", "first", git_sha="aaa111")
+    entities = _entities(_render(project, _graph(project)))
+
+    claimed = {ref["@id"] for ref in entities["./"]["conformsTo"]}
+    assert "https://w3id.org/ro/wfrun/provenance/0.5" in claimed
+    for profile in claimed:
+        assert entities[profile]["@type"] == "CreativeWork"
+
+
+# ---- the Provenance layer, structurally ------------------------------------
+
+
+def test_one_step_per_output_and_one_action_per_universe(project: Path) -> None:
+    """A step is spec structure and an action is one execution — which is
+    exactly how a multiverse maps onto the Provenance profile."""
+    for universe_id in ("baseline", "alt"):
+        _made(project, universe_id, "first", git_sha="aaa111")
+        _made(project, universe_id, "second", git_sha="aaa111")
+    entities = _entities(_render(project, _graph(project, ("baseline", "alt"))))
+
+    steps = [e for e in entities.values() if e["@type"] == "HowToStep"]
+    actions = [e for e in entities.values() if e["@type"] == "CreateAction"]
+    workflow = entities["astra.yaml"]
+    assert len(steps) == 2
+    assert {ref["@id"] for ref in workflow["step"]} == {"#step-first", "#step-second"}
+    # four tool-level actions, plus one workflow-level action for the run
+    assert len(actions) == 5
+    assert "HowTo" in workflow["@type"]
+
+
+def test_outputs_sharing_a_commit_are_one_run(project: Path) -> None:
+    """The driver reads HEAD once and hands it down, so `git_sha` groups
+    manifests into runs — the whole Provenance layer's identity."""
+    _made(project, "baseline", "first", git_sha="aaa111")
+    _made(project, "baseline", "second", git_sha="bbb222")
+    entities = _entities(_render(project, _graph(project)))
+
+    organizers = {i: e for i, e in entities.items() if e["@type"] == "OrganizeAction"}
+    assert set(organizers) == {"#organize-aaa111", "#organize-bbb222"}
+    for organizer in organizers.values():
+        run = entities[organizer["result"]["@id"]]
+        assert run["@type"] == "CreateAction"
+        assert run["instrument"]["@id"] == "astra.yaml"
+
+
+def test_an_action_chains_its_inputs_and_its_environment(project: Path) -> None:
+    _made(project, "baseline", "first", git_sha="aaa111", inputs={"catalog": "sha256:cafe"})
+    _made(project, "baseline", "second", git_sha="aaa111")
+    entities = _entities(_render(project, _graph(project)))
+
+    actions = {
+        e["name"]: e for e in entities.values() if e["@type"] == "CreateAction"
+    }
+    first = actions["run of `first` in universe `baseline`"]
+    second = actions["run of `second` in universe `baseline`"]
+    first_objects = {ref["@id"] for ref in first["object"]}
+    assert {"uv.lock", ".python-version", "pyproject.toml", "data/catalog.csv"} <= first_objects
+    assert entities["data/catalog.csv"]["sha256"] == "cafe"
+    assert "results/baseline/first/" in {ref["@id"] for ref in second["object"]}
+    assert second["result"] == [{"@id": "results/baseline/second/"}]
+    assert second["description"] == "make second"
+    assert entities["results/baseline/second/"]["version"] == "sha256:baseline-second"
+
+
+def test_the_manifest_is_in_the_crate_and_about_its_dataset(project: Path) -> None:
+    _made(project, "baseline", "first", git_sha="aaa111")
+    entities = _entities(_render(project, _graph(project)))
+
+    manifest = entities["results/baseline/first/.lightcone-manifest.json"]
+    assert manifest["about"] == {"@id": "results/baseline/first/"}
+    assert entities["results/baseline/first/"]["subjectOf"] == {
+        "@id": "results/baseline/first/.lightcone-manifest.json"
+    }
+
+
+def test_a_containerized_output_names_its_committed_archive(project: Path) -> None:
+    """Identity and payload as one entity: the archive file in the crate,
+    carrying the config-blob id the execution pinned."""
+    _made(
+        project,
+        "baseline",
+        "first",
+        git_sha="aaa111",
+        image={
+            "tag": "lc-env-x",
+            "id": "sha256:beef",
+            "archive": ".datalad/environments/lc-env-x/image",
+            "arch": "amd64",
+        },
+    )
+    entities = _entities(_render(project, _graph(project)))
+
+    archive = entities[".datalad/environments/lc-env-x/image"]
+    assert set(archive["@type"]) == {"File", "ContainerImage"}
+    assert archive["sha256"] == "beef"
+    action = next(e for e in entities.values() if e["@type"] == "CreateAction")
+    assert action["containerImage"] == {"@id": ".datalad/environments/lc-env-x/image"}
+
+
+def test_the_person_is_the_saving_commits_author(project: Path) -> None:
+    """The manifest's `git_sha` is the commit the run *started* at — the
+    author comes from the commit that saved the output, via the writer."""
+    _made(project, "baseline", "first", git_sha="aaa111")
+    entities = _entities(_render(project, _graph(project)))
+
+    person = entities["mailto:ada@example.org"]
+    assert person["name"] == "Ada Lovelace"
+    action = next(e for e in entities.values() if e["@type"] == "CreateAction")
+    assert action["agent"] == {"@id": "mailto:ada@example.org"}
+    assert {"@id": "mailto:ada@example.org"} in entities["./"]["author"]
+
+
+def test_decision_values_point_back_at_their_parameter(project: Path) -> None:
+    _made(project, "baseline", "first", git_sha="aaa111")
+    entities = _entities(_render(project, _graph(project)))
+
+    value = entities["#value-baseline-first-method"]
+    assert value["value"] == "alpha"
+    assert value["exampleOfWork"] == {"@id": "#param-method"}
+    workflow = entities["astra.yaml"]
+    assert {"@id": "#param-method"} in _as_list(workflow["input"])
+
+
+def test_a_never_materialized_project_still_describes_its_workflow(project: Path) -> None:
+    """No outputs, no runs — the crate is the workflow and the environment,
+    dated by the spec's own last commit rather than the clock."""
+    entities = _entities(_render(project, _graph(project)))
+
+    assert entities["./"]["datePublished"] == "2026-08-19"
+    assert not [e for e in entities.values() if e["@type"] == "CreateAction"]
+    assert "astra.yaml" in entities
+
+
+def test_the_license_is_an_spdx_entity(project: Path) -> None:
+    entities = _entities(_render(project, _graph(project)))
+
+    assert entities["./"]["license"] == {"@id": "https://spdx.org/licenses/MIT"}
+    assert entities["https://spdx.org/licenses/MIT"]["@type"] == "CreativeWork"
+
+
+def test_license_of_reads_every_spelling(tmp_path: Path) -> None:
+    cases = {
+        'license = "MIT"': "MIT",
+        'license = { text = "BSD-3-Clause" }': "BSD-3-Clause",
+        'license = { file = "LICENSE" }': "LICENSE",
+        "": "",
+    }
+    for spelling, expected in cases.items():
+        (tmp_path / "pyproject.toml").write_text(f'[project]\nname = "x"\n{spelling}\n')
+        assert crate.license_of(tmp_path) == expected, spelling
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else [value]

--- a/tests/test_crate_smoke.py
+++ b/tests/test_crate_smoke.py
@@ -1,0 +1,181 @@
+"""The validator's answer — the one file that can say the crate conforms.
+
+A real project is materialized through the real driver, and the committed
+``ro-crate-metadata.json`` is handed to the official ``rocrate-validator``
+against the deepest profile the crate claims. Gated exactly like the
+container smoke suite: hosts without the validator skip,
+``LC_CRATE_TESTS_REQUIRED=1`` turns that skip into a hard failure, and
+two tests cover the guard itself — an unfailing guard is worse than none.
+
+At RECOMMENDED there is a known floor, pinned as a *set* rather than a
+count: the workflow's id is the file in the crate and cannot be an http
+URI, the image lives in the annex and has no registry, and lc knows no
+publisher and no author affiliation. A new failure is a regression; a
+disappearing one is the floor to shrink.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lightcone.engine import dataset
+from lightcone.engine import materialize as engine
+from lightcone.engine.worker import TaskResult
+
+REQUIRED_ENV = "LC_CRATE_TESTS_REQUIRED"
+
+_VALIDATOR = importlib.util.find_spec("rocrate_validator") is not None
+
+#: The checks the crate cannot truthfully satisfy, by check identifier.
+_FLOOR = {
+    # the workflow's id is its path in the crate, and the shape wants http
+    "process-run-crate-0.5_5.1",
+    # the image is bytes in the annex; there is no registry to name
+    "process-run-crate-0.5_13.2",
+    # lc knows no publishing organization and no author affiliation
+    "ro-crate-1.1_22.3",
+    "ro-crate-1.1_29.2",
+    "ro-crate-1.1_29.3",
+}
+
+_SPEC = """
+version: "0.0.13"
+name: analysis
+description: A two-step analysis for the crate smoke test.
+
+inputs:
+  - id: catalog
+    type: data
+    source: data/catalog.fits
+
+outputs:
+  - id: first
+    type: metric
+    decisions: [method]
+    recipe:
+      command: echo {decisions.method} > {output}/value.txt
+
+  - id: second
+    type: report
+    inputs: [first]
+    recipe:
+      command: cat {inputs.first}/value.txt > {output}/copy.txt
+
+decisions:
+  method:
+    label: Method
+    default: alpha
+    options:
+      alpha: {label: alpha}
+      beta: {label: beta}
+"""
+
+
+def _gate() -> None:
+    if _VALIDATOR:
+        return
+    if os.environ.get(REQUIRED_ENV):
+        pytest.fail(
+            f"{REQUIRED_ENV} is set but rocrate-validator is not importable. "
+            "Crate validation must not be skipped on CI."
+        )
+    pytest.skip("rocrate-validator is not installed here")
+
+
+def test_the_guard_skips_without_the_validator(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys.modules[__name__], "_VALIDATOR", False)
+    monkeypatch.delenv(REQUIRED_ENV, raising=False)
+
+    with pytest.raises(pytest.skip.Exception):
+        _gate()
+
+
+def test_the_guard_fails_when_skipping_is_forbidden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys.modules[__name__], "_VALIDATOR", False)
+    monkeypatch.setenv(REQUIRED_ENV, "1")
+
+    with pytest.raises(pytest.fail.Exception):
+        _gate()
+
+
+class _Inline:
+    def submit(self, fn: Any, *args: Any, key: str) -> Any:
+        return fn(*args)
+
+    def completed(self, handles: list[Any]) -> Iterator[TaskResult]:
+        yield from handles
+
+
+def test_a_materialized_crate_validates_against_the_provenance_profile(
+    analysis: Callable[..., Path], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _gate()
+
+    @contextmanager
+    def inline() -> Iterator[_Inline]:
+        yield _Inline()
+
+    monkeypatch.setattr(engine, "cluster_for_run", inline)
+    root = analysis(
+        _SPEC,
+        files={"data/catalog.fits": "stars\n", "README.md": "# analysis\n\nA demo.\n"},
+        universes={"baseline": "id: baseline\ndecisions:\n  method: alpha\n"},
+    )
+    pyproject = root / "pyproject.toml"
+    pyproject.write_text(pyproject.read_text() + 'license = "MIT"\n')
+    # A remote gives the tools http ids; the manifests record origin.
+    dataset._git(
+        ["remote", "add", "origin", "https://github.com/example/analysis.git"], cwd=root
+    )
+    dataset.save(root, [root], "license and remote")
+
+    report = engine.materialize(root, [])
+    assert report.ok and (root / "ro-crate-metadata.json").is_file()
+    assert not dataset.status(root)
+
+    out = tmp_path / "validation.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            # The console script, run on this interpreter — the same one
+            # the gate probed for importability.
+            "from rocrate_validator.cli import cli; cli()",
+            "validate",
+            "-p",
+            "provenance-run-crate",
+            "-l",
+            "recommended",
+            "-f",
+            "json",
+            "-o",
+            str(out),
+            str(root),
+        ],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        timeout=600,
+    )
+    result = json.loads(out.read_text())
+    issues = result.get("issues") or []
+
+    required = [i for i in issues if i["severity"] == "REQUIRED"]
+    assert not required, f"REQUIRED failures:\n{json.dumps(required, indent=1)}"
+    unexpected = [i for i in issues if i["check"]["identifier"] not in _FLOOR]
+    assert not unexpected, (
+        f"failures beyond the recorded floor (validator exit {proc.returncode}):\n"
+        f"{json.dumps(unexpected, indent=1)}"
+    )

--- a/tests/test_crate_smoke.py
+++ b/tests/test_crate_smoke.py
@@ -21,16 +21,13 @@ import json
 import os
 import subprocess
 import sys
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from lightcone.engine import dataset
 from lightcone.engine import materialize as engine
-from lightcone.engine.worker import TaskResult
 
 REQUIRED_ENV = "LC_CRATE_TESTS_REQUIRED"
 
@@ -110,24 +107,10 @@ def test_the_guard_fails_when_skipping_is_forbidden(
         _gate()
 
 
-class _Inline:
-    def submit(self, fn: Any, *args: Any, key: str) -> Any:
-        return fn(*args)
-
-    def completed(self, handles: list[Any]) -> Iterator[TaskResult]:
-        yield from handles
-
-
 def test_a_materialized_crate_validates_against_the_provenance_profile(
-    analysis: Callable[..., Path], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    analysis: Callable[..., Path], inline: None, tmp_path: Path
 ) -> None:
     _gate()
-
-    @contextmanager
-    def inline() -> Iterator[_Inline]:
-        yield _Inline()
-
-    monkeypatch.setattr(engine, "cluster_for_run", inline)
     root = analysis(
         _SPEC,
         files={"data/catalog.fits": "stars\n", "README.md": "# analysis\n\nA demo.\n"},

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -454,3 +454,51 @@ def test_the_annex_executables_are_ours_to_install() -> None:
         assert ours.get(name) == value, f"{name} is not re-declared as {value}"
 
 
+
+
+# ---- who last wrote a path -------------------------------------------------
+
+
+def test_last_writer_names_the_commit_that_last_touched_a_path(repo: Path) -> None:
+    """The foreign-write fact's whole mechanism: every output is committed,
+    so a hand edit needs a commit, and history names it."""
+    out = repo / "results" / "fit"
+    out.mkdir()
+    (out / "value.txt").write_text("42\n")
+    dataset.save(repo, [out], "[DATALAD RUNCMD] fit [baseline]\n\nrecord body")
+
+    sha, subject, author, email, date = dataset.last_writer(repo, out)
+    assert sha and date
+    assert subject == "[DATALAD RUNCMD] fit [baseline]"
+    assert (author, email) == ("Test", "t@example.com")
+
+    (out / "value.txt").write_text("curated\n")
+    dataset.save(repo, [out], "tweak colors")
+    assert dataset.last_writer(repo, out)[1] == "tweak colors"
+
+
+def test_last_writer_of_an_untouched_path_is_empty(repo: Path) -> None:
+    assert dataset.last_writer(repo, repo / "results" / "never") == ("", "", "", "", "")
+
+
+def test_last_writer_answers_inside_an_enclosing_repository(
+    tmp_path: Path, real_tools: None
+) -> None:
+    """A project can sit inside a larger repository, and the answer must be
+    about the project's own subdirectory — a later commit elsewhere in the
+    tree must not become every output's last writer."""
+    outer = tmp_path / "outer"
+    project_root = outer / "project"
+    out = project_root / "results" / "fit"
+    out.mkdir(parents=True)
+    (out / "value.txt").write_text("42\n")
+    dataset.init_git(outer)
+    for key, value in (("user.email", "t@example.com"), ("user.name", "Test")):
+        dataset._git(["config", key, value], cwd=outer)
+    dataset._git(["add", "-A", "."], cwd=outer)
+    dataset._git(["commit", "-q", "-m", "[DATALAD RUNCMD] fit [baseline]"], cwd=outer)
+    (outer / "unrelated.txt").write_text("someone else's work\n")
+    dataset._git(["add", "-A", "."], cwd=outer)
+    dataset._git(["commit", "-q", "-m", "outer edit"], cwd=outer)
+
+    assert dataset.last_writer(project_root, out)[1] == "[DATALAD RUNCMD] fit [baseline]"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -467,18 +467,18 @@ def test_last_writer_names_the_commit_that_last_touched_a_path(repo: Path) -> No
     (out / "value.txt").write_text("42\n")
     dataset.save(repo, [out], "[DATALAD RUNCMD] fit [baseline]\n\nrecord body")
 
-    sha, subject, author, email, date = dataset.last_writer(repo, out)
-    assert sha and date
-    assert subject == "[DATALAD RUNCMD] fit [baseline]"
-    assert (author, email) == ("Test", "t@example.com")
+    write = dataset.last_writer(repo, out)
+    assert write and write.sha and write.date
+    assert write.subject == "[DATALAD RUNCMD] fit [baseline]"
+    assert (write.author, write.email) == ("Test", "t@example.com")
 
     (out / "value.txt").write_text("curated\n")
     dataset.save(repo, [out], "tweak colors")
-    assert dataset.last_writer(repo, out)[1] == "tweak colors"
+    assert dataset.last_writer(repo, out).subject == "tweak colors"
 
 
 def test_last_writer_of_an_untouched_path_is_empty(repo: Path) -> None:
-    assert dataset.last_writer(repo, repo / "results" / "never") == ("", "", "", "", "")
+    assert not dataset.last_writer(repo, repo / "results" / "never")
 
 
 def test_last_writer_answers_inside_an_enclosing_repository(
@@ -501,4 +501,5 @@ def test_last_writer_answers_inside_an_enclosing_repository(
     dataset._git(["add", "-A", "."], cwd=outer)
     dataset._git(["commit", "-q", "-m", "outer edit"], cwd=outer)
 
-    assert dataset.last_writer(project_root, out)[1] == "[DATALAD RUNCMD] fit [baseline]"
+    write = dataset.last_writer(project_root, out)
+    assert write.subject == "[DATALAD RUNCMD] fit [baseline]"

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from conftest import _Inline
 
 from lightcone.engine import assets, dataset, identity
 from lightcone.engine import materialize as engine
@@ -64,30 +65,6 @@ _UNIVERSE = "id: baseline\ndecisions:\n  method: alpha\n"
 @pytest.fixture
 def root(analysis: Callable[..., Path]) -> Path:
     return analysis(_SPEC, universes={"baseline": _UNIVERSE})
-
-
-class _Inline:
-    """Run the graph in this thread, in the order it was submitted.
-
-    Submission is topological, so a dependent is submitted only after its
-    upstreams have already run — which means the "handles" it is passed
-    are the upstream results themselves, exactly what the worker expects.
-    """
-
-    def submit(self, fn: Any, *args: Any, key: str) -> Any:
-        return fn(*args)
-
-    def completed(self, handles: list[Any]) -> Iterator[TaskResult]:
-        yield from handles
-
-
-@pytest.fixture
-def inline(monkeypatch: pytest.MonkeyPatch) -> None:
-    @contextmanager
-    def fake() -> Iterator[_Inline]:
-        yield _Inline()
-
-    monkeypatch.setattr(engine, "cluster_for_run", fake)
 
 
 def _commits(root: Path) -> int:
@@ -935,7 +912,9 @@ def test_a_foreign_write_is_stale_and_names_its_commit(root: Path, inline: None)
     outputs = {o.output: o for o in engine.status(root).outputs}
 
     assert outputs["baseline/first"].status == "stale"
-    assert "tweak colors" in outputs["baseline/first"].foreign_write
+    forged_sha = dataset.last_writer(root, root / "results/baseline/first").sha
+    assert outputs["baseline/first"].foreign_write == forged_sha
+    assert "tweak colors" in outputs["baseline/first"].why
     assert "git show" in outputs["baseline/first"].why
     assert not outputs["baseline/second"].foreign_write
 
@@ -971,7 +950,8 @@ def test_the_foreign_write_fact_survives_a_bytes_free_clone(
     outputs = {o.output: o for o in engine.status(clone).outputs}
 
     assert outputs["baseline/first"].status == "stale"
-    assert "tweak colors" in outputs["baseline/first"].foreign_write
+    assert "tweak colors" in outputs["baseline/first"].why
+    assert outputs["baseline/first"].foreign_write
     assert not outputs["baseline/second"].foreign_write
 
 
@@ -1021,7 +1001,7 @@ def test_a_licensed_materialize_converges_the_crate_and_commits_it(
     crate_path = root / "ro-crate-metadata.json"
     assert crate_path.is_file()
     assert not dataset.status(root)  # committed, tree exactly as clean as before
-    assert dataset.last_writer(root, crate_path)[1] == "Update the RO-Crate publication view"
+    assert dataset.last_writer(root, crate_path).subject == "Update the RO-Crate publication view"
     graph = json.loads(crate_path.read_text())["@graph"]
     types = {e["@id"]: e["@type"] for e in graph}
     assert "OrganizeAction" in types.values()

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -922,22 +922,38 @@ def test_a_materialized_output_has_no_foreign_write(root: Path, inline: None) ->
     assert all(not o.foreign_write for o in engine.status(root).outputs)
 
 
-def test_status_names_a_foreign_commit_that_touched_an_output(
-    root: Path, inline: None
-) -> None:
-    """The agent-forged-file fact: a hand-edited-and-committed output reads
-    `current` forever, because a skip returns the recorded digest — so
-    status says who wrote it last, since it was not the run record."""
+def test_a_foreign_write_is_stale_and_names_its_commit(root: Path, inline: None) -> None:
+    """The agent-forged-file fact: a hand-edited-and-committed output would
+    read `current` forever, because a skip returns the recorded digest —
+    so a directory last written by anything but its own run record is a
+    *contradiction*, and contradiction is what `stale` means."""
     engine.materialize(root, [])
     forged = root / "results" / "baseline" / "first" / "value.txt"
     _forge(forged, "curated by hand\n")
     dataset.save(root, [forged.parent], "tweak colors")
 
-    flagged = {o.output: o.foreign_write for o in engine.status(root).outputs}
+    outputs = {o.output: o for o in engine.status(root).outputs}
 
-    assert "tweak colors" in flagged["baseline/first"]
-    assert "git show" in flagged["baseline/first"]
-    assert not flagged["baseline/second"]
+    assert outputs["baseline/first"].status == "stale"
+    assert "tweak colors" in outputs["baseline/first"].foreign_write
+    assert "git show" in outputs["baseline/first"].why
+    assert not outputs["baseline/second"].foreign_write
+
+
+def test_check_plans_the_remake_of_a_foreign_written_output(
+    root: Path, inline: None
+) -> None:
+    """Status and `--check` answer from one walk, so they cannot disagree
+    about a foreign write — and the gate exits nonzero over it."""
+    engine.materialize(root, [])
+    forged = root / "results" / "baseline" / "first" / "value.txt"
+    _forge(forged, "curated by hand\n")
+    dataset.save(root, [forged.parent], "tweak colors")
+
+    report = engine.check(root, [])
+
+    assert any("tweak colors" in why for why in report.planned.values())
+    assert not report.up_to_date
 
 
 def test_the_foreign_write_fact_survives_a_bytes_free_clone(
@@ -952,31 +968,27 @@ def test_the_foreign_write_fact_survives_a_bytes_free_clone(
     dataset.save(root, [forged.parent], "tweak colors")
     clone = _clone(root, tmp_path)
 
-    flagged = {o.output: o.foreign_write for o in engine.status(clone).outputs}
+    outputs = {o.output: o for o in engine.status(clone).outputs}
 
-    assert "tweak colors" in flagged["baseline/first"]
-    assert not flagged["baseline/second"]
+    assert outputs["baseline/first"].status == "stale"
+    assert "tweak colors" in outputs["baseline/first"].foreign_write
+    assert not outputs["baseline/second"].foreign_write
 
 
-def test_a_rebuild_clears_the_foreign_write(root: Path, inline: None) -> None:
-    """Deleting the directory is the consent that remakes a current output;
-    the rebuild's own run record then becomes the last writer again."""
+def test_the_next_run_remakes_a_foreign_written_output(root: Path, inline: None) -> None:
+    """`results/` is lc's to write — the same philosophy as the dirty-tree
+    refusal's path split — so a committed hand edit is remade, and the
+    rebuild's own run record becomes the last writer again."""
     engine.materialize(root, [])
     forged = root / "results" / "baseline" / "first" / "value.txt"
     _forge(forged, "curated by hand\n")
     dataset.save(root, [forged.parent], "tweak colors")
-    _rmtree_and_commit(root, forged.parent)
 
-    engine.materialize(root, [])
+    report = engine.materialize(root, [])
 
+    assert "baseline/first" in report.made
+    assert forged.read_text() == "alpha\n"  # the recipe's bytes, not the hand's
     assert all(not o.foreign_write for o in engine.status(root).outputs)
-
-
-def _rmtree_and_commit(root: Path, directory: Path) -> None:
-    import shutil
-
-    shutil.rmtree(directory)
-    dataset.save(root, [directory], "drop the forged output")
 
 
 # ---- the publication view --------------------------------------------------

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -901,3 +901,171 @@ def test_the_report_is_json_ready(root: Path, inline: None) -> None:
 
     assert data["ok"] is True
     assert data["made"] == ["baseline/first"]
+
+
+# ---- the foreign-write fact ------------------------------------------------
+
+
+def _forge(path: Path, text: str) -> None:
+    """Overwrite a committed result the way a hand edit would — unlinking
+    first, because results are committed thin: an in-place truncate would
+    rewrite the shared annex object and dirty every file hard-linked to it
+    (the recorded thin-write hazard, demonstrated by this very test suite
+    when it forged in place)."""
+    path.unlink()
+    path.write_text(text)
+
+
+def test_a_materialized_output_has_no_foreign_write(root: Path, inline: None) -> None:
+    engine.materialize(root, [])
+
+    assert all(not o.foreign_write for o in engine.status(root).outputs)
+
+
+def test_status_names_a_foreign_commit_that_touched_an_output(
+    root: Path, inline: None
+) -> None:
+    """The agent-forged-file fact: a hand-edited-and-committed output reads
+    `current` forever, because a skip returns the recorded digest — so
+    status says who wrote it last, since it was not the run record."""
+    engine.materialize(root, [])
+    forged = root / "results" / "baseline" / "first" / "value.txt"
+    _forge(forged, "curated by hand\n")
+    dataset.save(root, [forged.parent], "tweak colors")
+
+    flagged = {o.output: o.foreign_write for o in engine.status(root).outputs}
+
+    assert "tweak colors" in flagged["baseline/first"]
+    assert "git show" in flagged["baseline/first"]
+    assert not flagged["baseline/second"]
+
+
+def test_the_foreign_write_fact_survives_a_bytes_free_clone(
+    root: Path, inline: None, tmp_path: Path
+) -> None:
+    """History-based on purpose: content changes move pointers in git, so
+    the fact needs no annex content — where a rehash would have nothing to
+    hash."""
+    engine.materialize(root, [])
+    forged = root / "results" / "baseline" / "first" / "value.txt"
+    _forge(forged, "curated by hand\n")
+    dataset.save(root, [forged.parent], "tweak colors")
+    clone = _clone(root, tmp_path)
+
+    flagged = {o.output: o.foreign_write for o in engine.status(clone).outputs}
+
+    assert "tweak colors" in flagged["baseline/first"]
+    assert not flagged["baseline/second"]
+
+
+def test_a_rebuild_clears_the_foreign_write(root: Path, inline: None) -> None:
+    """Deleting the directory is the consent that remakes a current output;
+    the rebuild's own run record then becomes the last writer again."""
+    engine.materialize(root, [])
+    forged = root / "results" / "baseline" / "first" / "value.txt"
+    _forge(forged, "curated by hand\n")
+    dataset.save(root, [forged.parent], "tweak colors")
+    _rmtree_and_commit(root, forged.parent)
+
+    engine.materialize(root, [])
+
+    assert all(not o.foreign_write for o in engine.status(root).outputs)
+
+
+def _rmtree_and_commit(root: Path, directory: Path) -> None:
+    import shutil
+
+    shutil.rmtree(directory)
+    dataset.save(root, [directory], "drop the forged output")
+
+
+# ---- the publication view --------------------------------------------------
+
+
+def _declare_license(root: Path) -> None:
+    """Declare publication intent the way a researcher would: one key,
+    committed like any other edit."""
+    pyproject = root / "pyproject.toml"
+    pyproject.write_text(pyproject.read_text() + 'license = "MIT"\n')
+    dataset.save(root, [pyproject], "declare a license")
+
+
+def test_an_unlicensed_project_gets_no_crate_and_one_report_line(
+    root: Path, inline: None
+) -> None:
+    report = engine.materialize(root, [])
+
+    assert not (root / "ro-crate-metadata.json").exists()
+    assert any("[project].license" in w for w in report.warnings)
+
+
+def test_a_licensed_materialize_converges_the_crate_and_commits_it(
+    root: Path, inline: None
+) -> None:
+    _declare_license(root)
+
+    engine.materialize(root, [])
+
+    crate_path = root / "ro-crate-metadata.json"
+    assert crate_path.is_file()
+    assert not dataset.status(root)  # committed, tree exactly as clean as before
+    assert dataset.last_writer(root, crate_path)[1] == "Update the RO-Crate publication view"
+    graph = json.loads(crate_path.read_text())["@graph"]
+    types = {e["@id"]: e["@type"] for e in graph}
+    assert "OrganizeAction" in types.values()
+    assert types["results/baseline/first/"] == "Dataset"
+
+
+def test_an_idempotent_rerun_commits_nothing(root: Path, inline: None) -> None:
+    """The document is a pure function of repository state — a re-render at
+    the same state is a string compare, not a commit."""
+    _declare_license(root)
+    engine.materialize(root, [])
+    before = _commits(root)
+
+    engine.materialize(root, [])
+
+    assert _commits(root) == before
+
+
+def test_declaring_a_license_later_creates_the_crate_then(root: Path, inline: None) -> None:
+    engine.materialize(root, [])
+    assert not (root / "ro-crate-metadata.json").exists()
+
+    _declare_license(root)
+    engine.materialize(root, [])
+
+    assert (root / "ro-crate-metadata.json").is_file()
+
+
+def test_a_removed_license_stops_maintenance_but_keeps_the_file(
+    root: Path, inline: None
+) -> None:
+    """The crate is in committed history either way; deleting a file over a
+    possibly temporary edit is not convergence's call."""
+    _declare_license(root)
+    engine.materialize(root, [])
+    pyproject = root / "pyproject.toml"
+    pyproject.write_text(pyproject.read_text().replace('license = "MIT"\n', ""))
+    dataset.save(root, [pyproject], "drop the license")
+
+    report = engine.materialize(root, [])
+
+    assert (root / "ro-crate-metadata.json").is_file()
+    assert any("no longer maintained" in w for w in report.warnings)
+
+
+def test_an_output_the_spec_dropped_is_excluded_and_named(root: Path, inline: None) -> None:
+    _declare_license(root)
+    engine.materialize(root, [])
+    spec_path = root / "astra.yaml"
+    spec = spec_path.read_text()
+    block = spec[spec.index("  - id: second") : spec.index("\ndecisions:") + 1]
+    spec_path.write_text(spec.replace(block, ""))
+    dataset.save(root, [spec_path], "drop the second output")
+
+    report = engine.materialize(root, [])
+
+    assert any("results/baseline/second" in w for w in report.warnings)
+    document = (root / "ro-crate-metadata.json").read_text()
+    assert "results/baseline/second/" not in document

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -79,6 +79,7 @@ def _make(
         _HEAD,
         assets.Versions(),
         refresh,
+        False,
         _runtime(root),
         *upstream,
     )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -79,7 +79,7 @@ def _make(
         _HEAD,
         assets.Versions(),
         refresh,
-        False,
+        "",
         _runtime(root),
         *upstream,
     )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -79,7 +79,7 @@ def _make(
         _HEAD,
         assets.Versions(),
         refresh,
-        "",
+        None,
         _runtime(root),
         *upstream,
     )


### PR DESCRIPTION
## Summary

The last layer of the rebuild table, rescoped during planning from the spec's "`lc verify`, WRROC export" to two mechanisms with **no new verbs**:

**The project is the crate.** `ro-crate-metadata.json` lives at the project root as a derived artifact, converged by `lc materialize` the way `uv.lock` is: rendered from repository state, string-compared, committed alone only on a difference. Deposit is `git archive`/`datalad export-archive` on a repository that is already an RO-Crate — nothing copied, no bundle, no `lc export`. Maintenance is derived, never configured: a declared `[project].license` turns it on (RO-Crate requires one; materialize must not refuse science over a missing key, and inventing CC-BY-4.0 — the pre-rebuild default — asserts terms over someone's data). Absence is one report line.

**Integrity is a status fact, not a verb.** The hole layer 4 recorded — a hand-edited-and-committed output reads `current` forever because a skip returns the recorded digest (the agent-forged-file scenario) — is closed by history, not hashing: every output is committed, so a hand edit *requires* a commit, and `dataset.last_writer` names it. `lc status` flags any output whose directory's last commit is not its own run record, with sha, author, date and a `git show` remedy. O(history), answers on a bytes-free clone, still exits 0.

## The crate itself

- `engine/crate.py`, the one new module — a **pure** builder over `plan.build()` and the manifests; git enters only as an injected `writer` callable.
- Targets **Provenance Run Crate 0.5 structurally, not vacuously** (the pre-rebuild exporter passed REQUIRED only because the SHACL shapes are vacuous over an empty target class): outputs sharing a manifest `git_sha` are one run — the driver's single HEAD read makes run identity free — giving `OrganizeAction` + workflow-level `CreateAction` per run, `ControlAction` per execution, `HowToStep` per output id.
- The workflow-run `@context` makes `containerImage`/`sha256`/`ContainerImage` real vocabulary (the old exporter emitted them as undefined terms JSON-LD silently drops). The committed image archive is one entity: `File` + `ContainerImage`, config-blob id and payload together.
- The manifest stays canonical: in the crate as a `File`, `subjectOf` its `Dataset`; `env_version`/`definition_version`/`hermeticity` are deliberately not transliterated.
- Deterministic by construction: sorted iteration, `sort_keys`, no clock (`datePublished` = newest manifest `finished_at`, overriding rocrate's stamp-now default), no `mimetypes` (it reads `/etc/mime.types`, which would make the render host-dependent).
- The crate's `Person` is the author of each output's **saving** commit via `last_writer` — never the manifest's `git_sha`, which is the commit the run *started* at.

## Validation

Official `rocrate-validator` against the Provenance profile, on a real materialized project: **REQUIRED clean**; RECOMMENDED failures pinned as a *set* (`test_crate_smoke.py::_FLOOR`) of checks the crate cannot truthfully satisfy (the workflow's id is its in-crate path and the shape wants `^http`; an annex-stored image has no registry; lc knows no publisher/affiliation). A new failure is a regression; a disappearing one is the floor to shrink. Gated with `LC_CRATE_TESTS_REQUIRED=1` on every CI runner — the validator is a dev dep, so none may skip.

## Also in here

- The worker stamps `started_at`/`finished_at` (millisecond ISO 8601 — crate consumers parse `endTime` with at most three fractional digits). Attestation like `lc_version`; `classify` never reads them; `SCHEMA_VERSION` stays 1.
- `materialize.run_subject` is now the one spelling of the run record's subject, shared by `run_record` (composer) and the foreign-write check (comparator) — byte-identical to the previous inline string, and the datalad parser + real `datalad rerun` tests all pass.
- Recorded rejections, with reasons in CLAUDE.md: no `lc verify` (O(bytes), blind on unfetched outputs, no lifecycle moment enforcing it; `git annex fsck` owns object corruption), no `lc export`, and the honest residues stated (a forged run-record subject defeats the history check; a manifest lc itself mis-recorded is the one case only a rehash would catch; the rerun entry point does not regenerate the crate).
- One trap the suite found live: forging a result **in place** dirties its byte-identical sibling through the shared thin annex object — the recorded thin hazard demonstrating itself. Tests unlink first; CLAUDE.md records it.

## Test plan

- 556 passed (31 new), ruff and mypy clean, `LC_CRATE_TESTS_REQUIRED=1` locally.
- New: `test_crate.py` (pure, 14 tests, no git — determinism, run grouping, the Provenance edges, ContainerImage, Person, license spellings), `test_crate_smoke.py` (real materialize → real validator, two guard tests), `last_writer` against real repos incl. the enclosing-repository case, the foreign-write fact end-to-end incl. a bytes-free clone, crate convergence (created once / idempotent re-run commits nothing / license added later / license removed keeps the file / spec-dropped output excluded and named).
- Manual e2e: `lc init` → license → materialize (crate lands in its own trailing commit) → re-materialize (no commit) → validator (0 REQUIRED) → forge + commit → `lc status` names the foreign commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9ikHqeMA9tTX1Jrx5DdNL