### PR TITLE
Eval trace follow-up: lc run syntax note, clean harness env

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -31,11 +31,19 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so hatch-vcs sees the tags and stamps a truthful
+          # dev version into the installed engine (and every manifest's
+          # lc_version) instead of a 0.1.dev fallback
+          fetch-depth: 0
 
       - name: Set up uv
+        # No python-version input: it would export an ambient UV_PYTHON,
+        # which lc's install-settings scrub then rightly warns about on
+        # every single invocation the agent makes. The interpreter is
+        # pinned per tool install below instead.
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.12"
           enable-cache: true
 
       - name: Install lightcone-cli + astra (uv tools)
@@ -49,8 +57,8 @@ jobs:
         # venv is activated: the agent's shell sees the tools exactly as
         # an end user's would.
         run: |
-          uv tool install "$GITHUB_WORKSPACE"
-          uv tool install "astra-tools==$(grep -oP 'astra-tools==\K[0-9][0-9.]*' pyproject.toml)"
+          uv tool install --python 3.12 "$GITHUB_WORKSPACE"
+          uv tool install --python 3.12 "astra-tools==$(grep -oP 'astra-tools==\K[0-9][0-9.]*' pyproject.toml)"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install Claude Code + astra plugin

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -13,7 +13,10 @@ lc run COMMAND...
 ```
 
 Everything after `run` is the command, verbatim — flags included.
-`lc run` takes no options of its own, so nothing needs escaping:
+Argv, the `docker run` / `uv run` convention: a single quoted string
+would be exec'd as one filename, so probe shell syntax through
+`bash -c` instead. `lc run` takes no options of its own, so nothing
+else needs escaping:
 
 ```bash
 lc run python -c "import numpy; print(numpy.__version__)"

--- a/evals/prompt.md
+++ b/evals/prompt.md
@@ -26,7 +26,10 @@ This project is driven by two CLIs — use them rather than improvising:
       making.
     - `lc run <command>` runs an ad-hoc command in the project
       environment under the same isolation a recipe gets — useful for
-      probing why a recipe would fail.
+      probing why a recipe would fail. Argv style, like `docker run` or
+      `uv run`: `lc run python scripts/fit.py --output /tmp/x`, never a
+      single quoted shell string; for shell syntax use
+      `lc run bash -c '...'`.
     - Outputs land in `results/baseline/<output_id>/`, each with a
       `.lightcone-manifest.json` manifest written and committed by the
       engine. Never write into `results/` yourself: a hand-placed file

--- a/src/lightcone/cli/commands.py
+++ b/src/lightcone/cli/commands.py
@@ -368,8 +368,8 @@ def status(as_json: bool) -> None:
             "unfetched": "content not in this clone — the next build or run fetches it",
         }[state]
         lines.append(f"  image:   {tag} — {described}")
-    lines.append(f"  sandbox: {report.sandbox}")
-    lines.append(f"  crate:   {report.crate}")
+    lines.append(f"  sandbox: {escape(report.sandbox)}")
+    lines.append(f"  crate:   {escape(report.crate)}")
     lines.append("")
     marks = {"current": "[dim]·[/dim]", "behind": "[cyan]·[/cyan]", "stale": "[yellow]![/yellow]"}
     width = max((len(o.output) for o in report.outputs), default=0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -561,6 +561,23 @@ def test_status_headers_answer_mode_image_and_sandbox(
     assert "crate:   up to date with the outputs" in output
 
 
+def test_status_header_prose_is_not_markup(
+    runner: CliRunner, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The crate line names `[project].license`, and rich would read the
+    brackets as a style tag and swallow the one word that names the fix."""
+    from lightcone.engine.materialize import StatusReport
+
+    report = _report()
+    assert isinstance(report, StatusReport)
+    report.crate = "not maintained — declare [project].license to enable it"
+    _status_stub(monkeypatch, report)
+
+    output = runner.invoke(main, ["status"]).output
+
+    assert "declare [project].license to enable it" in output
+
+
 def test_build_on_a_direct_project_is_an_explanatory_no_op(
     runner: CliRunner, project: Path
 ) -> None:


### PR DESCRIPTION
Follow-up to the PR #190 eval trace, which surfaced three harness-attributable frictions (the other findings were agent-side noise).

## The `lc run` convention question, settled

Checked the ecosystem before touching anything: `uv run "python -V"` fails with ``Failed to spawn: `python -V` `` (verified live), `docker run img "echo hi"` fails with `exec: "echo hi": executable file not found` — argv with no shell parsing is the convention across `docker run`, `uv run`, `kubectl exec`, `pipx run`, `poetry run`, `srun`. **`lc run` already matches it**, so the behavior stands unchanged and the syntax gets one line in the two places it was missing:

- `evals/prompt.md`: "Argv style, like `docker run` or `uv run`: `lc run python scripts/fit.py --output /tmp/x`, never a single quoted shell string; for shell syntax use `lc run bash -c '...'`."
- `docs/cli/run.md`: same sentence, in the synopsis.

In the trace, the missing line cost one round trip through a genuinely cryptic failure (`/usr/bin/env: '<whole string>': No such file or directory` + the sandbox trailer insinuating a denial).

## Harness environment

- **`UV_PYTHON` noise**: `setup-uv`'s `python-version` input exports `UV_PYTHON`, and the #184 install-settings scrub then (correctly) warned `ignored ambient UV_PYTHON — …` on *every* `lc run`/`lc materialize` — a dozen-plus unactionable lines the agent ended up `grep -v`'ing to read its own output. The input is dropped; determinism is kept by pinning `--python 3.12` on both tool installs. Same category as the `VIRTUAL_ENV` cleanup earlier.
- **Truthful dev versions**: the shallow checkout had no tags, so hatch-vcs stamped `0.1.dev1+g<sha>` into the installed engine — and into every manifest's `lc_version`. `fetch-depth: 0` fixes it.

Validation: label this PR `run-eval` to see the updated prompt and clean environment in action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJzmp2MUhwiNHR94cB91dx