### PR TITLE
Docs rewrite 2/5: core concepts, cluster, troubleshooting, glossary

### DIFF
--- a/docs/user/cluster.md
+++ b/docs/user/cluster.md
@@ -1,270 +1,127 @@
 # Running on a Cluster
 
-When local laptop time isn't enough, you can take the same project to
-a SLURM HPC system or a lightcone JupyterHub deployment. There's no
-separate configuration to learn — the same `lc run` command works
-everywhere, just with more hardware to spread across.
+When local laptop time isn't enough, the same project runs on a SLURM
+HPC system. There is no separate configuration to learn and no flag to
+pass — `lc materialize` detects where it is running, and the allocation
+you request *is* the resource declaration.
 
 ## The big picture
 
-`lc run` always dispatches through a Dask cluster. Four branches:
+`lc materialize` runs its tasks through a scheduler, and picks the venue
+by looking at the environment:
 
-1. On your laptop → a `LocalCluster` sized to the machine.
-2. **On a JupyterHub deployment** (Dask Gateway detected) → a
-   run-scoped Gateway cluster created with your project's container
-   image and shut down when the run finishes.
-3. **Inside a SLURM allocation** → an in-process scheduler bound to
-   the driver's hostname, with one `dask worker` per allocated node
-   launched via `srun`.
-4. With `DASK_SCHEDULER_ADDRESS` set → connect to whatever scheduler
-   you've pointed at.
+1. **Inside a SLURM allocation** (`SLURM_JOB_ID` is set) → the run
+   spans every node the allocation holds: one worker per node, launched
+   via `srun`, using every core it was granted.
+2. **Anywhere else** → the local machine, using every core.
 
-You don't pick — `lc run` detects which case applies. The only thing
-you do differently on a cluster is request the nodes (and on
-JupyterHub, not even that).
-
-## JupyterHub deployments (Kubernetes + Dask Gateway)
-
-On a lightcone JupyterHub (GKE with Dask Gateway and Cloud Build),
-everything is zero-configuration — the deployment injects the whole
-contract into your session (`DASK_GATEWAY__*`, `LIGHTCONE_REGISTRY`,
-`LIGHTCONE_BUILD_BUCKET`), and `lc` picks it up:
-
-- The scaffolded project image doubles as the Dask worker pod image
-  with no hub-specific content: `lc init` pins `lightcone-cli` in
-  `requirements.txt`, which brings the whole execution stack
-  (snakemake, dask, distributed, dask-gateway) on top of your own
-  dependencies — the same image runs anywhere.
-- `lc build` builds through the deployment's **GCP Cloud Build**
-  service (there's no docker in your session) and pushes
-  `<registry>/lc-<project>:<content-hash>` to the hub's Artifact
-  Registry. Unchanged files never rebuild — freshness is one registry
-  check.
-- `lc run` makes sure the image is up to date, **creates a Dask
-  Gateway cluster with that image**, runs the pipeline in worker pods
-  (recipes execute directly in the image — no nested containers), and
-  **culls the cluster when the run finishes**. Your NFS home is
-  mounted in every worker pod at the same path, so outputs land in
-  the project tree exactly as they do locally.
-
-A cluster's image is fixed at creation, so create-per-run is also what
-keeps the environment fresh: edit the Containerfile, `lc run`, and the
-next cluster runs the rebuilt image.
-
-## Pre-flight: pick the right container runtime
-
-On most HPC sites, docker isn't available on compute nodes. Most
-SLURM systems (including NERSC Perlmutter) provide `podman-hpc`. On a
-login node:
-
-```bash
-$EDITOR ~/.lightcone/config.yaml
-```
-
-```yaml
-container:
-  runtime: podman-hpc
-```
-
-Then build and migrate the images for your project:
-
-```bash
-cd my-analysis
-lc build
-```
-
-`lc build` runs `podman-hpc build` and then `podman-hpc migrate`,
-which copies the image into the per-node container cache. Compute
-nodes can read it without registry access.
-
-If your site has only `apptainer` / `singularity`, the Lightcone
-toolchain doesn't ship explicit support for those today — you can run
-without containers (`runtime: none`) for the moment, with the caveat
-that the manifest's `container_image` field will record what was
-declared, not what executed. (See [`lc run`](../cli/run.md) for the
-provenance warning.)
+You already answered every sizing question at `salloc` / `sbatch` —
+how many nodes, which constraint, how long — so `lc` asks none of its
+own. There is no `--jobs`, no worker count, no venue config file.
 
 ## A typical SLURM workflow
 
-### 1. Get an allocation
+### 1. Prepare on the login node
+
+Everything except executing recipes works on a login node — and one
+verb is *for* it:
 
 ```bash
-salloc -N 4 -t 02:00:00 -C gpu                       # interactive
-# or
-sbatch run.sbatch                                    # batch
+cd $SCRATCH/my-analysis
+lc materialize --check     # what would run, and why
+lc status                  # where every output stands
+lc build                   # containerized projects: build + commit the image
 ```
 
-`run.sbatch` looks like:
+### 2. Get an allocation and materialize inside it
 
-=== "Generic"
+=== "Interactive"
     ```bash
-    #!/bin/bash
-    #SBATCH -N 4
-    #SBATCH -t 02:00:00
-    #SBATCH -C gpu
-
-    cd $HOME/my-analysis
-    source .venv/bin/activate
-    lc run -j 16
+    salloc --nodes=1 --constraint=cpu --qos=interactive --time=02:00:00
+    # salloc drops you onto a compute node; from there:
+    cd $SCRATCH/my-analysis
+    lc materialize
     ```
 
-=== "NERSC Perlmutter"
+=== "Batch"
     ```bash
-    #!/bin/bash
-    #SBATCH -A <your_project>
-    #SBATCH -q regular
-    #SBATCH -C gpu
-    #SBATCH -N 4
-    #SBATCH -t 04:00:00
-
-    cd $SCRATCH/your-analysis
-
-    # make `lc` available — pick the line that matches your install:
-    export PATH=$HOME/.local/bin:$PATH                # uv tool install
-    # source ~/.conda/envs/your-env-name/bin/activate # conda env
-
-    lc run -j 16
+    cd $SCRATCH/my-analysis
+    sbatch --nodes=1 --constraint=cpu --qos=regular --time=02:00:00 \
+        --wrap 'lc materialize'
     ```
 
-### 2. `lc run` inside the allocation
+    (Make sure `lc` is on `PATH` in the batch environment — with a
+    `uv tool install`, that's `export PATH=$HOME/.local/bin:$PATH` in
+    the script if your shell profile doesn't already do it.)
 
-Once `SLURM_JOB_ID` is set in your environment, `lc run` does the rest:
+Ask for more nodes and the run uses them — independent outputs and
+universes spread across the allocation with nothing else to say.
 
-- Starts an in-process Dask scheduler bound to the SLURM node hostname.
-- Launches one `dask worker` per node via `srun`.
-- Each worker advertises the node's CPU, memory, and GPU resources.
-- Snakemake submits each rule via the Dask executor; rules with
-  per-recipe `resources:` constraints land on workers that can hold
-  them.
+### 3. Guard rails on known centers
 
-### 3. Per-recipe resource hints
+On centers `lc` knows (NERSC today), running `lc materialize` on a
+login node refuses with the center's own allocation spellings rather
+than quietly hammering a shared node:
 
-Add resource hints in your `astra.yaml` recipe blocks:
+```
+Error: lc materialize executes recipes on compute nodes, and this is a
+NERSC login node (NERSC_HOST is set with no SLURM allocation active).
 
-```yaml
-outputs:
-  - id: heavy_fit
-    type: metric
-    recipe:
-      command: python scripts/fit.py --output {output[0]}
-      resources:
-        cpus_per_task: 32
-        mem_mb: 64000
-        gpus_per_task: 1
+Get an allocation and run it there:
+
+  interactive:
+      salloc --nodes=1 --constraint=cpu --qos=interactive --time=02:00:00
+      lc materialize
+
+  batch (from the project root):
+      sbatch --nodes=1 --constraint=cpu --qos=regular --time=02:00:00 \
+          --wrap 'lc materialize'
+
+lc materialize --check, lc status and lc run work anywhere.
 ```
 
-The Snakemake-via-Dask executor maps these to per-task resource
-requests, so a rule that needs a GPU only schedules on nodes that
-advertise one.
+The read-only verbs are exempt on purpose — a login node is exactly
+where "where does this project stand?" gets asked.
 
-## Interactive: iterating inside an allocation
+## Containers on HPC
 
-During development you're usually iterating — run something, check the
-result, adjust the spec, repeat. For that loop you want an interactive
-shell inside a SLURM allocation, so that `lc run` executes on the
-compute node rather than the login node.
+A containerized project (one with `[tool.lightcone.image]` in its
+`pyproject.toml`) works the same way, with three site realities to
+know:
 
-```bash
-salloc -A <your_project> -q interactive -C gpu --nodes=1 -t 00:30:00
-# salloc drops you onto a compute node; from there:
-cd /path/to/your-analysis
-lc run --universe baseline
-lc status
-```
+- **`podman-hpc` is detected first.** Sites install it precisely
+  because plain podman's image store is invisible to compute nodes;
+  where both exist, `lc` prefers the wrapper and runs its extra
+  `migrate` step automatically, so the image is readable from every
+  node.
+- **Build on a login node, once.** `lc build` builds the image and
+  commits it into the repository as versioned content — compute nodes
+  never build and need no registry access; an unfetched image arrives
+  through the annex like any other data. The archive records the
+  architecture it was built for, and a mismatched host is refused
+  before anything runs — so build where the architecture matches the
+  compute nodes (on NERSC, a login node).
+- **Multi-node runs require a shared image store.** With plain podman
+  or docker the image exists only on the driver's node, so `lc`
+  refuses a multi-node containerized run unless the runtime is
+  `podman-hpc`. Single-node allocations work with any runtime.
 
-Everything you launch from that shell (`lc run`, scripts, etc.)
-executes on the allocated node. When you're done iterating and want a
-hands-off sweep of all universes, submit `lc run` as a batch job
-instead (the sbatch template above).
+## Data on parallel filesystems
 
-## What about login-node-only operations?
+Keep active projects on the filesystem your center recommends for job
+I/O (`$SCRATCH` on NERSC), and remember scratch purge policies — the
+project is a git repository, so `git push` to a remote (and
+`git annex copy --to` for the bytes) is the durable copy.
 
-Build images, dry-run, look at status — all fine on a login node
-without an allocation:
+!!! warning "Early days"
+    HPC support is the youngest part of lightcone-cli and has not yet
+    been broadly validated on production systems. If something refuses,
+    hangs, or surprises you on your center, please
+    [open an issue](https://github.com/LightconeResearch/lightcone-cli/issues)
+    — site reports are exactly what this layer needs right now.
 
-```bash
-lc build                       # build images (uses podman-hpc on login node)
-lc status                      # offline; reads only manifests
-```
+## Where to next
 
-The actual `lc run` should happen inside an allocation, since that's
-where the worker nodes are.
-
-## External Dask schedulers
-
-If you have a long-lived Dask cluster (Slurm jobqueue, k8s, etc.)
-that you'd rather attach to:
-
-```bash
-export DASK_SCHEDULER_ADDRESS=tcp://my-scheduler:8786
-lc run
-```
-
-`lc run` notices the env var and connects rather than starting its
-own scheduler. It does *not* tear the scheduler down on exit.
-
-## NERSC Perlmutter: site-specific notes
-
-!!! note "Setting up on Perlmutter for the first time?"
-    The [Install](install.md) page has NERSC-specific tabs for Python
-    (uv vs `module load python`, conda env storage) and lightcone-cli.
-    Come back here once `lc --version` works.
-
-### Storage: keep Snakemake state on `$SCRATCH`
-
-!!! danger "DVS silently ignores `flock()`"
-    `$HOME` and `/global/cfs/` are mounted on compute nodes via DVS,
-    which silently ignores `flock()`. Snakemake relies on `flock` for
-    locking, so its `.snakemake/` directory and Dask spill files
-    **must** live on Lustre (`$SCRATCH`), which honors `flock`.
-    Otherwise you get intermittent silent rule-rerun loops or hangs.
-
-`lc` redirects state automatically when it detects Perlmutter, so
-this usually just works. To pin explicitly at project creation:
-
-```bash
-lc init your-analysis --scratch '$SCRATCH'   # kept verbatim, expanded at run time
-```
-
-Or, after the fact, edit `<project>/.lightcone/lightcone.yaml`:
-
-```yaml
-scratch_root: $SCRATCH
-```
-
-!!! warning "12-week purge on `$SCRATCH`"
-    Perlmutter purges `$SCRATCH` on a rolling 12-week window. For
-    outputs you need to keep, copy or symlink to
-    `/global/cfs/cdirs/<project>/`.
-
-### Further reading
-
-- [NERSC interactive jobs](https://docs.nersc.gov/jobs/interactive/)
-  — `salloc` patterns and reservation queues
-- [Perlmutter system overview](https://docs.nersc.gov/systems/perlmutter/)
-  — node types and partitions
-- [NERSC queue policy](https://docs.nersc.gov/jobs/policy/)
-  — QoS options for GPU and CPU partitions
-
-## Troubleshooting
-
-- `dask CLI is not on PATH inside the SLURM allocation`. Install
-  `lightcone-cli` into the venv that your sbatch script activates;
-  `dask` ships with `distributed`, which is a transitive dep.
-- Workers never register. Usually means the SLURM node hostnames
-  aren't resolvable from each other; check `SLURMD_NODENAME` /
-  `gethostname()` and confirm the workers can reach the scheduler.
-- Image not found on compute nodes. Re-run `lc build` on the login
-  node — the migrate step is the one that actually publishes the
-  image to the per-node cache.
-- Snakemake locking errors or silent rule-rerun loops on Perlmutter.
-  `.snakemake/` ended up on DVS-mounted storage — set
-  `scratch_root: $SCRATCH` in the project's `.lightcone/lightcone.yaml`.
-- `pip install` hangs or times out. Compute nodes have no public
-  internet — always install from a login node.
-- `PermissionError` reading another user's symlinked `results/`.
-  Cross-user scratch path without group ACLs — request access from
-  the data owner, or copy the manifests into your own scratch.
-
-For the wiring detail, see
-[engine/dask_cluster](../api/dask_cluster.md) in the maintainer docs.
+- [Core Concepts](concepts.md) — the model all of this rests on.
+- [Troubleshooting](troubleshooting.md) — the refusals, quoted, with
+  remedies.

--- a/docs/user/concepts.md
+++ b/docs/user/concepts.md
@@ -1,0 +1,151 @@
+# Core Concepts
+
+The mental model behind `lc`, in one page. Nothing here is required to
+follow [Getting Started](getting-started.md) — come back when you want
+to know *why* the tool behaves the way it does.
+
+## A project is three files
+
+A lightcone project is a directory holding an ASTRA spec and a uv
+project:
+
+- **`astra.yaml`** describes the analysis — inputs, outputs, recipes,
+  methodological decisions. It is the single source of truth: everything
+  `lc` does is downstream of it.
+- **`pyproject.toml` + `uv.lock`** describe the environment — every
+  package a recipe may import, resolved to exact versions. The `.venv`
+  is built *from* the lock and is disposable; the lock is what's real,
+  and it travels in git.
+
+There is no global configuration, no registry, no state outside the
+project. Clone the repository and you have everything except two pieces
+of local machinery (`.venv` and the git-annex initialization), which
+`lc init` rebuilds.
+
+Adding a dependency is a uv operation, not an `lc` one:
+
+```bash
+uv add numpy
+```
+
+That updates `pyproject.toml`, re-locks, and syncs `.venv` in one step.
+Recipes import from the locked environment and nothing else — a stray
+`pip install` on your machine changes nothing they can see.
+
+## An output has an identity, and three facts about it
+
+Every materialized output records, in its
+`.lightcone-manifest.json`:
+
+1. **What it is** — a hash of its recipe and the decision values that
+   shaped it (its *definition*).
+2. **What it was made from** — a content hash of each declared input.
+3. **What it ran under** — a hash of the environment (the lock, the
+   interpreter, the image declaration if any), plus the git commit the
+   run started at.
+
+Those three facts are deliberately not one fact, because they age
+differently — and that is what the three states mean:
+
+| state | means | what `lc materialize` does |
+|---|---|---|
+| `current` | the output is exactly what the spec asks for, made from these inputs, under this environment | nothing |
+| `stale` | the output **contradicts** the project: the spec now defines it differently, or an input's content changed | remakes it |
+| `behind` | the output is still exactly what the spec asks for — only the **environment** moved since it was made | reports it, leaves it alone |
+
+The line between `stale` and `behind` is contradiction versus
+circumstance. A stale output is mislabelled — keeping it would be a
+lie, so it is remade. A behind output is not wrong in any way: one
+`uv add` for a plotting script rewrites the lock for the whole project,
+and remaking a week of computation over that buys nothing. Its manifest
+records exactly which environment and commit produced it, and that
+commit's own `uv.lock` reconstructs the environment if you ever need
+it.
+
+When you *do* want behind outputs remade — before a release, say —
+that is one flag:
+
+```bash
+lc materialize --refresh
+```
+
+`--refresh` only ever widens a run: a `current` output stays current
+under it, and there is deliberately no flag in the other direction —
+nothing suppresses the rebuild of a stale output.
+
+One more way an output can be stale: a hand edit. Every output is
+committed by the run that made it, so a file changed by hand and
+committed shows up in history under a commit that is not a run record —
+and the output classifies `stale` everywhere, with `lc status` naming
+the foreign commit.
+
+## Everything is committed, and the tree stays clean
+
+`lc` versions results in the project's own git repository: git carries
+the history and the small files, git-annex carries the data bytes —
+transparently, behind the ordinary `git add` / `git commit` you already
+type.
+
+That model has two consequences you'll feel:
+
+- **A run starts from a clean tree.** Every output is committed
+  together with the code that produced it; a run that started from
+  uncommitted edits could not say what that code was. So: commit, then
+  materialize.
+- **A run ends with a clean tree.** Each output is committed as it
+  lands — with its manifest, in a commit whose message is a *run
+  record* that `datalad rerun` can replay. A failed recipe's partial
+  work is rolled back. Your `git log` is the build log.
+
+`results/` is `lc`'s to write. Don't put files there by hand — a
+hand-placed file has no manifest and no run record, and the foreign
+write check above exists precisely to catch it.
+
+## Two modes, derived from the project
+
+How recipes execute is never configured — it is read off the project:
+
+- **Direct mode** (the default): recipes run on your machine, in the
+  project's `.venv`, under an OS sandbox — Landlock on Linux, Seatbelt
+  on macOS. The project tree is read-only except each recipe's own
+  output directory; undeclared tools don't execute.
+- **Containerized mode**: declaring a `[tool.lightcone.image]` table in
+  `pyproject.toml` *is* the switch. Recipes then run inside a
+  content-addressed image built from that declaration — and the image
+  itself is saved into the repository as versioned content, so a clone
+  obtains the exact bytes with no registry and no credentials.
+  `lc status` shows the mode and the image's state.
+
+Either way, every manifest records what enforcement actually ran
+(`hermeticity`) — a host with no sandbox mechanism runs the recipe and
+says so, rather than pretending.
+
+## Reading and gating are different verbs
+
+- **`lc status`** reports. It always exits 0 — a state is not a
+  failure — runs nothing, and doesn't mind a dirty tree, because the
+  moment you most need it is when things aren't clean. It's also the
+  verb that shows the commit each output was made at.
+- **`lc materialize --check`** gates. It classifies everything without
+  running anything and exits 1 if a run would do work — the thing a
+  script or CI job branches on.
+
+Both have `--json`; the first two keys of the check report, `ok` and
+`up_to_date`, are the ones to branch on.
+
+## Publication is a license away
+
+Declaring a `license` under `[project]` in `pyproject.toml` is
+declaring the intent to publish. From then on, every `lc materialize`
+maintains `ro-crate-metadata.json` at the project root — an
+[RO-Crate](https://www.researchobject.org/ro-crate/) describing the
+project, its outputs, and the runs that produced them. The repository
+*is* the crate; depositing it is `git archive` on something you already
+have.
+
+## Where to next
+
+- [Running on a Cluster](cluster.md) — the same model on SLURM.
+- [Troubleshooting](troubleshooting.md) — the refusals quoted, with
+  their remedies.
+- [Glossary](glossary.md) — the terms, one at a time.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -377,6 +377,8 @@ themselves follow with `git annex get` whenever you actually need them.
 
 ## Where to next
 
+- [Core Concepts](concepts.md) — the model behind what you just did:
+  the three states, the commit discipline, the two execution modes.
 - [Running on a Cluster](cluster.md) — take the same project to SLURM.
 - [Troubleshooting](troubleshooting.md) — when something goes sideways.
 - [Glossary](glossary.md) — terms like universe, decision, and manifest

--- a/docs/user/glossary.md
+++ b/docs/user/glossary.md
@@ -9,9 +9,9 @@ plain language.
 The schema lightcone-cli is built around. ASTRA's job is to capture an
 analysis's inputs, outputs, and methodological decisions in a single
 file (`astra.yaml`); lightcone-cli's job is to execute that spec
-reproducibly. ASTRA ships separately as the `astra-tools` package and
-the `astra` CLI handles the spec itself (validation, paper management,
-evidence verification).
+reproducibly. ASTRA ships separately as the `astra-tools` package, and
+its `astra` CLI handles the spec itself (validation, universe
+management, evidence verification).
 
 ## astra.yaml
 
@@ -21,20 +21,17 @@ nested via `analyses:` references.
 
 ## Recipe
 
-A short shell or Python command that produces an output. Lives inside
-an output's `recipe:` block in `astra.yaml`. Outputs declare which
-sibling outputs they depend on, and the recipe references them through
-placeholders:
+A short shell command that produces an output. Lives inside an output's
+`recipe:` block in `astra.yaml`. Outputs declare what they depend on,
+and the recipe references those dependencies through placeholders:
 
 ```yaml
 outputs:
-  - id: r2
+  - id: fit
+    inputs: [points]
+    decisions: [outliers]
     recipe:
-      command: python src/fit.py --output {output}
-  - id: fit_plot
-    inputs: [r2]
-    recipe:
-      command: python src/plot.py --r2_dir {inputs.r2} --output {output}
+      command: python src/fit.py --points {inputs.points} --outliers {decisions.outliers} --output {output}
 ```
 
 ## Decision
@@ -48,128 +45,139 @@ their `options`, and their `rationale`.
 
 One specific selection of decision values. Universes live as YAML
 files in `universes/` (e.g. `universes/baseline.yaml`,
-`universes/permissive.yaml`). Each universe materializes its results
+`universes/robust.yaml`). Each universe materializes its results
 to its own directory: `results/<universe>/<output_id>/`.
-
-If your spec has no universes, `lc run` materializes against a
-universe called `"default"` with all decisions at their declared
-defaults.
 
 ## Sub-analysis
 
 A nested ASTRA analysis with its own inputs, outputs, and decisions,
-referenced from a parent's `analyses:` section. The full tree shares
-one set of universes; sub-analyses can reference parent decisions
-with `from:` references. Sub-analyses are useful when an analysis has
-genuinely different stages (training vs. inference, fit vs. evaluate);
-keep things in one analysis when they share the same product.
+referenced from a parent's `analyses:` section. A sub-analysis output's
+directory uses its qualified id —
+`results/<universe>/<analysis>.<output>/` — so one addressing scheme
+spans however deep the spec nests.
+
+## Materialize
+
+Making the outputs the spec declares: `lc materialize` runs each recipe
+in dependency order and commits every result as it lands. Idempotent —
+a second run remakes only what is `stale`, and a run with nothing to do
+says so and touches nothing.
 
 ## Manifest
 
 The per-output sidecar JSON file
-(`<output_dir>/.lightcone-manifest.json`) that records what produced
-the output and what's inside it. Fields include `code_version`,
-`data_version`, `container_image`, `recipe`, `decisions`,
-`input_versions`, `git_sha`, `host`, `lc_version`, and a few more.
-Manifests are written atomically by `lc run` and read by `lc status`
-and `lc verify`.
+(`<output_dir>/.lightcone-manifest.json`) recording what produced the
+output: the recipe, the decisions, `definition_version`,
+`env_version`, `data_version`, `input_versions`, the git commit the
+run started at, the engine version, what enforcement actually ran
+(`hermeticity`), and — for containerized runs — the image. Written by
+the run, read by `lc status` and `lc materialize --check`; kept in
+plain git so a clone can classify a whole project without fetching any
+data.
 
-## code_version
+## definition_version
 
-A SHA-256 over `(recipe + container_image + decisions)`. The
-fingerprint of "what does this rule do?" When it drifts, downstream
-outputs go `stale` in `lc status`.
+A hash of an output's recipe and decision values — the fingerprint of
+"what is this output?". When it drifts, the output is `stale` and the
+next run remakes it.
+
+## env_version
+
+A hash of the environment — the lock file's bytes, the pinned
+interpreter, the install settings, and the image declaration if any.
+Deliberately *not* part of an output's definition: when it drifts, the
+output is `behind`, reported and left alone.
 
 ## data_version
 
-A SHA-256 over the contents of an output directory (excluding the
-manifest itself). The fingerprint of "what bytes were produced?"
-`lc verify` recomputes this and compares to the recorded value to
-catch tampering.
+A content hash over the files in an output's directory (or of a
+declared input). This is what flows downstream: a dependent is remade
+when an input's `data_version` changed, and a rebuild that comes out
+byte-identical stops the cascade right there.
 
 ## input_versions
 
-Inside a manifest, a dict mapping each declared input id to its
-version: the upstream output's `data_version` when the input is
-another materialized output, or an `mtime-size`/`sha256`
-fingerprint when the input is an external file. This is the chain
-`lc verify` walks back through.
+Inside a manifest, a map from each declared input to the
+`data_version` it had when the output was made. Comparing it against
+the present is how a change to an input cascades.
 
-## Container
+## current / behind / stale
 
-A Docker / Podman / podman-hpc image used to execute a recipe in
-isolation. Declared at the analysis level (`container: Containerfile`)
-or per-recipe (`recipe: { container: python:3.12-slim }`). Recipe-level
-overrides win.
+The three states an output can be in:
 
-## Containerfile
+- `current` — exactly what the spec asks for, made from these inputs,
+  under this environment. Nothing to do.
+- `behind` — still what the spec asks for; only the environment moved
+  since it was made. Reported, left alone; `--refresh` remakes.
+- `stale` — contradicts the project: the spec defines it differently,
+  an input changed, or the output was edited by hand. Remade on the
+  next run.
 
-A Dockerfile by another name (the syntax is identical). lightcone-cli
-calls them Containerfiles to make clear they work with podman as well
-as docker.
+## Direct mode / containerized mode
 
-## Image tag
+How recipes execute, derived from the project rather than configured.
+Direct mode (the default): the project's `.venv`, under the OS sandbox.
+Containerized mode: declaring `[tool.lightcone.image]` in
+`pyproject.toml` switches the project over — recipes run inside a
+content-addressed image built from that declaration.
 
-The string the runtime uses to identify a built image. lightcone-cli
-generates content-addressed tags for Containerfile builds:
-`lc-<project>-<sha256[:12]>`. The hash covers the Containerfile and
-your dependency files, so tags only change when the inputs to the
-build change.
+## Image
+
+Containerized mode's execution world: a base (digest-pinned), optional
+apt packages, and the pinned interpreter. Built by `lc build` and saved
+**into the repository** as versioned content, so clones obtain the
+exact bytes through git-annex with no registry involved. Execution pins
+the image's content id, never a tag.
 
 ## Runtime
 
-The OCI tool that actually executes containers: `docker`, `podman`,
-or `podman-hpc`. Set in `~/.lightcone/config.yaml` under
-`container.runtime`. `auto` picks the first usable; `none` opts out
-(runs recipes directly on the host).
+The OCI tool that executes containers. Detected, never configured:
+`podman-hpc`, then `podman`, then `docker` (skipped if its daemon is
+down).
 
-## Snakemake
+## Sandbox
 
-The workflow engine `lc run` shells out to. You don't need to learn
-Snakemake to use lightcone-cli — the Snakefile at `.lightcone/Snakefile`
-is auto-generated from your `astra.yaml`. If you're curious, peek at
-it; just don't edit it (your changes will get overwritten on the
-next `lc run`).
+The isolation every recipe and every `lc run` command executes under —
+Landlock on Linux, Seatbelt on macOS, the container boundary in
+containerized mode. The project tree is read-only apart from the
+output directory being made; undeclared tools don't execute. Each
+manifest's `hermeticity` field records what was actually enforced, and
+a host with no mechanism says so rather than pretending.
 
-## Dask
+## git-annex
 
-The distributed scheduler `lc run` dispatches jobs through. On a
-laptop it's a `LocalCluster` sized to your machine; inside a SLURM
-allocation it's an in-process scheduler with one `dask worker` per
-node launched via `srun`.
+How the repository carries data: git holds history and small files,
+git-annex holds the bytes of `data/` and `results/` behind ordinary
+git commands. You never run git-annex yourself except to fetch bytes
+on a clone (`git annex get`), and `lc materialize` even does that for
+declared inputs it needs.
+
+## Run record
+
+The commit message a materialized output is saved under — a
+machine-readable record of the exact command that made it, in a format
+`datalad rerun` can replay: it reconstructs the engine, the project
+environment, and the sandbox, and remakes the output from its spec.
+Your `git log` is the build log.
+
+## RO-Crate
+
+The publication view. Declare a `license` under `[project]` in
+`pyproject.toml` and every materialize maintains
+`ro-crate-metadata.json` — a machine-readable description of the
+project, its outputs, and the runs that produced them, following the
+Provenance Run Crate profile. The repository is the crate; deposit is
+`git archive`.
 
 ## Prior insight
 
 A piece of evidence from the literature that informs a decision.
-Lives in the `prior_insights:` section of `astra.yaml`. Each insight
-has a `claim`, one or more `evidence` entries with verbatim quotes,
-and a list of decision options it supports. Quotes are
-machine-verified against the source PDF.
+Lives in the `prior_insights:` section of `astra.yaml`, with a `claim`
+and verifiable `evidence` (DOI plus exact quote).
 
 ## Finding
 
-A conclusion drawn *from* the analysis (as opposed to a prior
-insight, which comes *into* the analysis). Findings live in the
-`findings:` section, can cite specific outputs as evidence, and act
-as the bridge between materialized results and the eventual paper.
-
-## Status (`ok`, `stale`, `missing`, `alias`)
-
-The four labels `lc status` produces:
-
-- `ok` — manifest present, recomputed `code_version` matches.
-- `stale` — manifest present but `code_version` drifted.
-- `missing` — no manifest at the expected output directory.
-- `alias` — output declared without a recipe; just a reference to
-  another output.
-
-## Failure kinds (`tampered_data`, `broken_chain`, `missing_manifest`)
-
-The three labels `lc verify` produces when something's wrong:
-
-- `tampered_data` — bytes on disk no longer match recorded
-  `data_version`.
-- `broken_chain` — recorded `input_versions` references an upstream
-  whose `data_version` drifted.
-- `missing_manifest` — output directory exists but the manifest is
-  missing or unparseable.
+A conclusion drawn *from* the analysis (as opposed to a prior insight,
+which comes *into* it). Findings live in the `findings:` section and
+cite specific outputs as evidence — the bridge between materialized
+results and the eventual paper.

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -18,6 +18,9 @@ recipe, the decisions, the input data, the environment, and the commit.
   machine or on a cluster.
 - [Getting Started](getting-started.md) — create your first project,
   build it end-to-end, and understand what each piece does.
+- [Core Concepts](concepts.md) — the model behind the tool: what the
+  states mean, why everything is committed, and how the two execution
+  modes differ.
 - [Running on a Cluster](cluster.md) — taking your analysis to a SLURM
   HPC system.
 - [Troubleshooting](troubleshooting.md) — common issues and how to

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -1,138 +1,156 @@
 # Troubleshooting
 
-Common issues and how to unstick them. Roughly ordered by how often
-they come up.
+Common situations and how to unstick them, roughly ordered by how often
+they come up. `lc`'s refusals try to carry their own remedy — this page
+adds the context around them.
 
-## "No global configuration found."
+## "uncommitted changes in …"
 
-`~/.lightcone/config.yaml` is normally created automatically on first
-use, but it may be missing if the home directory was unavailable or if
-the file was deleted manually. Re-create it by hand:
+```
+Error: uncommitted changes in /home/you/my-analysis — every
+materialization is committed with the code that produced it, so a run
+cannot start from a tree that does not say what that code is.
 
-```bash
-mkdir -p ~/.lightcone
-cat > ~/.lightcone/config.yaml <<'EOF'
-container:
-  runtime: auto
-EOF
+  commit these:   git add -A . && git commit -m "…"
+      M src/fit.py
 ```
 
-Or just run any `lc` command (e.g. `lc --version`) — the auto-creation
-runs before every command.
+Not an error in your project — just the order of operations: commit,
+then materialize. The refusal sorts the paths it found: work you own
+gets the `commit these` line, while leftover files under `results/`
+(from an interrupted run of an older `lc`, or a hand write) are listed
+as wreckage to discard instead — `results/` is `lc`'s to write, and
+committing hand-placed files there defeats the provenance the tool
+exists for.
 
-## "No astra.yaml found in current directory or any parent."
+## "… is not a Lightcone project"
 
-You're outside an ASTRA project. Either:
+You're outside a project. The current directory *is* the project — `lc`
+never walks up to find one, by design — so:
 
 ```bash
 cd path/to/your/project
 ```
 
-or, if you're starting fresh:
-
-```bash
-lc init my-analysis
-cd my-analysis
-```
-
-`lc init` is idempotent — re-running it inside an existing project is
-safe and just fills in anything missing (`lc init --check` tells you
-whether it would change anything).
+or, starting fresh, `lc init my-analysis && cd my-analysis`. If you're
+in a fresh clone, run `lc init` once — it rebuilds the `.venv` and the
+annex, the two pieces of local state git doesn't carry.
 
 ## "lc: command not found" or `lc` prints a directory listing
 
 Two possibilities:
 
-1. The package isn't installed for your current Python. Check
-   `pip show lightcone-cli` (or `uv pip show lightcone-cli`).
+1. The tool isn't on `PATH` — with `uv tool install`, that's
+   `~/.local/bin`; `uv tool update-shell` fixes the profile.
 2. Your shell has a personal alias `lc='ls --color'` shadowing the
    real command. Run `type lc` to see; `unalias lc` to remove.
 
-## `lc run` warning: "No container runtime found on PATH"
+## A recipe fails with "Permission denied" or "No module named …"
 
-You declared a container in `astra.yaml` but `auto` couldn't find any
-of `docker`, `podman`, or `podman-hpc`. Two options:
+Every sandboxed failure ends with this trailer:
 
-- **Install one.** Podman is the smallest install on Linux and macOS.
-- **Opt out explicitly.** Edit `~/.lightcone/config.yaml`:
-  ```yaml
-  container:
-    runtime: none
-  ```
-  This silences the warning, but then your manifests will record an
-  image that didn't actually run — fine for development, not fine for
-  archival.
-
-## `lc run` says "Workflow defines that rule … but no input"
-
-This is Snakemake speak. It usually means:
-
-- A recipe declares `inputs: [foo]` but no other output produces
-  `foo`. Either the input is external (in which case it shouldn't be
-  in the recipe's `inputs:` list — recipes only chain to *sibling*
-  outputs), or there's a typo.
-- Sub-analysis output ids that collide with root output ids — qualify
-  with `<analysis_id>.<output_id>`.
-
-The fix is in `astra.yaml`. `astra validate astra.yaml` will catch
-most typos.
-
-## `lc status` shows everything `stale` after I just ran
-
-Something in the spec changed in a way that affects `code_version`.
-That hash covers recipe text, container image identifier, and
-decisions. Common causes:
-
-- You edited a `Containerfile` or a dependency file (`requirements.txt`,
-  `pyproject.toml`). The image's content-addressed tag changed →
-  every recipe that uses it is now `stale`.
-- You edited a recipe `command:`. Just rerun.
-- You changed the default for a decision.
-
-Re-running `lc run` will bring everything back to `ok`.
-
-## `lc verify` fails with `tampered_data`
-
-The bytes in an output directory no longer hash to the recorded
-`data_version`. Most innocent cause: someone hand-edited a result
-file. Most concerning: results were forged.
-
-If it was you, regenerate with `lc run --force <output>`. If it
-wasn't you, audit your shared filesystem.
-
-## `lc verify` fails with `broken_chain`
-
-A downstream output was materialized against an upstream version that
-no longer exists. Usually caused by:
-
-- The upstream was rerun without rerunning the downstream.
-- The upstream's output directory was edited by hand (which would also
-  trigger `tampered_data` on the upstream itself).
-
-Fix: `lc run` the downstream output. The chain will re-anchor.
-
-## I want to start the spec over
-
-Move `astra.yaml` aside (don't delete it — it's useful context about
-what you tried), then write a fresh one:
-
-```bash
-mv astra.yaml astra.previous.yaml
-$EDITOR astra.yaml
+```
+this ran under the lc sandbox (landlock) — a permissions or missing-file
+error can mean the command reached for something outside the declared
+environment
 ```
 
-Re-running `lc init` afterwards is safe — it only fills in whatever is
-missing and leaves the rest of the layout (`universes/`, `.lightcone/`)
-as is.
+Recipes run in the project's locked environment, with the tree
+read-only apart from their own output directory. The common cases:
+
+- **`ModuleNotFoundError`** — the package isn't in the project's lock.
+  `uv add <package>`, commit, re-run. (Installing it on the host with
+  `pip` changes nothing a recipe sees — that's the point.)
+- **Reading a file outside the project** — declare it as an ASTRA
+  input; declared inputs are readable and their content becomes part
+  of the output's provenance.
+- **Writing outside the output directory** — a recipe's product
+  belongs in `{output}`; for true scratch files, use
+  `tempfile.mkdtemp()`, which lands in the writable temp area.
+
+To probe interactively, `lc run <command>` runs any command under
+exactly the isolation a recipe gets — if it works there, it works as a
+recipe.
+
+## Everything shows `behind` after a `uv add`
+
+Not a problem, and nothing was invalidated. `behind` means: the output
+is still exactly what the spec asks for, but the environment has moved
+since it was made. Environment changes deliberately don't trigger
+rebuilds — the manifest records which environment and commit produced
+each output, so nothing is lost by leaving it. When you do want them
+remade under the current environment:
+
+```bash
+lc materialize --refresh
+```
+
+See [Core Concepts](concepts.md) for the `stale` / `behind`
+distinction.
+
+## Everything shows `stale` after a spec edit
+
+`stale` means the spec now defines the output differently than it was
+made — you edited its recipe, a decision, or a declared input's
+content changed. That's the invalidation model working; the next
+`lc materialize` remakes exactly those outputs.
+
+One edit that deliberately does *not* invalidate: changing your
+analysis code (`src/…`). The recipe *string* is the identity, so if
+you want code changes to cascade, declare the source file as an ASTRA
+input of the outputs it shapes — that choice is yours to make per
+output.
+
+## "the content is not in this clone"
+
+```
+data/points.csv: the content is not in this clone — git-annex holds a
+reference to it, not the data. Fetch it with `git annex get data/points.csv`.
+```
+
+The clone has the *pointer* to an annexed file but not its bytes.
+`lc materialize` fetches the declared inputs it needs by itself; the
+read-only verbs (`lc status`, `--check`) never transfer data, so they
+report the fact instead. Fetch by hand only when you want the bytes
+for your own inspection.
+
+## "… and this is a NERSC login node"
+
+`lc materialize` executes recipes, and on centers `lc` recognizes it
+refuses to do that on a shared login node. The refusal prints the
+center's own `salloc` and `sbatch` spellings — copy one, run the same
+command inside the allocation. `lc status`, `lc materialize --check`,
+`lc build` and `lc run` work anywhere. See
+[Running on a Cluster](cluster.md).
+
+## git doesn't know who you are
+
+Every output is committed, so a machine that has never committed needs
+an identity before the first run — `lc materialize` checks up front,
+before any recipe spends time:
+
+```bash
+git config --global user.name "Ada Lovelace"
+git config --global user.email "ada@example.org"
+```
+
+## Containerized projects
+
+- **"image absent"** — the declared image hasn't been built and
+  committed yet: `lc build` (announced by materialize too, which
+  builds it as a preflight when missing).
+- **No runtime found** — install [Podman](https://podman.io/) or
+  [Docker](https://docs.docker.com/get-docker/); detection is
+  automatic and there is nothing to configure.
+- **Architecture mismatch** — the committed archive records the
+  architecture it was built for, and a host that can't execute it is
+  refused before the recipe would have died mid-run. Build on a
+  matching host (on NERSC, a login node), commit, push, and pull on
+  the other side.
 
 ## Filing a bug
 
 Open an issue at
 [github.com/LightconeResearch/lightcone-cli/issues](https://github.com/LightconeResearch/lightcone-cli/issues).
 Include the output of `lc --version`, the command you ran, and the
-error trace.
-
-## When all else fails
-
-Run `lc verify` — it's the fastest way to know whether your problem
-is provenance (real problem) or a transient build/run issue (rerun).
+full message — the refusals are designed to be pasted.

--- a/zensical.toml
+++ b/zensical.toml
@@ -14,6 +14,7 @@ nav = [
     {"Welcome" = "user/index.md"},
     {"Install" = "user/install.md"},
     {"Getting Started" = "user/getting-started.md"},
+    {"Core Concepts" = "user/concepts.md"},
     {"Running on a Cluster" = "user/cluster.md"},
     {"Troubleshooting" = "user/troubleshooting.md"},
     {"Glossary" = "user/glossary.md"},


### PR DESCRIPTION
Second pass of the documentation rewrite — the rest of the user guide: a new **Core Concepts** page plus rewrites of **Running on a Cluster**, **Troubleshooting**, and the **Glossary**. Style follows the frozen predecessors.

## What's in it

- **`docs/user/concepts.md`** (new, added to nav + user index): the mental model in one page — a project is spec + lock; an output's three recorded facts and why they age differently; the `current`/`behind`/`stale` table with the contradiction-vs-circumstance line; the commit discipline (clean tree in, clean tree out, git log as build log, foreign-write detection); direct vs containerized mode; `lc status` vs `lc materialize --check`; the license ⇒ crate rule.
- **`docs/user/cluster.md`**: the venue model replaces the old Snakemake/Dask-Gateway/site-registry content. The allocation *is* the resource declaration (no `--jobs`, no venue config); login-node prep vs in-allocation materialize with interactive/batch tabs; the login guard's refusal quoted verbatim; containers on HPC (podman-hpc detection + migrate, build-on-login-node with the arch gate, the multi-node shared-store refusal); an honest "early days" admonition inviting site reports.
- **`docs/user/troubleshooting.md`**: organized around the CLI's actual messages, each captured live against a real project before being quoted — dirty tree (and its commit/discard path split, verified against the source), not-a-project, the sandbox trailer with the three denial remedies (`uv add`, declare the input, write to `{output}`/mkdtemp), behind-after-`uv add` as a non-error, stale-after-spec-edit (including the deliberate "code edits don't cascade" position), unfetched annex content, the NERSC login guard, git identity, and the three containerized refusals.
- **`docs/user/glossary.md`**: ASTRA-side entries kept (ASTRA, spec, recipe, decision, universe, sub-analysis, insights/findings); execution-layer half replaced — materialize, manifest, `definition_version` / `env_version` / `data_version` / `input_versions`, the three states, the two modes, image + runtime, sandbox, git-annex, run record, RO-Crate. Snakemake, `code_version`, `ok`/`missing`/`alias`, and the `lc verify` failure kinds are gone with the architecture that defined them.

## Verification

- Every quoted refusal/denial was produced by actually triggering it: dirty tree, not-a-project, `NERSC_HOST` login guard, a sandboxed read denial, `ModuleNotFoundError` under the sandbox, and the `behind`-everywhere state after a real `uv add` (plus the `--check` verdict line with its `--refresh` hint).
- The dirty-refusal "discard these (lc writes results/)" branch was verified against the source.
- `zensical build` passes; the only warnings remain the two frozen pages (`api/snakefile.md`, `hpc/targets.md`) that pass 4 replaces.

Next: (3) CLI + JSON reference, (4) developer corner, (5) nav + workflow refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJzmp2MUhwiNHR94cB91dx